### PR TITLE
fix(lambda-alarms): Add alarms support to PocketEventBridgeWithLambdaTarget module

### DIFF
--- a/src/base/ApplicationAutoscaling.ts
+++ b/src/base/ApplicationAutoscaling.ts
@@ -151,7 +151,7 @@ export class ApplicationAutoscaling extends Resource {
       }
     );
 
-    const scaleOutAlarm = new CloudwatchMetricAlarm(this, `scale_out_alarm`, {
+    new CloudwatchMetricAlarm(this, `scale_out_alarm`, {
       alarmName: `${config.prefix} Service High CPU`,
       alarmDescription: 'Alarm to add capacity if CPU is high',
       comparisonOperator: 'GreaterThanThreshold',
@@ -162,24 +162,15 @@ export class ApplicationAutoscaling extends Resource {
       namespace: 'AWS/ECS',
       metricName: 'CPUUtilization',
       treatMissingData: 'notBreaching',
-      dimensions: {},
+      dimensions: {
+        ClusterName: config.ecsClusterName,
+        ServiceName: config.ecsServiceName,
+      },
       alarmActions: [applicationScaleOut.arn],
       tags: config.tags,
     });
 
-    // This override is related to CDK bug: https://github.com/hashicorp/terraform-cdk/issues/235
-    // CDK does not respect the case of keys and causing
-    // wrong synthesizing. For dimensions it will be:
-    // { cluster_name: 'testapp-', service_name: 'testapp-' }
-    // instead of:
-    // { ClusterName: 'testapp-', ServiceName: 'testapp-' }
-
-    scaleOutAlarm.addOverride('dimensions', {
-      ClusterName: config.ecsClusterName,
-      ServiceName: config.ecsServiceName,
-    });
-
-    const scaleInAlarm = new CloudwatchMetricAlarm(this, `scale_in_alarm`, {
+    new CloudwatchMetricAlarm(this, `scale_in_alarm`, {
       alarmName: `${config.prefix} Service Low CPU`,
       alarmDescription: 'Alarm to reduce capacity if container CPU is low',
       comparisonOperator: 'LessThanThreshold',
@@ -190,15 +181,12 @@ export class ApplicationAutoscaling extends Resource {
       namespace: 'AWS/ECS',
       metricName: 'CPUUtilization',
       treatMissingData: 'notBreaching',
-      dimensions: {},
+      dimensions: {
+        ClusterName: config.ecsClusterName,
+        ServiceName: config.ecsServiceName,
+      },
       alarmActions: [applicationScaleIn.arn],
       tags: config.tags,
-    });
-
-    // This override is related to CDK bug: https://github.com/hashicorp/terraform-cdk/issues/235
-    scaleInAlarm.addOverride('dimensions', {
-      ClusterName: config.ecsClusterName,
-      ServiceName: config.ecsServiceName,
     });
   }
 }

--- a/src/pocket/PocketEventBridgeWithLambdaTarget.ts
+++ b/src/pocket/PocketEventBridgeWithLambdaTarget.ts
@@ -118,63 +118,21 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
   private createLambdaAlarms(lambda: ApplicationVersionedLambda): void {
     const alarmsConfig = this.config.lambda.alarms;
 
-    if (alarmsConfig.invocations) {
-      this.createLambdaInvocationsAlarm(lambda);
-    }
+    const alarms = {
+      invocations: 'Invocations',
+      errors: 'Errors',
+      concurrentExecutions: 'ConcurrentExecutions',
+      throttles: 'Throttles',
+      duration: 'Duration',
+    };
 
-    if (alarmsConfig.errors) {
-      this.createLambdaErrorsAlarm(lambda);
-    }
-
-    if (alarmsConfig.concurrentExecutions) {
-      this.createLambdaConcurrentExecutionsAlarm(lambda);
-    }
-
-    if (alarmsConfig.throttles) {
-      this.createLambdaThrottlesAlarm(lambda);
-    }
-
-    if (alarmsConfig.duration) {
-      this.createLambdaDurationAlarm(lambda);
-    }
-  }
-
-  private createLambdaDurationAlarm(lambda: ApplicationVersionedLambda): void {
-    this.createLambdaAlarm(lambda, {
-      metricName: 'Duration',
-      props: this.config.lambda.alarms.duration,
-    });
-  }
-
-  private createLambdaThrottlesAlarm(lambda: ApplicationVersionedLambda): void {
-    this.createLambdaAlarm(lambda, {
-      metricName: 'Throttles',
-      props: this.config.lambda.alarms.throttles,
-    });
-  }
-
-  private createLambdaConcurrentExecutionsAlarm(
-    lambda: ApplicationVersionedLambda
-  ): void {
-    this.createLambdaAlarm(lambda, {
-      metricName: 'ConcurrentExecutions',
-      props: this.config.lambda.alarms.concurrentExecutions,
-    });
-  }
-
-  private createLambdaErrorsAlarm(lambda: ApplicationVersionedLambda): void {
-    this.createLambdaAlarm(lambda, {
-      metricName: 'Errors',
-      props: this.config.lambda.alarms.errors,
-    });
-  }
-
-  private createLambdaInvocationsAlarm(
-    lambda: ApplicationVersionedLambda
-  ): void {
-    this.createLambdaAlarm(lambda, {
-      metricName: 'Invocations',
-      props: this.config.lambda.alarms.invocations,
+    Object.keys(alarms).forEach((name) => {
+      if (alarmsConfig[name]) {
+        this.createLambdaAlarm(lambda, {
+          metricName: alarms[name],
+          props: this.config.lambda.alarms[name],
+        });
+      }
     });
   }
 

--- a/src/pocket/PocketEventBridgeWithLambdaTarget.ts
+++ b/src/pocket/PocketEventBridgeWithLambdaTarget.ts
@@ -89,7 +89,7 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
 
   private static validateConfig(
     config: PocketEventBridgeWithLambdaTargetProps
-  ) {
+  ): void {
     if (!config.lambda.alarms) return;
 
     const alarms = {
@@ -115,7 +115,7 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
     });
   }
 
-  private createLambdaAlarms(lambda: ApplicationVersionedLambda) {
+  private createLambdaAlarms(lambda: ApplicationVersionedLambda): void {
     const alarmsConfig = this.config.lambda.alarms;
 
     if (alarmsConfig.invocations) {
@@ -139,14 +139,14 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
     }
   }
 
-  private createLambdaDurationAlarm(lambda: ApplicationVersionedLambda) {
+  private createLambdaDurationAlarm(lambda: ApplicationVersionedLambda): void {
     this.createLambdaAlarm(lambda, {
       metricName: 'Duration',
       props: this.config.lambda.alarms.duration,
     });
   }
 
-  private createLambdaThrottlesAlarm(lambda: ApplicationVersionedLambda) {
+  private createLambdaThrottlesAlarm(lambda: ApplicationVersionedLambda): void {
     this.createLambdaAlarm(lambda, {
       metricName: 'Throttles',
       props: this.config.lambda.alarms.throttles,
@@ -155,21 +155,23 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
 
   private createLambdaConcurrentExecutionsAlarm(
     lambda: ApplicationVersionedLambda
-  ) {
+  ): void {
     this.createLambdaAlarm(lambda, {
       metricName: 'ConcurrentExecutions',
       props: this.config.lambda.alarms.concurrentExecutions,
     });
   }
 
-  private createLambdaErrorsAlarm(lambda: ApplicationVersionedLambda) {
+  private createLambdaErrorsAlarm(lambda: ApplicationVersionedLambda): void {
     this.createLambdaAlarm(lambda, {
       metricName: 'Errors',
       props: this.config.lambda.alarms.errors,
     });
   }
 
-  private createLambdaInvocationsAlarm(lambda: ApplicationVersionedLambda) {
+  private createLambdaInvocationsAlarm(
+    lambda: ApplicationVersionedLambda
+  ): void {
     this.createLambdaAlarm(lambda, {
       metricName: 'Invocations',
       props: this.config.lambda.alarms.invocations,
@@ -182,7 +184,7 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
       metricName: string;
       props: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
     }
-  ) {
+  ): void {
     const props = config.props;
     const defaultEvaluationPeriods = 1;
 
@@ -210,7 +212,7 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
     });
   }
 
-  private createLambdaCodeDeploy() {
+  private createLambdaCodeDeploy(): void {
     const lambdaConfig = this.config.lambda;
 
     new ApplicationLambdaCodeDeploy(this, 'lambda-code-deploy', {
@@ -225,7 +227,7 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
   private createLambdaEventRuleResourcePermission(
     lambda: ApplicationVersionedLambda,
     eventBridgeRule: ApplicationEventBridgeRule
-  ) {
+  ): void {
     new LambdaPermission(this, 'lambda-permission', {
       action: 'lambda:InvokeFunction',
       functionName: lambda.versionedLambda.functionName,
@@ -236,7 +238,9 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
     });
   }
 
-  private createEventBridgeRule(lambda: ApplicationVersionedLambda) {
+  private createEventBridgeRule(
+    lambda: ApplicationVersionedLambda
+  ): ApplicationEventBridgeRule {
     const eventRuleConfig = this.config.eventRule;
 
     return new ApplicationEventBridgeRule(this, 'event-bridge-rule', {
@@ -253,7 +257,7 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
     });
   }
 
-  private createVersionedLambda() {
+  private createVersionedLambda(): ApplicationVersionedLambda {
     const lambdaConfig = this.config.lambda;
 
     return new ApplicationVersionedLambda(this, 'lambda', {

--- a/src/pocket/PocketEventBridgeWithLambdaTarget.ts
+++ b/src/pocket/PocketEventBridgeWithLambdaTarget.ts
@@ -6,75 +6,226 @@ import {
   LAMBDA_RUNTIMES,
 } from '../base/ApplicationVersionedLambda';
 import {
+  CloudwatchMetricAlarm,
   DataAwsIamPolicyDocumentStatement,
   LambdaFunctionVpcConfig,
   LambdaPermission,
 } from '../../.gen/providers/aws';
 import { ApplicationLambdaCodeDeploy } from '../base/ApplicationLambdaCodeDeploy';
 
+export interface PocketEventBridgeWithLambdaTargetDefaultAlarmProps {
+  threshold: number;
+  period: number;
+  evaluationPeriods?: number;
+  datapointsToAlarm?: number;
+  comparisonOperator?:
+    | 'GreaterThanOrEqualToThreshold'
+    | 'GreaterThanThreshold'
+    | 'GreaterThanUpperThreshold'
+    | 'LessThanLowerOrGreaterThanUpperThreshold'
+    | 'LessThanLowerThreshold'
+    | 'LessThanOrEqualToThreshold'
+    | 'LessThanThreshold';
+  alarmDescription?: string;
+  actions?: string[];
+}
+
 export interface PocketEventBridgeWithLambdaTargetProps {
   name: string;
-  lambdaDescription?: string;
-  ruleDescription?: string;
-  eventBusName?: string;
-  eventPattern: { [key: string]: any };
-  runtime: LAMBDA_RUNTIMES;
-  handler: string;
-  timeout?: number;
-  environment?: { [key: string]: string };
-  vpcConfig?: LambdaFunctionVpcConfig;
-  executionPolicyStatements?: DataAwsIamPolicyDocumentStatement[];
-  logRetention?: number;
-  s3Bucket?: string;
-  tags?: { [key: string]: string };
-  codeDeploy?: {
-    deploySnsTopicArn?: string;
-    detailType?: 'BASIC' | 'FULL';
-    region: string;
-    accountId: string;
+  lambda: {
+    description?: string;
+    runtime: LAMBDA_RUNTIMES;
+    handler: string;
+    timeout?: number;
+    environment?: { [key: string]: string };
+    vpcConfig?: LambdaFunctionVpcConfig;
+    executionPolicyStatements?: DataAwsIamPolicyDocumentStatement[];
+    logRetention?: number;
+    s3Bucket?: string;
+    codeDeploy?: {
+      deploySnsTopicArn?: string;
+      detailType?: 'BASIC' | 'FULL';
+      region: string;
+      accountId: string;
+    };
+    alarms?: {
+      invocations?: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
+      errors?: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
+      concurrentExecutions?: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
+      throttles?: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
+      duration?: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
+    };
   };
+  eventRule: {
+    description?: string;
+    eventBusName?: string;
+    pattern: { [key: string]: any };
+  };
+  tags?: { [key: string]: string };
 }
 
 export class PocketEventBridgeWithLambdaTarget extends Resource {
   constructor(
     scope: Construct,
     name: string,
-    config: PocketEventBridgeWithLambdaTargetProps
+    private readonly config: PocketEventBridgeWithLambdaTargetProps
   ) {
     super(scope, name);
 
-    const lambda = new ApplicationVersionedLambda(this, 'lambda', {
-      name: config.name,
-      description: config.lambdaDescription,
-      runtime: config.runtime,
-      handler: config.handler,
-      timeout: config.timeout,
-      environment: config.environment,
-      vpcConfig: config.vpcConfig,
-      executionPolicyStatements: config.executionPolicyStatements,
-      logRetention: config.logRetention,
-      s3Bucket: config.s3Bucket ?? `pocket-${config.name.toLowerCase()}`,
-      tags: config.tags,
-      usesCodeDeploy: !!config.codeDeploy,
-    });
+    PocketEventBridgeWithLambdaTarget.validateConfig(config);
 
-    const eventBridgeRule = new ApplicationEventBridgeRule(
-      this,
-      'event-bridge-rule',
-      {
-        name: config.name,
-        description: config.ruleDescription,
-        eventBusName: config.eventBusName,
-        eventPattern: config.eventPattern,
-        target: {
-          targetId: 'lambda',
-          arn: lambda.versionedLambda.arn,
-          dependsOn: lambda.versionedLambda,
-        },
-        tags: config.tags,
+    const lambda = this.createVersionedLambda();
+    const eventBridgeRule = this.createEventBridgeRule(lambda);
+    this.createLambdaEventRuleResourcePermission(lambda, eventBridgeRule);
+
+    if (config.lambda.codeDeploy) {
+      this.createLambdaCodeDeploy();
+    }
+
+    if (config.lambda.alarms) {
+      this.createLambdaAlarms(lambda);
+    }
+  }
+
+  private static validateConfig(
+    config: PocketEventBridgeWithLambdaTargetProps
+  ) {
+    if (!config.lambda.alarms) return;
+
+    const alarms = {
+      invocations: 'Invocations',
+      errors: 'Errors',
+      concurrentExecutions: 'Concurrent Executions',
+      throttles: 'Throttles',
+      duration: 'Duration',
+    };
+
+    const errorMessage =
+      'DatapointsToAlarm must be less than or equal to EvaluationPeriods';
+
+    const alarmsConfig = config.lambda.alarms;
+
+    Object.keys(alarms).forEach((key) => {
+      if (
+        alarmsConfig[key]?.datapointsToAlarm >
+        (alarmsConfig[key]?.evaluationPeriods ?? 1)
+      ) {
+        throw new Error(`${alarms[key]} Alarm: ${errorMessage}`);
       }
-    );
+    });
+  }
 
+  private createLambdaAlarms(lambda: ApplicationVersionedLambda) {
+    const alarmsConfig = this.config.lambda.alarms;
+
+    if (alarmsConfig.invocations) {
+      this.createLambdaInvocationsAlarm(lambda);
+    }
+
+    if (alarmsConfig.errors) {
+      this.createLambdaErrorsAlarm(lambda);
+    }
+
+    if (alarmsConfig.concurrentExecutions) {
+      this.createLambdaConcurrentExecutionsAlarm(lambda);
+    }
+
+    if (alarmsConfig.throttles) {
+      this.createLambdaThrottlesAlarm(lambda);
+    }
+
+    if (alarmsConfig.duration) {
+      this.createLambdaDurationAlarm(lambda);
+    }
+  }
+
+  private createLambdaDurationAlarm(lambda: ApplicationVersionedLambda) {
+    this.createLambdaAlarm(lambda, {
+      metricName: 'Duration',
+      props: this.config.lambda.alarms.duration,
+    });
+  }
+
+  private createLambdaThrottlesAlarm(lambda: ApplicationVersionedLambda) {
+    this.createLambdaAlarm(lambda, {
+      metricName: 'Throttles',
+      props: this.config.lambda.alarms.throttles,
+    });
+  }
+
+  private createLambdaConcurrentExecutionsAlarm(
+    lambda: ApplicationVersionedLambda
+  ) {
+    this.createLambdaAlarm(lambda, {
+      metricName: 'ConcurrentExecutions',
+      props: this.config.lambda.alarms.concurrentExecutions,
+    });
+  }
+
+  private createLambdaErrorsAlarm(lambda: ApplicationVersionedLambda) {
+    this.createLambdaAlarm(lambda, {
+      metricName: 'Errors',
+      props: this.config.lambda.alarms.errors,
+    });
+  }
+
+  private createLambdaInvocationsAlarm(lambda: ApplicationVersionedLambda) {
+    this.createLambdaAlarm(lambda, {
+      metricName: 'Invocations',
+      props: this.config.lambda.alarms.invocations,
+    });
+  }
+
+  private createLambdaAlarm(
+    lambda: ApplicationVersionedLambda,
+    config: {
+      metricName: string;
+      props: PocketEventBridgeWithLambdaTargetDefaultAlarmProps;
+    }
+  ) {
+    const props = config.props;
+    const defaultEvaluationPeriods = 1;
+
+    new CloudwatchMetricAlarm(this, config.metricName.toLowerCase(), {
+      alarmName: `${this.config.name}-Lambda-${config.metricName}-Alarm`,
+      namespace: 'AWS/Lambda',
+      metricName: config.metricName,
+      dimensions: {
+        FunctionName: lambda.versionedLambda.functionName,
+        Resource: `${lambda.versionedLambda.functionName}:${lambda.versionedLambda.name}`,
+      },
+      period: props.period,
+      evaluationPeriods: props.evaluationPeriods ?? defaultEvaluationPeriods,
+      datapointsToAlarm: props.datapointsToAlarm ?? defaultEvaluationPeriods,
+      statistic: 'Sum',
+      comparisonOperator: props.comparisonOperator ?? 'GreaterThanThreshold',
+      threshold: props.threshold,
+      alarmDescription:
+        props.alarmDescription ??
+        `Total ${config.metricName.toLowerCase()} breaches threshold`,
+      insufficientDataActions: [],
+      alarmActions: props.actions ?? [],
+      okActions: props.actions ?? [],
+      tags: this.config.tags,
+    });
+  }
+
+  private createLambdaCodeDeploy() {
+    const lambdaConfig = this.config.lambda;
+
+    new ApplicationLambdaCodeDeploy(this, 'lambda-code-deploy', {
+      name: this.config.name,
+      deploySnsTopicArn: lambdaConfig.codeDeploy.deploySnsTopicArn,
+      detailType: lambdaConfig.codeDeploy.detailType,
+      region: lambdaConfig.codeDeploy.region,
+      accountId: lambdaConfig.codeDeploy.accountId,
+    });
+  }
+
+  private createLambdaEventRuleResourcePermission(
+    lambda: ApplicationVersionedLambda,
+    eventBridgeRule: ApplicationEventBridgeRule
+  ) {
     new LambdaPermission(this, 'lambda-permission', {
       action: 'lambda:InvokeFunction',
       functionName: lambda.versionedLambda.functionName,
@@ -83,15 +234,42 @@ export class PocketEventBridgeWithLambdaTarget extends Resource {
       sourceArn: eventBridgeRule.rule.arn,
       dependsOn: [lambda.versionedLambda, eventBridgeRule.rule],
     });
+  }
 
-    if (config.codeDeploy) {
-      new ApplicationLambdaCodeDeploy(this, 'lambda-code-deploy', {
-        name: config.name,
-        deploySnsTopicArn: config.codeDeploy.deploySnsTopicArn,
-        detailType: config.codeDeploy.detailType,
-        region: config.codeDeploy.region,
-        accountId: config.codeDeploy.accountId,
-      });
-    }
+  private createEventBridgeRule(lambda: ApplicationVersionedLambda) {
+    const eventRuleConfig = this.config.eventRule;
+
+    return new ApplicationEventBridgeRule(this, 'event-bridge-rule', {
+      name: this.config.name,
+      description: eventRuleConfig.description,
+      eventBusName: eventRuleConfig.eventBusName,
+      eventPattern: eventRuleConfig.pattern,
+      target: {
+        targetId: 'lambda',
+        arn: lambda.versionedLambda.arn,
+        dependsOn: lambda.versionedLambda,
+      },
+      tags: this.config.tags,
+    });
+  }
+
+  private createVersionedLambda() {
+    const lambdaConfig = this.config.lambda;
+
+    return new ApplicationVersionedLambda(this, 'lambda', {
+      name: this.config.name,
+      description: lambdaConfig.description,
+      runtime: lambdaConfig.runtime,
+      handler: lambdaConfig.handler,
+      timeout: lambdaConfig.timeout,
+      environment: lambdaConfig.environment,
+      vpcConfig: lambdaConfig.vpcConfig,
+      executionPolicyStatements: lambdaConfig.executionPolicyStatements,
+      logRetention: lambdaConfig.logRetention,
+      s3Bucket:
+        lambdaConfig.s3Bucket ?? `pocket-${this.config.name.toLowerCase()}`,
+      tags: this.config.tags,
+      usesCodeDeploy: !!lambdaConfig.codeDeploy,
+    });
   }
 }

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -247,6 +247,380 @@ exports[`renders an event bridge and lambda target 1`] = `
 }"
 `;
 
+exports[`renders an event bridge and lambda target with alarms 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"aws_s3_bucket\\": {
+      \\"test-event-bridge-lambda_code-bucket_3703E73B\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-test-event-bridge-lambda\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/code-bucket\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_code-bucket_3703E73B\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"test-event-bridge-lambda_code-bucket-public-access-block_A1A4EF9D\\": {
+        \\"block_public_acls\\": true,
+        \\"block_public_policy\\": true,
+        \\"bucket\\": \\"\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/code-bucket-public-access-block\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_code-bucket-public-access-block_A1A4EF9D\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-event-bridge-lambda_execution-role_7936A26A\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-event-bridge-lambda_assume-policy-document_59E97C0B.json}\\",
+        \\"name\\": \\"test-event-bridge-lambda-ExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/execution-role\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_execution-role_7936A26A\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-event-bridge-lambda_execution-role-policy_2830D73D\\": {
+        \\"name\\": \\"test-event-bridge-lambda-ExecutionRolePolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-event-bridge-lambda_execution-policy-document_0A3C0E28.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/execution-role-policy\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_execution-role-policy_2830D73D\\"
+          }
+        }
+      }
+    },
+    \\"aws_lambda_function\\": {
+      \\"test-event-bridge-lambda_65C2E1CE\\": {
+        \\"filename\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_path}\\",
+        \\"function_name\\": \\"test-event-bridge-lambda-Function\\",
+        \\"handler\\": \\"index.handler\\",
+        \\"publish\\": true,
+        \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}\\",
+        \\"runtime\\": \\"python3.8\\",
+        \\"source_code_hash\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}\\",
+        \\"timeout\\": 5,
+        \\"vpc_config\\": [],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"filename\\",
+            \\"source_code_hash\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/lambda\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_65C2E1CE\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_log_group\\": {
+      \\"test-event-bridge-lambda_log-group_CF4CF8D4\\": {
+        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
+        \\"retention_in_days\\": 14,
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/log-group\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_log-group_CF4CF8D4\\"
+          }
+        }
+      }
+    },
+    \\"aws_lambda_alias\\": {
+      \\"test-event-bridge-lambda_alias_2EC274FC\\": {
+        \\"function_name\\": \\"\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
+        \\"function_version\\": \\"\${split(\\\\\\":\\\\\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn)[7]}\\",
+        \\"name\\": \\"DEPLOYED\\",
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"function_version\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/alias\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_alias_2EC274FC\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_event_rule\\": {
+      \\"test-event-bridge-lambda_event-bridge-rule_529FF7C2\\": {
+        \\"event_bus_name\\": \\"default\\",
+        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"name\\": \\"test-event-bridge-lambda-Rule\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/event-bridge-rule/event-bridge-rule\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_event_target\\": {
+      \\"test-event-bridge-lambda_event-bridge-rule_event-bridge-target_84D24AD3\\": {
+        \\"arn\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}\\",
+        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}\\",
+        \\"target_id\\": \\"lambda\\",
+        \\"depends_on\\": [
+          \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
+          \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/event-bridge-rule/event-bridge-target\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_event-bridge-rule_event-bridge-target_84D24AD3\\"
+          }
+        }
+      }
+    },
+    \\"aws_lambda_permission\\": {
+      \\"test-event-bridge-lambda_lambda-permission_D900B300\\": {
+        \\"action\\": \\"lambda:InvokeFunction\\",
+        \\"function_name\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
+        \\"principal\\": \\"events.amazonaws.com\\",
+        \\"qualifier\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\",
+        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.arn}\\",
+        \\"depends_on\\": [
+          \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
+          \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda-permission\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_lambda-permission_D900B300\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"test-event-bridge-lambda_invocations_D3AC4914\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total invocations breaches threshold\\",
+        \\"alarm_name\\": \\"test-event-bridge-lambda-Lambda-Invocations-Alarm\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"FunctionName\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
+          \\"Resource\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}:\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"Invocations\\",
+        \\"namespace\\": \\"AWS/Lambda\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 60,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 1,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/invocations\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_invocations_D3AC4914\\"
+          }
+        }
+      },
+      \\"test-event-bridge-lambda_errors_2C954972\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total errors breaches threshold\\",
+        \\"alarm_name\\": \\"test-event-bridge-lambda-Lambda-Errors-Alarm\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"FunctionName\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
+          \\"Resource\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}:\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"Errors\\",
+        \\"namespace\\": \\"AWS/Lambda\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 60,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 1,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/errors\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_errors_2C954972\\"
+          }
+        }
+      },
+      \\"test-event-bridge-lambda_concurrentexecutions_0F0BAFF4\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total concurrentexecutions breaches threshold\\",
+        \\"alarm_name\\": \\"test-event-bridge-lambda-Lambda-ConcurrentExecutions-Alarm\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"FunctionName\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
+          \\"Resource\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}:\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"ConcurrentExecutions\\",
+        \\"namespace\\": \\"AWS/Lambda\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 60,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 1,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/concurrentexecutions\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_concurrentexecutions_0F0BAFF4\\"
+          }
+        }
+      },
+      \\"test-event-bridge-lambda_throttles_036A8B85\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total throttles breaches threshold\\",
+        \\"alarm_name\\": \\"test-event-bridge-lambda-Lambda-Throttles-Alarm\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"FunctionName\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
+          \\"Resource\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}:\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"Throttles\\",
+        \\"namespace\\": \\"AWS/Lambda\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 60,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 1,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/throttles\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_throttles_036A8B85\\"
+          }
+        }
+      },
+      \\"test-event-bridge-lambda_duration_D6272254\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total duration breaches threshold\\",
+        \\"alarm_name\\": \\"test-event-bridge-lambda-Lambda-Duration-Alarm\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"FunctionName\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
+          \\"Resource\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}:\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"Duration\\",
+        \\"namespace\\": \\"AWS/Lambda\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 60,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 1,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/duration\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_duration_D6272254\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-event-bridge-lambda_assume-policy-document_59E97C0B\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"lambda.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/assume-policy-document\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_assume-policy-document_59E97C0B\\"
+          }
+        }
+      },
+      \\"test-event-bridge-lambda_execution-policy-document_0A3C0E28\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"logs:CreateLogGroup\\",
+              \\"logs:CreateLogStream\\",
+              \\"logs:PutLogEvents\\",
+              \\"logs:DescribeLogStreams\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:logs:*:*:*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/execution-policy-document\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_execution-policy-document_0A3C0E28\\"
+          }
+        }
+      }
+    },
+    \\"archive_file\\": {
+      \\"test-event-bridge-lambda_lambda-default-file_57164BB7\\": {
+        \\"output_path\\": \\"index.py.zip\\",
+        \\"type\\": \\"zip\\",
+        \\"source\\": [
+          {
+            \\"content\\": \\"handler(event, context):\\\\n\\\\t print(event)\\",
+            \\"filename\\": \\"index.py\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-event-bridge-lambda/lambda/lambda-default-file\\",
+            \\"uniqueId\\": \\"test-event-bridge-lambda_lambda-default-file_57164BB7\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders an event bridge and lambda target with code deploy 1`] = `
 "{
   \\"//\\": {


### PR DESCRIPTION
## Goal

- Add alarms support to PocketEventBridgeWithLambdaTarget module
- Stop using escape hatch for dimensions in other modules (fixed in `cdktf` 0.0.19)
