### PR TITLE
fix(alarms): Validate alarm config and fix name prefix

### DIFF
--- a/src/pocket/PocketALBApplication.spec.ts
+++ b/src/pocket/PocketALBApplication.spec.ts
@@ -164,4 +164,115 @@ describe('PocketALBApplication', () => {
 
     expect(Testing.synth(stack)).toMatchSnapshot();
   });
+
+  it('renders an application custom default alarms', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const alarmConfig = {
+      ...BASE_CONFIG,
+      alarms: {
+        customAlarms: [
+          {
+            alarmName: `Alarm-Custom`,
+            namespace: 'TM/Alarm',
+            metricName: 'Custom',
+            dimensions: { Test: 'Alarm' },
+            period: 300,
+            statistic: 'Sum',
+            comparisonOperator: 'GreaterThanThreshold',
+            threshold: 500,
+            evaluationPeriods: 1,
+          },
+        ],
+      },
+    };
+
+    new PocketALBApplication(stack, 'testPocketApp', alarmConfig);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('validates http 5xx alarm config', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const alarmConfig = {
+      ...BASE_CONFIG,
+      alarms: {
+        http5xxError: {
+          datapointsToAlarm: 2,
+        },
+      },
+    };
+
+    expect(
+      () => new PocketALBApplication(stack, 'testPocketApp', alarmConfig)
+    ).toThrow(Error);
+  });
+
+  it('validates http latency alarm config', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const alarmConfig = {
+      ...BASE_CONFIG,
+      alarms: {
+        httpLatency: {
+          datapointsToAlarm: 2,
+        },
+      },
+    };
+
+    expect(
+      () => new PocketALBApplication(stack, 'testPocketApp', alarmConfig)
+    ).toThrow(Error);
+  });
+
+  it('validates http request count alarm config', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const alarmConfig = {
+      ...BASE_CONFIG,
+      alarms: {
+        httpRequestCount: {
+          datapointsToAlarm: 2,
+        },
+      },
+    };
+
+    expect(
+      () => new PocketALBApplication(stack, 'testPocketApp', alarmConfig)
+    ).toThrow(Error);
+  });
+
+  it('validates custom alarms config', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const alarmConfig = {
+      ...BASE_CONFIG,
+      alarms: {
+        customAlarms: [
+          {
+            alarmName: `Test-Alarm-Custom`,
+            namespace: 'TM/Alarm',
+            metricName: 'Custom',
+            dimensions: { Test: 'Alarm' },
+            period: 300,
+            statistic: 'Sum',
+            comparisonOperator: 'GreaterThanThreshold',
+            threshold: 500,
+            evaluationPeriods: 1,
+            datapointsToAlarm: 2,
+          },
+        ],
+      },
+    };
+
+    expect(
+      () => new PocketALBApplication(stack, 'testPocketApp', alarmConfig)
+    ).toThrow(Error);
+  });
 });

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -1,5 +1,990 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PocketALBApplication renders an application custom default alarms 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_ssm_parameter\\": {
+      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
+        \\"name\\": \\"/Shared/Vpc\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/vpc_ssm_param\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
+        \\"name\\": \\"/Shared/PrivateSubnets\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/private_subnets\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
+        \\"name\\": \\"/Shared/PublicSubnets\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/public_subnets\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\"
+          }
+        }
+      }
+    },
+    \\"aws_vpc\\": {
+      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/vpc\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_C4E157E3\\"
+          }
+        }
+      }
+    },
+    \\"aws_subnet_ids\\": {
+      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/private_subnet_ids\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/public_subnet_ids\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\"
+          }
+        }
+      }
+    },
+    \\"aws_caller_identity\\": {
+      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/current_identity\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_current_identity_06D87057\\"
+          }
+        }
+      }
+    },
+    \\"aws_region\\": {
+      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/current_region\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
+        \\"name\\": \\"alias/aws/secretsmanager\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/secrets_manager_key\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_groups\\": {
+      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"group-name\\",
+            \\"values\\": [
+              \\"default\\"
+            ]
+          },
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/default_security_groups\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\"
+          }
+        }
+      }
+    },
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
+        \\"name\\": \\"bowling.gov\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns_main_hosted_zone\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-task-assume\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_assume\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"cloudwatch:PutMetricAlarm\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:DeleteAlarms\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:cloudwatch:*:*:alarm:/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:DescribeServices\\",
+              \\"ecs:UpdateService\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:ecs:*:*:service/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/role_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns/subhosted_zone\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\"
+          }
+        }
+      }
+    },
+    \\"aws_route53_record\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
+        \\"ttl\\": 86400,
+        \\"type\\": \\"NS\\",
+        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns/subhosted_zone_ns\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\"
+          }
+        }
+      },
+      \\"testPocketApp_alb_record_7B56ED33\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"set_identifier\\": \\"1\\",
+        \\"type\\": \\"A\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\",
+        \\"alias\\": [
+          {
+            \\"evaluate_target_health\\": true,
+            \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
+            \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+          }
+        ],
+        \\"weighted_routing_policy\\": [
+          {
+            \\"weight\\": 1
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"weighted_routing_policy[0].weight\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_record\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_record_7B56ED33\\"
+          }
+        }
+      },
+      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
+        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_name}\\",
+        \\"records\\": [
+          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_value}\\"
+        ],
+        \\"ttl\\": 60,
+        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_type}\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\",
+        \\"depends_on\\": [
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate_record\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        },
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/application_load_balancer/alb_security_group\\",
+            \\"uniqueId\\": \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 8675309
+          }
+        ],
+        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_security_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb\\": {
+      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+        ],
+        \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/application_load_balancer/alb\\",
+            \\"uniqueId\\": \\"testPocketApp_application_load_balancer_alb_D538DEEE\\"
+          }
+        }
+      }
+    },
+    \\"aws_acm_certificate\\": {
+      \\"testPocketApp_alb_certificate_417C14FF\\": {
+        \\"domain_name\\": \\"testing.bowling.gov\\",
+        \\"validation_method\\": \\"DNS\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_417C14FF\\"
+          }
+        }
+      }
+    },
+    \\"aws_acm_certificate_validation\\": {
+      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"validation_record_fqdns\\": [
+          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        ],
+        \\"depends_on\\": [
+          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate_validation\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_cluster\\": {
+      \\"testPocketApp_ecs_cluster_C3960066\\": {
+        \\"name\\": \\"testapp\\",
+        \\"setting\\": [
+          {
+            \\"name\\": \\"containerInsights\\",
+            \\"value\\": \\"enabled\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_cluster/ecs_cluster\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_cluster_C3960066\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_listener\\": {
+      \\"testPocketApp_listener_http_A9E227C2\\": {
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"default_action\\": [
+          {
+            \\"type\\": \\"redirect\\",
+            \\"redirect\\": [
+              {
+                \\"port\\": \\"443\\",
+                \\"protocol\\": \\"HTTPS\\",
+                \\"status_code\\": \\"HTTP_301\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/listener_http\\",
+            \\"uniqueId\\": \\"testPocketApp_listener_http_A9E227C2\\"
+          }
+        }
+      },
+      \\"testPocketApp_listener_https_7F49DE83\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 443,
+        \\"protocol\\": \\"HTTPS\\",
+        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\",
+        \\"default_action\\": [
+          {
+            \\"type\\": \\"fixed-response\\",
+            \\"fixed_response\\": [
+              {
+                \\"content_type\\": \\"text/plain\\",
+                \\"message_body\\": \\"\\",
+                \\"status_code\\": \\"503\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/listener_https\\",
+            \\"uniqueId\\": \\"testPocketApp_listener_https_7F49DE83\\"
+          }
+        }
+      }
+    },
+    \\"null_resource\\": {
+      \\"testPocketApp_ecs_service_8F213571\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_8F213571\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-execution-role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-task-role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7.json}\\",
+        \\"name\\": \\"testapp-AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_role\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
+        \\"family\\": \\"testapp\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
+        \\"depends_on\\": [],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_target_group\\": {
+      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
+        \\"deregistration_delay\\": 120,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"tags\\": {
+          \\"type\\": \\"blue\\"
+        },
+        \\"target_type\\": \\"ip\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"health_check\\": [
+          {
+            \\"healthy_threshold\\": 5,
+            \\"interval\\": 15,
+            \\"path\\": \\"/test\\",
+            \\"protocol\\": \\"HTTP\\",
+            \\"unhealthy_threshold\\": 3
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/blue_target_group/ecs_target_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_listener_rule\\": {
+      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
+        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
+        \\"priority\\": 1,
+        \\"action\\": [
+          {
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
+            \\"type\\": \\"forward\\"
+          }
+        ],
+        \\"condition\\": [
+          {
+            \\"path_pattern\\": [
+              {
+                \\"values\\": [
+                  \\"*\\"
+                ]
+              }
+            ]
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"action\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/listener_rule\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_service\\": {
+      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
+        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"name\\": \\"testapp\\",
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",
+        \\"deployment_controller\\": [
+          {
+            \\"type\\": \\"ECS\\"
+          }
+        ],
+        \\"load_balancer\\": [
+          {
+            \\"container_name\\": \\"main_container\\",
+            \\"container_port\\": 8675309,
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+          }
+        ],
+        \\"network_configuration\\": [
+          {
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+            ],
+            \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
+          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-service\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\": {
+        \\"name\\": \\"testapp-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_role_policy_4E03A5E2.json}\\",
+        \\"role\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_role_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
+        \\"max_capacity\\": 2,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_target\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
+        \\"name\\": \\"testapp-ScaleOutPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_lower_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": 2
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_out_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
+        \\"name\\": \\"testapp-ScaleInPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_upper_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": -1
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_in_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_name\\": \\"testapp Service High CPU\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 45,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_out_alarm\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
+        \\"alarm_name\\": \\"testapp Service Low CPU\\",
+        \\"comparison_operator\\": \\"LessThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 30,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_in_alarm\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"evaluation_periods\\": 5,
+        \\"insufficient_data_actions\\": [],
+        \\"ok_actions\\": [],
+        \\"threshold\\": 5,
+        \\"metric_query\\": [
+          {
+            \\"id\\": \\"requests\\",
+            \\"metric\\": [
+              {
+                \\"dimensions\\": {
+                  \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+                },
+                \\"metric_name\\": \\"RequestCount\\",
+                \\"namespace\\": \\"AWS/ApplicationELB\\",
+                \\"period\\": 60,
+                \\"stat\\": \\"Sum\\",
+                \\"unit\\": \\"Count\\"
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"errors\\",
+            \\"metric\\": [
+              {
+                \\"dimensions\\": {
+                  \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+                },
+                \\"metric_name\\": \\"HTTPCode_ELB_5XX_Count\\",
+                \\"namespace\\": \\"AWS/ApplicationELB\\",
+                \\"period\\": 60,
+                \\"stat\\": \\"Sum\\",
+                \\"unit\\": \\"Count\\"
+              }
+            ]
+          },
+          {
+            \\"expression\\": \\"errors/requests*100\\",
+            \\"id\\": \\"expression\\",
+            \\"label\\": \\"HTTP 5xx Error Rate\\",
+            \\"return_data\\": true
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"TargetResponseTime\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 300,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"RequestCount\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 500,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-custom_F535C2DE\\": {
+        \\"alarm_name\\": \\"testapp-Alarm-Custom\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"dimensions\\": {
+          \\"Test\\": \\"Alarm\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"metric_name\\": \\"Custom\\",
+        \\"namespace\\": \\"TM/Alarm\\",
+        \\"period\\": 300,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 500,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-custom\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-custom_F535C2DE\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_dashboard\\": {
+      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
+        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#17becf\\\\\\",\\\\\\"label\\\\\\":\\\\\\"RequestCountThreshold\\\\\\",\\\\\\"value\\\\\\":500,\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\"}]},\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#17becf\\\\\\",\\\\\\"label\\\\\\":\\\\\\"RequestCountThreshold\\\\\\",\\\\\\"value\\\\\\":500,\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\"}]},\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.cluster}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
+        \\"dashboard_name\\": \\"testapp-ALBDashboard\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/cloudwatch-dashboard\\",
+            \\"uniqueId\\": \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`PocketALBApplication renders an application with autoscaling group and tags 1`] = `
 "{
   \\"//\\": {
@@ -894,10 +1879,10 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -948,15 +1933,15 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -976,15 +1961,15 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -1004,8 +1989,8 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -1872,10 +2857,10 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -1922,15 +2907,15 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -1946,15 +2931,15 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -1970,8 +2955,8 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -2886,10 +3871,10 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -2940,15 +3925,15 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -2968,15 +3953,15 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -2996,8 +3981,8 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -3864,10 +4849,10 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -3914,15 +4899,15 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -3938,15 +4923,15 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -3962,8 +4947,8 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -4876,10 +5861,10 @@ exports[`PocketALBApplication renders an application with modified container def
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -4926,15 +5911,15 @@ exports[`PocketALBApplication renders an application with modified container def
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -4950,15 +5935,15 @@ exports[`PocketALBApplication renders an application with modified container def
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -4974,8 +5959,8 @@ exports[`PocketALBApplication renders an application with modified container def
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -6003,10 +6988,10 @@ exports[`PocketALBApplication renders an external application 1`] = `
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -6053,15 +7038,15 @@ exports[`PocketALBApplication renders an external application 1`] = `
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -6077,15 +7062,15 @@ exports[`PocketALBApplication renders an external application 1`] = `
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -6101,8 +7086,8 @@ exports[`PocketALBApplication renders an external application 1`] = `
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -6969,10 +7954,10 @@ exports[`PocketALBApplication renders an internal application 1`] = `
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -7019,15 +8004,15 @@ exports[`PocketALBApplication renders an internal application 1`] = `
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -7043,15 +8028,15 @@ exports[`PocketALBApplication renders an internal application 1`] = `
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -7067,8 +8052,8 @@ exports[`PocketALBApplication renders an internal application 1`] = `
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }
@@ -7983,10 +8968,10 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\": {
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
         \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"evaluation_periods\\": 5,
@@ -8037,15 +9022,15 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
         ],
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-http5xxerrorrate\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-http5xxerrorrate_A1A507E5\\"
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPResponseTime\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -8065,15 +9050,15 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
         \\"threshold\\": 300,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httpresponsetime\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httpresponsetime_111D468B\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
           }
         }
       },
-      \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\": {
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
         \\"alarm_actions\\": [],
         \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-testapp-Alarm-HTTPRequestCount\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"datapoints_to_alarm\\": 1,
         \\"dimensions\\": {
@@ -8093,8 +9078,8 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
         \\"threshold\\": 500,
         \\"//\\": {
           \\"metadata\\": {
-            \\"path\\": \\"test/testPocketApp/testapp-alarm-httprequestcount\\",
-            \\"uniqueId\\": \\"testPocketApp_testapp-alarm-httprequestcount_A9309D20\\"
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
           }
         }
       }


### PR DESCRIPTION
## Goal

- Validate alarm config to check `datapointsToAlarm` is not greater than `evaluationPeriods`.
- Add tests for alarm config validation.
- Fix alarm names to avoid double prefixing.