### PR TITLE
fix(packaged files): ignore more files when publishing package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,6 @@ src
 .idea
 .editorconfig
 .eslintrc.js
+.prettier*
+cdktf.json
+tsconfig.json


### PR DESCRIPTION
# Goal

just need to add a few more files to `.npmignore`