### PR TITLE
feat(ecs) Add container health check property

### DIFF
--- a/src/base/ApplicationECSContainerDefinition.spec.ts
+++ b/src/base/ApplicationECSContainerDefinition.spec.ts
@@ -79,6 +79,30 @@ describe('ApplicationECSContainerDefinition', () => {
       expect(result).to.contain(`"command": ["go to in-n-out","go bowling"]`);
     });
 
+    it('builds JSON with a healthcheck', () => {
+      config.healthCheck = {
+        command: [
+          'CMD-SHELL',
+          'curl -f "http://127.0.0.1:8000/pulse" || exit 1',
+        ],
+        timeout: 5,
+        startPeriod: 0,
+        interval: 30,
+        retries: 2,
+      };
+
+      const result = buildDefinitionJSON(config);
+
+      expect(result).to.contain(
+        `"healthCheck": {` +
+          `"command":["CMD-SHELL","curl -f \\"http://127.0.0.1:8000/pulse\\" || exit 1"],` +
+          `"interval":30,` +
+          `"retries":2,` +
+          `"startPeriod":0,` +
+          `"timeout":5}`
+      );
+    });
+
     it('builds JSON without repository credentials', () => {
       config.repositoryCredentialsParam = undefined;
 

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -151,18 +151,20 @@ export function buildDefinitionJSON(
     config.protocol ?? 'tcp'
   );
 
-  templateInstance = templateInstance.replace(
-    '[[HEALTH_CHECK]]',
-    config.healthCheck
-      ? JSON.stringify({
-          command: config.healthCheck.command,
-          interval: config.healthCheck.interval,
-          retries: config.healthCheck.retries,
-          startPeriod: config.healthCheck.startPeriod,
-          timeout: config.healthCheck.timeout,
+  if (config.healthCheck) {
+    templateInstance = templateInstance.replace(
+      '[[HEALTH_CHECK]]',
+      JSON.stringify({
+        command: config.healthCheck.command,
+        interval: config.healthCheck.interval,
+        retries: config.healthCheck.retries,
+        startPeriod: config.healthCheck.startPeriod,
+        timeout: config.healthCheck.timeout,
       })
-      : 'null'
-  );
+    );
+  } else {
+    templateInstance = templateInstance.replace('[[HEALTH_CHECK]]', 'null');
+  }
 
   // strip out whitespace and newlines and return
   return templateInstance.replace(/\n/g, '');

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -41,7 +41,7 @@ export const JSON_TEMPLATE = `
   "dependsOn": null,
   "disableNetworking": null,
   "interactive": null,
-  "healthCheck": null,
+  "healthCheck": [[HEALTH_CHECK]],
   "essential": true,
   "links": null,
   "hostname": null,
@@ -65,6 +65,14 @@ interface SecretEnvironmentVariable {
   valueFrom: string;
 }
 
+interface HealthcheckVariable {
+  command: string[];
+  interval: number;
+  retries: number;
+  startPeriod: number;
+  timeout: number;
+}
+
 export interface ApplicationECSContainerDefinitionProps {
   containerImage?: string;
   logGroup?: string;
@@ -78,6 +86,7 @@ export interface ApplicationECSContainerDefinitionProps {
   memoryReservation?: number;
   protocol?: string;
   cpu?: number;
+  healthCheck?: HealthcheckVariable;
 }
 
 export function buildDefinitionJSON(
@@ -140,6 +149,19 @@ export function buildDefinitionJSON(
   templateInstance = templateInstance.replace(
     '[[PROTOCOL]]',
     config.protocol ?? 'tcp'
+  );
+
+  templateInstance = templateInstance.replace(
+    '[[HEALTH_CHECK]]',
+    config.healthCheck
+      ? JSON.stringify({
+        command: config.healthCheck.command,
+        interval: config.healthCheck.interval,
+        retries: config.healthCheck.retries,
+        startPeriod: config.healthCheck.startPeriod,
+        timeout: config.healthCheck.timeout,
+      })
+      : 'null'
   );
 
   // strip out whitespace and newlines and return

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -155,11 +155,11 @@ export function buildDefinitionJSON(
     '[[HEALTH_CHECK]]',
     config.healthCheck
       ? JSON.stringify({
-        command: config.healthCheck.command,
-        interval: config.healthCheck.interval,
-        retries: config.healthCheck.retries,
-        startPeriod: config.healthCheck.startPeriod,
-        timeout: config.healthCheck.timeout,
+          command: config.healthCheck.command,
+          interval: config.healthCheck.interval,
+          retries: config.healthCheck.retries,
+          startPeriod: config.healthCheck.startPeriod,
+          timeout: config.healthCheck.timeout,
       })
       : 'null'
   );


### PR DESCRIPTION
# Goal
Add `healthCheck` property to `containerConfigs`.

If no container health check is set, blue/green deployments will succeed whenever tasks get to the 'running' state, regardless of whether a target group health check will subsequently stop the tasks. This means a deployment may succeed and bring down the service.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/BACK-625

## Implementation Decisions
- Is there a reason why we're manually stringifying json? Why ``'[' + config.command.map((c) => `"${c}"`).join(',') + ']'`` instead of `JSON.stringify(config.command)`? The latter also json-escapes values, which would matter for a command like `curl -f "http://127.0.0.1:8000/pulse" || exit 1`.
- The health check is not set by default using the `exposedContainer` property in `PocketALBApplication`, because we can't know whether `curl` is installed in that container. I can easily imagine myself forgetting to set a `healthCheck` in the future.
   - Should we log a warning if the exposedContainer does not have a health check set?
   - Would it be better to default to a `curl` healthcheck, even if that would bring down services that don't have curl and don't override the health check?