### PR TITLE
fix(alb creation bug): fix alb reference bug

### DIFF
--- a/src/pocket/PocketALBApplication.ts
+++ b/src/pocket/PocketALBApplication.ts
@@ -120,8 +120,8 @@ export class PocketALBApplication extends Resource {
       ],
       alias: [
         {
-          name: this.alb.alb.dnsName,
-          zoneId: this.alb.alb.zoneId,
+          name: alb.alb.dnsName,
+          zoneId: alb.alb.zoneId,
           evaluateTargetHealth: true,
         },
       ],


### PR DESCRIPTION
# Goal

`this.alb` was being referenced before being set to anything. probably copy pasta.
