### PR TITLE
fix(vpc filter name): correct name of subnet filter

### DIFF
--- a/src/pocket/PocketVPC.ts
+++ b/src/pocket/PocketVPC.ts
@@ -47,7 +47,7 @@ export class PocketVPC extends Resource {
         vpcId: this.vpc.id,
         filter: [
           {
-            name: 'subnetIds',
+            name: 'subnet-id',
             values: privateString.value.split(','),
           },
         ],
@@ -70,7 +70,7 @@ export class PocketVPC extends Resource {
         vpcId: this.vpc.id,
         filter: [
           {
-            name: 'subnetIds',
+            name: 'subnet-id',
             values: publicString.value.split(','),
           },
         ],


### PR DESCRIPTION
# Goal

attempts to fix the filter name for vpc subnet query - `subnetIds` ➡️ `subnet-id`.

based off: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-subnets.html#options