### PR TITLE
feat(pocket-ecs-codepipeline): Add a Pocket ECS CodePipeline module

### DIFF
--- a/src/base/ApplicationECSService.spec.ts
+++ b/src/base/ApplicationECSService.spec.ts
@@ -6,7 +6,15 @@ import {
 
 let BASE_CONFIG: ApplicationECSServiceProps;
 
-describe('AppliationECSService', () => {
+const testAlbConfig: ApplicationECSServiceProps['albConfig'] = {
+  healthCheckPath: '/health',
+  listenerArn: 'listen-to-me',
+  containerPort: 3000,
+  containerName: 'runme',
+  albSecurityGroupId: 'strike',
+};
+
+describe('ApplicationECSService', () => {
   beforeEach(() => {
     BASE_CONFIG = {
       ecsClusterName: 'cluster-name',
@@ -187,13 +195,7 @@ describe('AppliationECSService', () => {
       },
     ];
 
-    BASE_CONFIG.albConfig = {
-      healthCheckPath: '/health',
-      listenerArn: 'listen-to-me',
-      containerPort: 3000,
-      containerName: 'runme',
-      albSecurityGroupId: 'strike',
-    };
+    BASE_CONFIG.albConfig = testAlbConfig;
 
     new ApplicationECSService(stack, 'testECSService', BASE_CONFIG);
 
@@ -239,6 +241,33 @@ describe('AppliationECSService', () => {
     ];
 
     new ApplicationECSService(stack, 'testECSService', BASE_CONFIG);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders an ECS service with code deploy', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    new ApplicationECSService(stack, 'testECSService', {
+      ...BASE_CONFIG,
+      ...testAlbConfig,
+      useCodeDeploy: true,
+    });
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders an ECS service with code deploy and excludes the code deployment command resource when useCodePipeline is true', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    new ApplicationECSService(stack, 'testECSService', {
+      ...BASE_CONFIG,
+      ...testAlbConfig,
+      useCodeDeploy: true,
+      useCodePipeline: true,
+    });
 
     expect(Testing.synth(stack)).toMatchSnapshot();
   });

--- a/src/base/ApplicationECSService.ts
+++ b/src/base/ApplicationECSService.ts
@@ -50,6 +50,7 @@ export interface ApplicationECSServiceProps {
   lifecycleIgnoreChanges?: string[]; // defaults to ['task_definition', 'desired_count', 'load_balancer']
   ecsIamConfig: ApplicationECSIAMProps;
   useCodeDeploy: boolean; //defaults to true
+  useCodePipeline?: boolean;
   codeDeploySnsNotificationTopicArn?: string;
 }
 
@@ -67,6 +68,7 @@ export class ApplicationECSService extends Resource {
 
   private readonly config: ApplicationECSServiceProps;
   public readonly mainTargetGroup?: ApplicationTargetGroup;
+  public readonly codeDeployApp?: ApplicationECSAlbCodeDeploy;
 
   // set defaults on optional properties
   private static hydrateConfig(
@@ -183,7 +185,7 @@ export class ApplicationECSService extends Resource {
       const greenTargetGroup = this.createTargetGroup('green');
       targetGroupNames.push(greenTargetGroup.targetGroup.name);
       //Setup codedeploy
-      const codeDeployApp = new ApplicationECSAlbCodeDeploy(
+      const codeDeployApp = (this.codeDeployApp = new ApplicationECSAlbCodeDeploy(
         this,
         'ecs_codedeploy',
         {
@@ -198,30 +200,32 @@ export class ApplicationECSService extends Resource {
           tags: this.config.tags,
           dependsOn: [this.service],
         }
-      );
+      ));
 
-      /**
-       * If you make any changes to the Task Definition this must be called since we ignore changes to it.
-       *
-       * We typically ignore changes to the following since we rely on BlueGreen Deployments:
-       * ALB Default Action Target Group ARN
-       * ECS Service LoadBalancer Config
-       * ECS Task Definition
-       * ECS Placement Strategy Config
-       */
-      const nullECSTaskUpdate = new Resource(this, 'update-task-definition', {
-        triggers: { task_arn: taskDef.arn },
-        dependsOn: [
-          taskDef,
-          codeDeployApp.codeDeployApp,
-          codeDeployApp.codeDeployDeploymentGroup,
-        ],
-      });
+      if (!this.config.useCodePipeline) {
+        /**
+         * If you make any changes to the Task Definition this must be called since we ignore changes to it.
+         *
+         * We typically ignore changes to the following since we rely on BlueGreen Deployments:
+         * ALB Default Action Target Group ARN
+         * ECS Service LoadBalancer Config
+         * ECS Task Definition
+         * ECS Placement Strategy Config
+         */
+        const nullECSTaskUpdate = new Resource(this, 'update-task-definition', {
+          triggers: { task_arn: taskDef.arn },
+          dependsOn: [
+            taskDef,
+            codeDeployApp.codeDeployApp,
+            codeDeployApp.codeDeployDeploymentGroup,
+          ],
+        });
 
-      nullECSTaskUpdate.addOverride(
-        'provisioner.local-exec.command',
-        `export app_spec_content_string='{"version":1,"Resources":[{"TargetService":{"Type":"AWS::ECS::Service","Properties":{"TaskDefinition":"${taskDef.arn}","LoadBalancerInfo":{"ContainerName":"${this.config.albConfig.containerName}","ContainerPort":${this.config.albConfig.containerPort}}}}}]}' && export revision="revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}" && aws deploy create-deployment  --application-name="${codeDeployApp.codeDeployApp.name}"  --deployment-group-name="${codeDeployApp.codeDeployDeploymentGroup.deploymentGroupName}" --description="Triggered from Terraform/CodeBuild due to a task definition update" --revision="$revision"`
-      );
+        nullECSTaskUpdate.addOverride(
+          'provisioner.local-exec.command',
+          `export app_spec_content_string='{"version":1,"Resources":[{"TargetService":{"Type":"AWS::ECS::Service","Properties":{"TaskDefinition":"${taskDef.arn}","LoadBalancerInfo":{"ContainerName":"${this.config.albConfig.containerName}","ContainerPort":${this.config.albConfig.containerPort}}}}}]}' && export revision="revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}" && aws deploy create-deployment  --application-name="${codeDeployApp.codeDeployApp.name}"  --deployment-group-name="${codeDeployApp.codeDeployDeploymentGroup.deploymentGroupName}" --description="Triggered from Terraform/CodeBuild due to a task definition update" --revision="$revision"`
+        );
+      }
     }
 
     // NEXT STEPS:

--- a/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -1,6 +1,380 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AppliationECSService renders an ECS service with full container definition props 1`] = `
+exports[`ApplicationECSService renders an ECS service with code deploy 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"null_resource\\": {
+      \\"testECSService\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService\\",
+            \\"uniqueId\\": \\"testECSService\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testECSService_ecs_security_group_67979722\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"self\\": null
+          }
+        ],
+        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"myhouse\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs_security_group\\",
+            \\"uniqueId\\": \\"testECSService_ecs_security_group_67979722\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
+        \\"name\\": \\"abides-dev-TaskExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-execution-role\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\"
+          }
+        }
+      },
+      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
+        \\"name\\": \\"abides-dev-TaskRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-task-role\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-task-role_83E10144\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
+        \\"policy_arn\\": \\"someArn\\",
+        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-task-execution-default-attachment\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testECSService_ecs-task_A268C927\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
+        \\"family\\": \\"abides-dev\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
+        \\"volume\\": [],
+        \\"depends_on\\": [],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-task\\",
+            \\"uniqueId\\": \\"testECSService_ecs-task_A268C927\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_service\\": {
+      \\"testECSService_ecs-service_33F309B3\\": {
+        \\"cluster\\": \\"gorp\\",
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"name\\": \\"abides-dev\\",
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\",
+        \\"deployment_controller\\": [
+          {
+            \\"type\\": \\"CODE_DEPLOY\\"
+          }
+        ],
+        \\"load_balancer\\": [],
+        \\"network_configuration\\": [
+          {
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+            ],
+            \\"subnets\\": [
+              \\"1.1.1.1\\",
+              \\"2.2.2.2\\"
+            ]
+          }
+        ],
+        \\"depends_on\\": [],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\",
+            \\"task_definition\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-service\\",
+            \\"uniqueId\\": \\"testECSService_ecs-service_33F309B3\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-task-assume\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationECSService renders an ECS service with code deploy and excludes the code deployment command resource when useCodePipeline is true 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"null_resource\\": {
+      \\"testECSService\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService\\",
+            \\"uniqueId\\": \\"testECSService\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testECSService_ecs_security_group_67979722\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"self\\": null
+          }
+        ],
+        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"myhouse\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs_security_group\\",
+            \\"uniqueId\\": \\"testECSService_ecs_security_group_67979722\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
+        \\"name\\": \\"abides-dev-TaskExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-execution-role\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\"
+          }
+        }
+      },
+      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
+        \\"name\\": \\"abides-dev-TaskRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-task-role\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-task-role_83E10144\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
+        \\"policy_arn\\": \\"someArn\\",
+        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-task-execution-default-attachment\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testECSService_ecs-task_A268C927\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
+        \\"family\\": \\"abides-dev\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
+        \\"volume\\": [],
+        \\"depends_on\\": [],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-task\\",
+            \\"uniqueId\\": \\"testECSService_ecs-task_A268C927\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_service\\": {
+      \\"testECSService_ecs-service_33F309B3\\": {
+        \\"cluster\\": \\"gorp\\",
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"name\\": \\"abides-dev\\",
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\",
+        \\"deployment_controller\\": [
+          {
+            \\"type\\": \\"CODE_DEPLOY\\"
+          }
+        ],
+        \\"load_balancer\\": [],
+        \\"network_configuration\\": [
+          {
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+            ],
+            \\"subnets\\": [
+              \\"1.1.1.1\\",
+              \\"2.2.2.2\\"
+            ]
+          }
+        ],
+        \\"depends_on\\": [],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\",
+            \\"task_definition\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-service\\",
+            \\"uniqueId\\": \\"testECSService_ecs-service_33F309B3\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testECSService/ecs-iam/ecs-task-assume\\",
+            \\"uniqueId\\": \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationECSService renders an ECS service with full container definition props 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -187,7 +561,7 @@ exports[`AppliationECSService renders an ECS service with full container definit
 }"
 `;
 
-exports[`AppliationECSService renders an ECS service with full container definition props and ALB security group config 1`] = `
+exports[`ApplicationECSService renders an ECS service with full container definition props and ALB security group config 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -454,7 +828,7 @@ exports[`AppliationECSService renders an ECS service with full container definit
 }"
 `;
 
-exports[`AppliationECSService renders an ECS service with minimal config 1`] = `
+exports[`ApplicationECSService renders an ECS service with minimal config 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -640,7 +1014,7 @@ exports[`AppliationECSService renders an ECS service with minimal config 1`] = `
 }"
 `;
 
-exports[`AppliationECSService renders an ECS service with mountPoints deduplicated in the task definition 1`] = `
+exports[`ApplicationECSService renders an ECS service with mountPoints deduplicated in the task definition 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -961,7 +1335,7 @@ exports[`AppliationECSService renders an ECS service with mountPoints deduplicat
 }"
 `;
 
-exports[`AppliationECSService renders an ECS service without a log group container definition props 1`] = `
+exports[`ApplicationECSService renders an ECS service without a log group container definition props 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -1160,7 +1534,7 @@ exports[`AppliationECSService renders an ECS service without a log group contain
 }"
 `;
 
-exports[`AppliationECSService renders an ECS service without an image container definition props 1`] = `
+exports[`ApplicationECSService renders an ECS service without an image container definition props 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './pocket/PocketPagerDuty';
 export * from './pocket/PocketSQSWithLambdaTarget';
 export * from './pocket/PocketVersionedLambda';
 export * from './pocket/PocketEventBridgeWithLambdaTarget';
+export * from './pocket/PocketECSCodePipeline';
 export * from './base/ApplicationBaseDNS';
 export * from './base/ApplicationCertificate';
 export * from './base/ApplicationECSCluster';

--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -1,0 +1,103 @@
+import { TerraformStack, Testing } from 'cdktf';
+import {
+  PocketECSCodePipeline,
+  PocketECSCodePipelineProps,
+} from './PocketECSCodePipeline';
+
+const config: PocketECSCodePipelineProps = {
+  prefix: 'Test-Env',
+  source: {
+    repository: 'string',
+    branchName: 'test',
+    codeStarConnectionArn: 'arn:codestart-connection:*',
+  },
+};
+
+test('renders a Pocket ECS Codepipeline template', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', config);
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with tags', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', {
+    ...config,
+    tags: { yup: 'a tag' },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with the provided code build project name', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', {
+    ...config,
+    codeBuildProjectName: 'TestBuildName',
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with the provided CodeDeploy app name', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', {
+    ...config,
+    codeDeploy: {
+      applicationName: 'TestAppName',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with the provided CodeDeploy deployment group name', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', {
+    ...config,
+    codeDeploy: {
+      deploymentGroupName: 'TestDeploymentGroupName',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with the provided appspec path', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', {
+    ...config,
+    codeDeploy: {
+      appSpecPath: 'testappspec.json',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with the provided taskdef path', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new PocketECSCodePipeline(stack, 'test-codepipeline', {
+    ...config,
+    codeDeploy: {
+      taskDefPath: 'testtaskdef.json',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -1,0 +1,295 @@
+import { Resource } from 'cdktf';
+import { Construct } from 'constructs';
+import {
+  Codepipeline,
+  DataAwsIamPolicyDocument,
+  DataAwsKmsAlias,
+  IamRole,
+  IamRolePolicy,
+  S3Bucket,
+} from '../../.gen/providers/aws';
+import crypto from 'crypto';
+
+export interface PocketECSCodePipelineProps {
+  prefix: string;
+  source: {
+    repository: string;
+    branchName: string;
+    codeStarConnectionArn: string;
+  };
+  codeBuildProjectName?: string;
+  codeDeploy?: {
+    applicationName?: string;
+    deploymentGroupName?: string;
+    appSpecPath?: string;
+    taskDefPath?: string;
+  };
+  tags?: { [key: string]: string };
+}
+
+export class PocketECSCodePipeline extends Resource {
+  private static DEFAULT_TASKDEF_PATH = 'taskdef.json';
+  private static DEFAULT_APPSPEC_PATH = 'appspec.json';
+
+  public readonly codePipeline: Codepipeline;
+
+  constructor(
+    scope: Construct,
+    name: string,
+    private config: PocketECSCodePipelineProps
+  ) {
+    super(scope, name);
+
+    this.codePipeline = this.createCodePipeline();
+  }
+
+  /**
+   * Create a CodePipeline that runs CodeBuild and ECS CodeDeploy
+   * @private
+   */
+  private createCodePipeline(): Codepipeline {
+    const pipelineRole = this.createPipelineRole();
+
+    const s3KmsAlias = new DataAwsKmsAlias(this, 'kms_s3_alias', {
+      name: 'alias/aws/s3',
+    });
+
+    const pipelineArtifactBucket = this.createArtifactBucket();
+
+    const codeBuildProjectName =
+      this.config.codeBuildProjectName ?? this.config.prefix;
+
+    const codeDeployApplicationName =
+      this.config.codeDeploy?.applicationName ?? `${this.config.prefix}-ECS`;
+
+    const codeDeployDeploymentGroupName =
+      this.config.codeDeploy?.deploymentGroupName ??
+      `${this.config.prefix}-ECS`;
+
+    this.attachPipelineRolePolicy(
+      pipelineRole,
+      pipelineArtifactBucket,
+      codeBuildProjectName,
+      codeDeployApplicationName,
+      codeDeployDeploymentGroupName
+    );
+
+    return new Codepipeline(this, 'codepipeline', {
+      name: `${this.config.prefix}-CodePipeline`,
+      roleArn: pipelineRole.arn,
+      artifactStore: [
+        {
+          location: pipelineArtifactBucket.bucket,
+          type: 'S3',
+          encryptionKey: [{ id: s3KmsAlias.arn, type: 'KMS' }],
+        },
+      ],
+      stage: [
+        {
+          name: 'Source',
+          action: [
+            {
+              name: 'GitHub_Checkout',
+              category: 'Source',
+              owner: 'AWS',
+              provider: 'CodeStarSourceConnection',
+              version: '1',
+              outputArtifacts: ['SourceOutput'],
+              configuration: {
+                ConnectionArn: this.config.source.codeStarConnectionArn,
+                FullRepositoryId: this.config.source.repository,
+                BranchName: this.config.source.branchName,
+                DetectChanges: 'false',
+              },
+              namespace: 'SourceVariables',
+            },
+          ],
+        },
+        {
+          name: 'Deploy',
+          action: [
+            {
+              name: 'CodeBuild',
+              category: 'Build',
+              owner: 'AWS',
+              provider: 'CodeBuild',
+              inputArtifacts: ['SourceOutput'],
+              outputArtifacts: ['CodeBuildOutput'],
+              version: '1',
+              configuration: {
+                ProjectName: codeBuildProjectName,
+                EnvironmentVariables: `[${JSON.stringify({
+                  name: 'GIT_BRANCH',
+                  value: '#{SourceVariables.BranchName}',
+                })}]`,
+              },
+              runOrder: 1,
+            },
+            {
+              name: 'Deploy_ECS',
+              category: 'Deploy',
+              owner: 'AWS',
+              provider: 'CodeDeployToECS',
+              inputArtifacts: ['CodeBuildOutput'],
+              version: '1',
+              configuration: {
+                ApplicationName: codeDeployApplicationName,
+                DeploymentGroupName: codeDeployDeploymentGroupName,
+                TaskDefinitionTemplateArtifact: 'CodeBuildOutput',
+                TaskDefinitionTemplatePath:
+                  this.config.codeDeploy?.taskDefPath ??
+                  PocketECSCodePipeline.DEFAULT_TASKDEF_PATH,
+                AppSpecTemplateArtifact: 'CodeBuildOutput',
+                AppSpecTemplatePath:
+                  this.config.codeDeploy?.appSpecPath ??
+                  PocketECSCodePipeline.DEFAULT_APPSPEC_PATH,
+              },
+              runOrder: 2,
+            },
+          ],
+        },
+      ],
+      tags: this.config.tags,
+    });
+  }
+
+  /**
+   * Create CodePipeline artifact s3 bucket
+   * @private
+   */
+  private createArtifactBucket() {
+    const prefixHash = crypto
+      .createHash('md5')
+      .update(this.config.prefix)
+      .digest('hex');
+
+    return new S3Bucket(this, 'codepipeline-bucket', {
+      bucket: `pocket-codepipeline-${prefixHash}`,
+      acl: 'private',
+      forceDestroy: true,
+      tags: this.config.tags,
+    });
+  }
+
+  /**
+   * Attach IAM policy to the pipeline role
+   * @param pipelineRole
+   * @param pipelineArtifactBucket
+   * @param codeBuildProjectName
+   * @param codeDeployApplicationName
+   * @param codeDeployDeploymentGroupName
+   * @private
+   */
+  private attachPipelineRolePolicy(
+    pipelineRole: IamRole,
+    pipelineArtifactBucket: S3Bucket,
+    codeBuildProjectName: string,
+    codeDeployApplicationName: string,
+    codeDeployDeploymentGroupName: string
+  ) {
+    new IamRolePolicy(this, 'codepipeline-role-policy', {
+      name: `${this.config.prefix}-CodePipeline-Role-Policy`,
+      role: pipelineRole.id,
+      policy: new DataAwsIamPolicyDocument(
+        this,
+        `codepipeline-role-policy-document`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['codestar-connections:UseConnection'],
+              resources: [this.config.source.codeStarConnectionArn],
+            },
+            {
+              effect: 'Allow',
+              actions: [
+                'codebuild:BatchGetBuilds',
+                'codebuild:StartBuild',
+                'codebuild:BatchGetBuildBatches',
+                'codebuild:StartBuildBatch',
+              ],
+              resources: [
+                `arn:aws:codebuild:*:*:project/${codeBuildProjectName}`,
+              ],
+            },
+            {
+              effect: 'Allow',
+              actions: [
+                'codedeploy:CreateDeployment',
+                'codedeploy:GetApplication',
+                'codedeploy:GetApplicationRevision',
+                'codedeploy:GetDeployment',
+                'codedeploy:RegisterApplicationRevision',
+                'codedeploy:GetDeploymentConfig',
+              ],
+              resources: [
+                `arn:aws:codedeploy:*:*:application:${codeDeployApplicationName}`,
+                `arn:aws:codedeploy:*:*:deploymentgroup:${codeDeployApplicationName}/${codeDeployDeploymentGroupName}`,
+                'arn:aws:codedeploy:*:*:deploymentconfig:*',
+              ],
+            },
+            {
+              effect: 'Allow',
+              actions: [
+                's3:GetObject',
+                's3:GetObjectVersion',
+                's3:GetBucketVersioning',
+                's3:PutObjectAcl',
+                's3:PutObject',
+              ],
+              resources: [
+                pipelineArtifactBucket.arn,
+                `${pipelineArtifactBucket.arn}/*`,
+              ],
+            },
+            {
+              effect: 'Allow',
+              actions: ['iam:PassRole'],
+              resources: ['*'],
+              condition: [
+                {
+                  variable: 'iam:PassedToService',
+                  test: 'StringEqualsIfExists',
+                  values: ['ecs-tasks.amazonaws.com'],
+                },
+              ],
+            },
+            {
+              effect: 'Allow',
+              actions: ['ecs:RegisterTaskDefinition'],
+              resources: ['*'],
+            },
+          ],
+        }
+      ).json,
+    });
+  }
+
+  /**
+   * Creates a CodePipeline role.
+   * @private
+   */
+  private createPipelineRole() {
+    return new IamRole(this, 'codepipeline-role', {
+      name: `${this.config.prefix}-CodePipelineRole`,
+      assumeRolePolicy: new DataAwsIamPolicyDocument(
+        this,
+        `codepipeline-assume-role-policy`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sts:AssumeRole'],
+              principals: [
+                {
+                  identifiers: ['codepipeline.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+        }
+      ).json,
+    });
+  }
+}

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -1,0 +1,1883 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a Pocket ECS Codepipeline template 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"Test-Env\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"tags\\": {
+          \\"yup\\": \\"a tag\\"
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"tags\\": {
+          \\"yup\\": \\"a tag\\"
+        },
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"Test-Env\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy app name 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:TestAppName\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:TestAppName/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"Test-Env\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"TestAppName\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy deployment group name 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/TestDeploymentGroupName\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"Test-Env\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"TestDeploymentGroupName\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a Pocket ECS Codepipeline template with the provided appspec path 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"Test-Env\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"testappspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a Pocket ECS Codepipeline template with the provided code build project name 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/TestBuildName\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"TestBuildName\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a Pocket ECS Codepipeline template with the provided taskdef path 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-assume-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\"
+          }
+        }
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy-document\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/kms_s3_alias\\",
+            \\"uniqueId\\": \\"test-codepipeline_kms_s3_alias_6C922DC1\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role_4D3D2364\\"
+          }
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-bucket\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-bucket_D4671464\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline-role-policy\\",
+            \\"uniqueId\\": \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\"
+          }
+        }
+      }
+    },
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"artifact_store\\": [
+          {
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\",
+            \\"encryption_key\\": [
+              {
+                \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+                \\"type\\": \\"KMS\\"
+              }
+            ]
+          }
+        ],
+        \\"stage\\": [
+          {
+            \\"name\\": \\"Source\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"FullRepositoryId\\": \\"string\\",
+                  \\"BranchName\\": \\"test\\",
+                  \\"DetectChanges\\": \\"false\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ]
+          },
+          {
+            \\"name\\": \\"Deploy\\",
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"ProjectName\\": \\"Test-Env\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"CodeBuild\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"testtaskdef.json\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-codepipeline/codepipeline\\",
+            \\"uniqueId\\": \\"test-codepipeline_367BF1E2\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;


### PR DESCRIPTION
## Goal
Create a CodePipeline to queue code deployments.

- [x] Create an ECS CodePipeline module for Pocket backend needs.
- [x] Exclude null resource for creating a deployment on task definition update when `useCodePipeline` is set to true