### PR TITLE
fix(ecs): fixing ecs repo race creation

### DIFF
--- a/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -109,6 +109,7 @@ exports[`AppliationECSService renders an ECS service with full container definit
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testECSService_ecsiam_ecstaskrole_C95D2F7D.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testECSService/ecs-task\\",
@@ -139,6 +140,7 @@ exports[`AppliationECSService renders an ECS service with full container definit
             ]
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"bowling\\",
@@ -316,6 +318,7 @@ exports[`AppliationECSService renders an ECS service with full container definit
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testECSService_ecsiam_ecstaskrole_C95D2F7D.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testECSService/ecs-task\\",
@@ -352,6 +355,7 @@ exports[`AppliationECSService renders an ECS service with full container definit
             ]
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",
@@ -520,6 +524,7 @@ exports[`AppliationECSService renders an ECS service with minimal config 1`] = `
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testECSService_ecsiam_ecstaskrole_C95D2F7D.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testECSService/ecs-task\\",
@@ -550,6 +555,7 @@ exports[`AppliationECSService renders an ECS service with minimal config 1`] = `
             ]
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",
@@ -730,6 +736,7 @@ exports[`AppliationECSService renders an ECS service without a log group contain
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testECSService_ecsiam_ecstaskrole_C95D2F7D.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testECSService/ecs-task\\",
@@ -760,6 +767,7 @@ exports[`AppliationECSService renders an ECS service without a log group contain
             ]
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"bowling\\",
@@ -956,6 +964,9 @@ exports[`AppliationECSService renders an ECS service without an image container 
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testECSService_ecsiam_ecstaskrole_C95D2F7D.arn}\\",
+        \\"depends_on\\": [
+          \\"aws_ecr_repository.test_testECSService_ecrlebowski_ecrrepo_AB712F26\\"
+        ],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testECSService/ecs-task\\",
@@ -985,6 +996,9 @@ exports[`AppliationECSService renders an ECS service without an image container 
               \\"2.2.2.2\\"
             ]
           }
+        ],
+        \\"depends_on\\": [
+          \\"aws_ecr_repository.test_testECSService_ecrlebowski_ecrrepo_AB712F26\\"
         ],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [

--- a/src/pocket/__snapshots__/PocketALBAppliation.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBAppliation.spec.ts.snap
@@ -492,6 +492,7 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testPocketApp_ecsservice_ecsiam_ecstaskrole_E41363D4.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
@@ -519,6 +520,7 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
             \\"subnets\\": \\"\${data.aws_subnet_ids.test_testPocketApp_pocketvpc_privatesubnetids_A272E250.ids}\\"
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",
@@ -1031,6 +1033,7 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testPocketApp_ecsservice_ecsiam_ecstaskrole_E41363D4.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
@@ -1058,6 +1061,7 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
             \\"subnets\\": \\"\${data.aws_subnet_ids.test_testPocketApp_pocketvpc_privatesubnetids_A272E250.ids}\\"
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",
@@ -1731,6 +1735,7 @@ exports[`PocketALBApplication renders an external application 1`] = `
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testPocketApp_ecsservice_ecsiam_ecstaskrole_E41363D4.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
@@ -1758,6 +1763,7 @@ exports[`PocketALBApplication renders an external application 1`] = `
             \\"subnets\\": \\"\${data.aws_subnet_ids.test_testPocketApp_pocketvpc_privatesubnetids_A272E250.ids}\\"
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",
@@ -2270,6 +2276,7 @@ exports[`PocketALBApplication renders an internal application 1`] = `
           \\"FARGATE\\"
         ],
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testPocketApp_ecsservice_ecsiam_ecstaskrole_E41363D4.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
@@ -2297,6 +2304,7 @@ exports[`PocketALBApplication renders an internal application 1`] = `
             \\"subnets\\": \\"\${data.aws_subnet_ids.test_testPocketApp_pocketvpc_privatesubnetids_A272E250.ids}\\"
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",
@@ -2843,6 +2851,7 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
           \\"hobby\\": \\"bowling\\"
         },
         \\"task_role_arn\\": \\"\${aws_iam_role.test_testPocketApp_ecsservice_ecsiam_ecstaskrole_E41363D4.arn}\\",
+        \\"depends_on\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
@@ -2874,6 +2883,7 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
             \\"subnets\\": \\"\${data.aws_subnet_ids.test_testPocketApp_pocketvpc_privatesubnetids_A272E250.ids}\\"
           }
         ],
+        \\"depends_on\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"task_definition\\",


### PR DESCRIPTION
# Goal

There seemed to be a race condition when a stack is created fresh on AWS CodeBuild. To solve for this we need ECSService and ECSTaskDefinition to depend on the ECR repository to first be created.

## Todos
- [x] Add a depends on.

## Review
- [ ] @Pocket/backend 
