### PR TITLE
feat(lambda): trigger Lambda using an existing SQS queue

### DIFF
--- a/src/pocket/PocketSQSWithLambdaTarget.spec.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.spec.ts
@@ -30,7 +30,7 @@ test('renders a plain sqs queue with a deadletter and lambda target', () => {
 
   new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
     ...config,
-    sqsQueue: {
+    configForNewSqsQueue: {
       maxReceiveCount: 3,
     },
   });
@@ -46,7 +46,7 @@ test('validates batch config errors if no batch window', () => {
     () =>
       new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
         ...config,
-        sqsQueue: {
+        configForNewSqsQueue: {
           maxReceiveCount: 3,
         },
         batchSize: 20,
@@ -62,7 +62,7 @@ test('validates batch config errors if batch window is less then 1', () => {
     () =>
       new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
         ...config,
-        sqsQueue: {
+        configForNewSqsQueue: {
           maxReceiveCount: 3,
         },
         batchSize: 20,
@@ -77,7 +77,7 @@ test('renders a lambda triggered by an existing sqs queue', () => {
 
   new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
     ...config,
-    dataSqsQueue: {
+    configFromPreexistingSqsQueue: {
       name: 'my-existing-sqs',
     },
   });

--- a/src/pocket/PocketSQSWithLambdaTarget.spec.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.spec.ts
@@ -70,3 +70,18 @@ test('validates batch config errors if batch window is less then 1', () => {
       })
   ).toThrow(Error);
 });
+
+test('renders a lambda triggered by an existing sqs queue', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
+    ...config,
+    dataSqsQueue: {
+      name: 'my-existing-sqs',
+    },
+  });
+
+  const s = Testing.synth(stack);
+  expect(s).toMatchSnapshot();
+});

--- a/src/pocket/PocketSQSWithLambdaTarget.spec.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.spec.ts
@@ -77,7 +77,7 @@ test('renders a lambda triggered by an existing sqs queue', () => {
 
   new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
     ...config,
-    dataSqsQueue: {
+    configFromPreexistingSqsQueue: {
       name: 'my-existing-sqs',
     },
   });

--- a/src/pocket/PocketSQSWithLambdaTarget.spec.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.spec.ts
@@ -30,7 +30,7 @@ test('renders a plain sqs queue with a deadletter and lambda target', () => {
 
   new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
     ...config,
-    configForNewSqsQueue: {
+    sqsQueue: {
       maxReceiveCount: 3,
     },
   });
@@ -46,7 +46,7 @@ test('validates batch config errors if no batch window', () => {
     () =>
       new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
         ...config,
-        configForNewSqsQueue: {
+        sqsQueue: {
           maxReceiveCount: 3,
         },
         batchSize: 20,
@@ -62,7 +62,7 @@ test('validates batch config errors if batch window is less then 1', () => {
     () =>
       new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
         ...config,
-        configForNewSqsQueue: {
+        sqsQueue: {
           maxReceiveCount: 3,
         },
         batchSize: 20,
@@ -77,7 +77,7 @@ test('renders a lambda triggered by an existing sqs queue', () => {
 
   new PocketSQSWithLambdaTarget(stack, 'test-sqs-lambda', {
     ...config,
-    configFromPreexistingSqsQueue: {
+    dataSqsQueue: {
       name: 'my-existing-sqs',
     },
   });

--- a/src/pocket/PocketSQSWithLambdaTarget.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.ts
@@ -23,7 +23,7 @@ import {
 export interface PocketSQSWithLambdaTargetProps
   extends PocketVersionedLambdaProps {
   /**
-   * Set dataSqsQueue to use an existing SQS queue. If not provided, then a queue will be created.
+   * Set configFromPreexistingSqsQueue to use an existing SQS queue. If not provided, then a queue will be created.
    */
   configFromPreexistingSqsQueue?: DataAwsSqsQueueConfig;
   /**

--- a/src/pocket/PocketSQSWithLambdaTarget.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.ts
@@ -27,7 +27,7 @@ export interface PocketSQSWithLambdaTargetProps
    */
   configFromPreexistingSqsQueue?: DataAwsSqsQueueConfig;
   /**
-   * Configure a new SQS queue. Cannot be used in combination with dataSqsQueue.
+   * Configure a new SQS queue. Cannot be used in combination with configFromPreexistingSqsQueue.
    */
   sqsQueue?: PocketSQSProps;
   batchSize?: number;
@@ -116,7 +116,7 @@ export class PocketSQSWithLambdaTarget extends PocketVersionedLambda {
 
     if (config.configFromPreexistingSqsQueue && config.sqsQueue) {
       throw new Error(
-        'dataSqsQueue and sqsQueue cannot be used simultaneously.'
+        'configFromPreexistingSqsQueue and sqsQueue cannot be used simultaneously.'
       );
     }
   }

--- a/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
@@ -1,5 +1,289 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a lambda triggered by an existing sqs queue 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"aws_s3_bucket\\": {
+      \\"test-sqs-lambda_code-bucket_34D549A2\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-test-sqs-lambda\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/code-bucket\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_code-bucket_34D549A2\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"test-sqs-lambda_code-bucket-public-access-block_942034EC\\": {
+        \\"block_public_acls\\": true,
+        \\"block_public_policy\\": true,
+        \\"bucket\\": \\"\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/code-bucket-public-access-block\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_code-bucket-public-access-block_942034EC\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-sqs-lambda_execution-role_7323CCD9\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}\\",
+        \\"name\\": \\"test-sqs-lambda-ExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/execution-role\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_execution-role_7323CCD9\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"test-sqs-lambda_execution-policy_ED32F1C0\\": {
+        \\"name\\": \\"test-sqs-lambda-ExecutionRolePolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/execution-policy\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_execution-policy_ED32F1C0\\"
+          }
+        }
+      },
+      \\"test-sqs-lambda_sqs-policy_E98CC69F\\": {
+        \\"name\\": \\"test-sqs-lambda-LambdaSQSPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/sqs-policy\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_sqs-policy_E98CC69F\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-sqs-lambda_execution-role-policy-attachment_45759A7F\\": {
+        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
+          \\"aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/execution-role-policy-attachment\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_execution-role-policy-attachment_45759A7F\\"
+          }
+        }
+      },
+      \\"test-sqs-lambda_execution-role-policy-attachment_CA21C309\\": {
+        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
+          \\"aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/execution-role-policy-attachment\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_execution-role-policy-attachment_CA21C309\\"
+          }
+        }
+      }
+    },
+    \\"aws_lambda_function\\": {
+      \\"test-sqs-lambda_C2DB9DC9\\": {
+        \\"filename\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}\\",
+        \\"function_name\\": \\"test-sqs-lambda-Function\\",
+        \\"handler\\": \\"index.handler\\",
+        \\"publish\\": true,
+        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
+        \\"runtime\\": \\"python3.8\\",
+        \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",
+        \\"timeout\\": 5,
+        \\"vpc_config\\": [],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"filename\\",
+            \\"source_code_hash\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/lambda\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_C2DB9DC9\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_log_group\\": {
+      \\"test-sqs-lambda_log-group_F69AB78F\\": {
+        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
+        \\"retention_in_days\\": 14,
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/log-group\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_log-group_F69AB78F\\"
+          }
+        }
+      }
+    },
+    \\"aws_lambda_alias\\": {
+      \\"test-sqs-lambda_alias_2C2A09A2\\": {
+        \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
+        \\"function_version\\": \\"\${split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn)[7]}\\",
+        \\"name\\": \\"DEPLOYED\\",
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"function_version\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/alias\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_alias_2C2A09A2\\"
+          }
+        }
+      }
+    },
+    \\"aws_lambda_event_source_mapping\\": {
+      \\"test-sqs-lambda_lambda_event_source_mapping_C60D5FF2\\": {
+        \\"event_source_arn\\": \\"\${data.aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_D097423A.arn}\\",
+        \\"function_name\\": \\"\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda_event_source_mapping\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_lambda_event_source_mapping_C60D5FF2\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-sqs-lambda_assume-policy-document_98DE5C4D\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"lambda.amazonaws.com\\",
+                  \\"edgelambda.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/assume-policy-document\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_assume-policy-document_98DE5C4D\\"
+          }
+        }
+      },
+      \\"test-sqs-lambda_execution-policy-document_2C5F0106\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"logs:CreateLogGroup\\",
+              \\"logs:CreateLogStream\\",
+              \\"logs:PutLogEvents\\",
+              \\"logs:DescribeLogStreams\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:logs:*:*:*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/execution-policy-document\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_execution-policy-document_2C5F0106\\"
+          }
+        }
+      },
+      \\"test-sqs-lambda_lambda_sqs_policy_3C63A136\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sqs:SendMessage\\",
+              \\"sqs:ReceiveMessage\\",
+              \\"sqs:DeleteMessage\\",
+              \\"sqs:GetQueueAttributes\\",
+              \\"sqs:ChangeMessageVisibility\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${data.aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_D097423A.arn}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda_sqs_policy\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_lambda_sqs_policy_3C63A136\\"
+          }
+        }
+      }
+    },
+    \\"archive_file\\": {
+      \\"test-sqs-lambda_lambda-default-file_52E1CC8A\\": {
+        \\"output_path\\": \\"index.py.zip\\",
+        \\"type\\": \\"zip\\",
+        \\"source\\": [
+          {
+            \\"content\\": \\"handler(event, context):\\\\n\\\\t print(event)\\",
+            \\"filename\\": \\"index.py\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda/lambda-default-file\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_lambda-default-file_52E1CC8A\\"
+          }
+        }
+      }
+    },
+    \\"aws_sqs_queue\\": {
+      \\"test-sqs-lambda_lambda_sqs_queue_D097423A\\": {
+        \\"name\\": \\"my-existing-sqs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-sqs-lambda/lambda_sqs_queue\\",
+            \\"uniqueId\\": \\"test-sqs-lambda_lambda_sqs_queue_D097423A\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders a plain sqs queue and lambda target 1`] = `
 "{
   \\"//\\": {


### PR DESCRIPTION
# Goal
Allow PocketSQSWithLambdaTarget to accept an existing SQS queue, instead of creating one.

This is necessary for the Parser cron job migration.

## Todos
- [x] Test using example.ts

## Review
- [ ] Is this the best way to pass an existing SQS queue into PocketSQSWithLambdaTargetProps? Some alternatives:
  - I tried writing two interfaces that [enforce the either-or constraint through typing](https://stackoverflow.com/a/61281828/331030). This ended up feeling cluttered.
  - We could create two classes, for new and existing SQS queues respectively, and put the shared logic in an abstract class. This seems like it might get cluttered too, and would deviate from the existing patterns.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/BACK-704

Parser migration:
* https://docs.google.com/document/d/1O6HArmwD1QdKP92-yJwzny7XI_mD-LLiqQ3tG6b-dnA/edit#

## Implementation Decisions
