### PR TITLE
feat(codepipeline): Generate appspec.json and taskdef.json on terrform apply

### DIFF
--- a/cdktf.json
+++ b/cdktf.json
@@ -5,6 +5,7 @@
     "aws@~> 3.30.0",
     "pagerduty/pagerduty@~> 1.8.0",
     "archive@~> 1.3.0",
-    "null@~> 3.0.0"
+    "null@~> 3.0.0",
+    "local@~> 2.1.0"
   ]
 }

--- a/src/pocket/PocketALBApplication.spec.ts
+++ b/src/pocket/PocketALBApplication.spec.ts
@@ -368,4 +368,33 @@ describe('PocketALBApplication', () => {
 
     expect(Testing.synth(stack)).toMatchSnapshot();
   });
+
+  it('renders an Pocket App with code deploy', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    new PocketALBApplication(stack, 'testPocketApp', {
+      ...BASE_CONFIG,
+      codeDeploy: {
+        useCodeDeploy: true,
+      },
+    });
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders an Pocket App with code deploy and creates appspec.json and taskdef.json when using code pipeline', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    new PocketALBApplication(stack, 'testPocketApp', {
+      ...BASE_CONFIG,
+      codeDeploy: {
+        useCodePipeline: true,
+        useCodeDeploy: true,
+      },
+    });
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
 });

--- a/src/pocket/PocketALBApplication.ts
+++ b/src/pocket/PocketALBApplication.ts
@@ -38,6 +38,7 @@ export interface PocketALBApplicationProps {
   domain: string;
   cdn?: boolean;
   codeDeploy: {
+    useCodePipeline?: boolean;
     useCodeDeploy: boolean;
     snsNotificationTopicArn?: string;
   };
@@ -434,6 +435,7 @@ export class PocketALBApplication extends Resource {
       ecsClusterArn: ecsCluster.cluster.arn,
       ecsClusterName: ecsCluster.cluster.name,
       useCodeDeploy: this.config.codeDeploy.useCodeDeploy,
+      useCodePipeline: this.config.codeDeploy.useCodePipeline,
       codeDeploySnsNotificationTopicArn: this.config.codeDeploy
         .snsNotificationTopicArn,
       albConfig: {

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -999,6 +999,2349 @@ exports[`PocketALBApplication forwards http traffic to the target if disableHttp
 }"
 `;
 
+exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_ssm_parameter\\": {
+      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
+        \\"name\\": \\"/Shared/Vpc\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/vpc_ssm_param\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
+        \\"name\\": \\"/Shared/PrivateSubnets\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/private_subnets\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
+        \\"name\\": \\"/Shared/PublicSubnets\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/public_subnets\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\"
+          }
+        }
+      }
+    },
+    \\"aws_vpc\\": {
+      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/vpc\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_C4E157E3\\"
+          }
+        }
+      }
+    },
+    \\"aws_subnet_ids\\": {
+      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/private_subnet_ids\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/public_subnet_ids\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\"
+          }
+        }
+      }
+    },
+    \\"aws_caller_identity\\": {
+      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/current_identity\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_current_identity_06D87057\\"
+          }
+        }
+      }
+    },
+    \\"aws_region\\": {
+      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/current_region\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
+        \\"name\\": \\"alias/aws/secretsmanager\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/secrets_manager_key\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_groups\\": {
+      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"group-name\\",
+            \\"values\\": [
+              \\"default\\"
+            ]
+          },
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/default_security_groups\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\"
+          }
+        }
+      }
+    },
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
+        \\"name\\": \\"bowling.gov\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns_main_hosted_zone\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-task-assume\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codedeploy.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/codedeploy_assume_role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_assume\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"cloudwatch:PutMetricAlarm\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:DeleteAlarms\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:cloudwatch:*:*:alarm:/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:DescribeServices\\",
+              \\"ecs:UpdateService\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:ecs:*:*:service/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/role_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns/subhosted_zone\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\"
+          }
+        }
+      }
+    },
+    \\"aws_route53_record\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
+        \\"ttl\\": 86400,
+        \\"type\\": \\"NS\\",
+        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns/subhosted_zone_ns\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\"
+          }
+        }
+      },
+      \\"testPocketApp_alb_record_7B56ED33\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"set_identifier\\": \\"1\\",
+        \\"type\\": \\"A\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\",
+        \\"alias\\": [
+          {
+            \\"evaluate_target_health\\": true,
+            \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
+            \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+          }
+        ],
+        \\"weighted_routing_policy\\": [
+          {
+            \\"weight\\": 1
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"weighted_routing_policy[0].weight\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_record\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_record_7B56ED33\\"
+          }
+        }
+      },
+      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
+        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_name}\\",
+        \\"records\\": [
+          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_value}\\"
+        ],
+        \\"ttl\\": 60,
+        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_type}\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\",
+        \\"depends_on\\": [
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate_record\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        },
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/application_load_balancer/alb_security_group\\",
+            \\"uniqueId\\": \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 8675309
+          }
+        ],
+        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_security_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb\\": {
+      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+        ],
+        \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/application_load_balancer/alb\\",
+            \\"uniqueId\\": \\"testPocketApp_application_load_balancer_alb_D538DEEE\\"
+          }
+        }
+      }
+    },
+    \\"aws_acm_certificate\\": {
+      \\"testPocketApp_alb_certificate_417C14FF\\": {
+        \\"domain_name\\": \\"testing.bowling.gov\\",
+        \\"validation_method\\": \\"DNS\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_417C14FF\\"
+          }
+        }
+      }
+    },
+    \\"aws_acm_certificate_validation\\": {
+      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"validation_record_fqdns\\": [
+          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        ],
+        \\"depends_on\\": [
+          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate_validation\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_cluster\\": {
+      \\"testPocketApp_ecs_cluster_C3960066\\": {
+        \\"name\\": \\"testapp\\",
+        \\"setting\\": [
+          {
+            \\"name\\": \\"containerInsights\\",
+            \\"value\\": \\"enabled\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_cluster/ecs_cluster\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_cluster_C3960066\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_listener\\": {
+      \\"testPocketApp_listener_http_A9E227C2\\": {
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"default_action\\": [
+          {
+            \\"type\\": \\"redirect\\",
+            \\"redirect\\": [
+              {
+                \\"port\\": \\"443\\",
+                \\"protocol\\": \\"HTTPS\\",
+                \\"status_code\\": \\"HTTP_301\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/listener_http\\",
+            \\"uniqueId\\": \\"testPocketApp_listener_http_A9E227C2\\"
+          }
+        }
+      },
+      \\"testPocketApp_listener_https_7F49DE83\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 443,
+        \\"protocol\\": \\"HTTPS\\",
+        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\",
+        \\"default_action\\": [
+          {
+            \\"type\\": \\"fixed-response\\",
+            \\"fixed_response\\": [
+              {
+                \\"content_type\\": \\"text/plain\\",
+                \\"message_body\\": \\"\\",
+                \\"status_code\\": \\"503\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/listener_https\\",
+            \\"uniqueId\\": \\"testPocketApp_listener_https_7F49DE83\\"
+          }
+        }
+      }
+    },
+    \\"null_resource\\": {
+      \\"testPocketApp_ecs_service_8F213571\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_8F213571\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_update-task-definition_23CCF5D1\\": {
+        \\"triggers\\": {
+          \\"task_arn\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        },
+        \\"depends_on\\": [
+          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\",
+          \\"aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\",
+          \\"aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\"
+        ],
+        \\"provisioner\\": {
+          \\"local-exec\\": {
+            \\"command\\": \\"export app_spec_content_string='{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}' && export revision=\\\\\\"revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}\\\\\\" && aws deploy create-deployment  --application-name=\\\\\\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\\\\\"  --deployment-group-name=\\\\\\"\${aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1.deployment_group_name}\\\\\\" --description=\\\\\\"Triggered from Terraform/CodeBuild due to a task definition update\\\\\\" --revision=\\\\\\"$revision\\\\\\"\\"
+          }
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/update-task-definition\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_update-task-definition_23CCF5D1\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\": {
+        \\"triggers\\": {
+          \\"alwaysRun\\": \\"\${timestamp()}\\"
+        },
+        \\"depends_on\\": [
+          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+        ],
+        \\"provisioner\\": {
+          \\"local-exec\\": {
+            \\"command\\": \\"aws ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json\\"
+          }
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/create-task-definition-file\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-execution-role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-task-role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}\\",
+        \\"name\\": \\"testapp-ECSCodeDeployRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_code_deploy_role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7.json}\\",
+        \\"name\\": \\"testapp-AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_role\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
+        \\"family\\": \\"testapp\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
+        \\"volume\\": [],
+        \\"depends_on\\": [],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_target_group\\": {
+      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
+        \\"deregistration_delay\\": 120,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"tags\\": {
+          \\"type\\": \\"blue\\"
+        },
+        \\"target_type\\": \\"ip\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"health_check\\": [
+          {
+            \\"healthy_threshold\\": 5,
+            \\"interval\\": 15,
+            \\"path\\": \\"/test\\",
+            \\"protocol\\": \\"HTTP\\",
+            \\"unhealthy_threshold\\": 3
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/blue_target_group/ecs_target_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\": {
+        \\"deregistration_delay\\": 120,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"tags\\": {
+          \\"type\\": \\"green\\"
+        },
+        \\"target_type\\": \\"ip\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"health_check\\": [
+          {
+            \\"healthy_threshold\\": 5,
+            \\"interval\\": 15,
+            \\"path\\": \\"/test\\",
+            \\"protocol\\": \\"HTTP\\",
+            \\"unhealthy_threshold\\": 3
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/green_target_group/ecs_target_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_listener_rule\\": {
+      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
+        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
+        \\"priority\\": 1,
+        \\"action\\": [
+          {
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
+            \\"type\\": \\"forward\\"
+          }
+        ],
+        \\"condition\\": [
+          {
+            \\"path_pattern\\": [
+              {
+                \\"values\\": [
+                  \\"*\\"
+                ]
+              }
+            ]
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"action\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/listener_rule\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_service\\": {
+      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
+        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"name\\": \\"testapp\\",
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",
+        \\"deployment_controller\\": [
+          {
+            \\"type\\": \\"CODE_DEPLOY\\"
+          }
+        ],
+        \\"load_balancer\\": [
+          {
+            \\"container_name\\": \\"main_container\\",
+            \\"container_port\\": 8675309,
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+          }
+        ],
+        \\"network_configuration\\": [
+          {
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+            ],
+            \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
+          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\",
+            \\"task_definition\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-service\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\": {
+        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
+        \\"role\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_codedeploy_role_attachment\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\"
+          }
+        }
+      }
+    },
+    \\"aws_codedeploy_app\\": {
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\": {
+        \\"compute_platform\\": \\"ECS\\",
+        \\"name\\": \\"testapp-ECS\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_code_deploy\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\"
+          }
+        }
+      }
+    },
+    \\"aws_codedeploy_deployment_group\\": {
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\": {
+        \\"app_name\\": \\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\",
+        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
+        \\"deployment_group_name\\": \\"testapp-ECS\\",
+        \\"service_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}\\",
+        \\"auto_rollback_configuration\\": [
+          {
+            \\"enabled\\": true,
+            \\"events\\": [
+              \\"DEPLOYMENT_FAILURE\\"
+            ]
+          }
+        ],
+        \\"blue_green_deployment_config\\": [
+          {
+            \\"deployment_ready_option\\": [
+              {
+                \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+              }
+            ],
+            \\"terminate_blue_instances_on_deployment_success\\": [
+              {
+                \\"action\\": \\"TERMINATE\\",
+                \\"termination_wait_time_in_minutes\\": 5
+              }
+            ]
+          }
+        ],
+        \\"deployment_style\\": [
+          {
+            \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
+            \\"deployment_type\\": \\"BLUE_GREEN\\"
+          }
+        ],
+        \\"ecs_service\\": [
+          {
+            \\"cluster_name\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+            \\"service_name\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+          }
+        ],
+        \\"load_balancer_info\\": [
+          {
+            \\"target_group_pair_info\\": [
+              {
+                \\"prod_traffic_route\\": [
+                  {
+                    \\"listener_arns\\": [
+                      \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\"
+                    ]
+                  }
+                ],
+                \\"target_group\\": [
+                  {
+                    \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}\\"
+                  },
+                  {
+                    \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}\\"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_codedeploy_deployment_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\"
+          }
+        }
+      }
+    },
+    \\"local_file\\": {
+      \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\": {
+        \\"content\\": \\"{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}\\",
+        \\"filename\\": \\"appspec.json\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/appspec\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\": {
+        \\"name\\": \\"testapp-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_role_policy_4E03A5E2.json}\\",
+        \\"role\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_role_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
+        \\"max_capacity\\": 2,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_target\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
+        \\"name\\": \\"testapp-ScaleOutPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_lower_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": 2
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_out_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
+        \\"name\\": \\"testapp-ScaleInPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_upper_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": -1
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_in_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_name\\": \\"testapp Service High CPU\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 45,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_out_alarm\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
+        \\"alarm_name\\": \\"testapp Service Low CPU\\",
+        \\"comparison_operator\\": \\"LessThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 30,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_in_alarm\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
+        \\"datapoints_to_alarm\\": 5,
+        \\"evaluation_periods\\": 5,
+        \\"insufficient_data_actions\\": [],
+        \\"ok_actions\\": [],
+        \\"threshold\\": 5,
+        \\"metric_query\\": [
+          {
+            \\"id\\": \\"requests\\",
+            \\"metric\\": [
+              {
+                \\"dimensions\\": {
+                  \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+                },
+                \\"metric_name\\": \\"RequestCount\\",
+                \\"namespace\\": \\"AWS/ApplicationELB\\",
+                \\"period\\": 60,
+                \\"stat\\": \\"Sum\\",
+                \\"unit\\": \\"Count\\"
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"errors\\",
+            \\"metric\\": [
+              {
+                \\"dimensions\\": {
+                  \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+                },
+                \\"metric_name\\": \\"HTTPCode_ELB_5XX_Count\\",
+                \\"namespace\\": \\"AWS/ApplicationELB\\",
+                \\"period\\": 60,
+                \\"stat\\": \\"Sum\\",
+                \\"unit\\": \\"Count\\"
+              }
+            ]
+          },
+          {
+            \\"expression\\": \\"errors/requests*100\\",
+            \\"id\\": \\"expression\\",
+            \\"label\\": \\"HTTP 5xx Error Rate\\",
+            \\"return_data\\": true
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"TargetResponseTime\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 300,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"RequestCount\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 500,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_dashboard\\": {
+      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
+        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#17becf\\\\\\",\\\\\\"label\\\\\\":\\\\\\"RequestCountThreshold\\\\\\",\\\\\\"value\\\\\\":500,\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\"}]},\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#17becf\\\\\\",\\\\\\"label\\\\\\":\\\\\\"RequestCountThreshold\\\\\\",\\\\\\"value\\\\\\":500,\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\"}]},\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
+        \\"dashboard_name\\": \\"testapp-ALBDashboard\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/cloudwatch-dashboard\\",
+            \\"uniqueId\\": \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`PocketALBApplication renders an Pocket App with code deploy and creates appspec.json and taskdef.json when using code pipeline 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_ssm_parameter\\": {
+      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
+        \\"name\\": \\"/Shared/Vpc\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/vpc_ssm_param\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
+        \\"name\\": \\"/Shared/PrivateSubnets\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/private_subnets\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
+        \\"name\\": \\"/Shared/PublicSubnets\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/public_subnets\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\"
+          }
+        }
+      }
+    },
+    \\"aws_vpc\\": {
+      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/vpc\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_C4E157E3\\"
+          }
+        }
+      }
+    },
+    \\"aws_subnet_ids\\": {
+      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/private_subnet_ids\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\"
+          }
+        }
+      },
+      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/public_subnet_ids\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\"
+          }
+        }
+      }
+    },
+    \\"aws_caller_identity\\": {
+      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/current_identity\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_current_identity_06D87057\\"
+          }
+        }
+      }
+    },
+    \\"aws_region\\": {
+      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/current_region\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\"
+          }
+        }
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
+        \\"name\\": \\"alias/aws/secretsmanager\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/secrets_manager_key\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_groups\\": {
+      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"group-name\\",
+            \\"values\\": [
+              \\"default\\"
+            ]
+          },
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/pocket_vpc/default_security_groups\\",
+            \\"uniqueId\\": \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\"
+          }
+        }
+      }
+    },
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
+        \\"name\\": \\"bowling.gov\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns_main_hosted_zone\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
+        \\"version\\": \\"2012-10-17\\",
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-task-assume\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codedeploy.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/codedeploy_assume_role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_assume\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"cloudwatch:PutMetricAlarm\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:DeleteAlarms\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:cloudwatch:*:*:alarm:/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:DescribeServices\\",
+              \\"ecs:UpdateService\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:ecs:*:*:service/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/role_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns/subhosted_zone\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\"
+          }
+        }
+      }
+    },
+    \\"aws_route53_record\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
+        \\"ttl\\": 86400,
+        \\"type\\": \\"NS\\",
+        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/base_dns/subhosted_zone_ns\\",
+            \\"uniqueId\\": \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\"
+          }
+        }
+      },
+      \\"testPocketApp_alb_record_7B56ED33\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"set_identifier\\": \\"1\\",
+        \\"type\\": \\"A\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\",
+        \\"alias\\": [
+          {
+            \\"evaluate_target_health\\": true,
+            \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
+            \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+          }
+        ],
+        \\"weighted_routing_policy\\": [
+          {
+            \\"weight\\": 1
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"weighted_routing_policy[0].weight\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_record\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_record_7B56ED33\\"
+          }
+        }
+      },
+      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
+        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_name}\\",
+        \\"records\\": [
+          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_value}\\"
+        ],
+        \\"ttl\\": 60,
+        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_type}\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\",
+        \\"depends_on\\": [
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate_record\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\"
+          }
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        },
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/application_load_balancer/alb_security_group\\",
+            \\"uniqueId\\": \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 8675309
+          }
+        ],
+        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_security_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb\\": {
+      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+        ],
+        \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/application_load_balancer/alb\\",
+            \\"uniqueId\\": \\"testPocketApp_application_load_balancer_alb_D538DEEE\\"
+          }
+        }
+      }
+    },
+    \\"aws_acm_certificate\\": {
+      \\"testPocketApp_alb_certificate_417C14FF\\": {
+        \\"domain_name\\": \\"testing.bowling.gov\\",
+        \\"validation_method\\": \\"DNS\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_417C14FF\\"
+          }
+        }
+      }
+    },
+    \\"aws_acm_certificate_validation\\": {
+      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"validation_record_fqdns\\": [
+          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        ],
+        \\"depends_on\\": [
+          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alb_certificate/certificate_validation\\",
+            \\"uniqueId\\": \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_cluster\\": {
+      \\"testPocketApp_ecs_cluster_C3960066\\": {
+        \\"name\\": \\"testapp\\",
+        \\"setting\\": [
+          {
+            \\"name\\": \\"containerInsights\\",
+            \\"value\\": \\"enabled\\"
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_cluster/ecs_cluster\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_cluster_C3960066\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_listener\\": {
+      \\"testPocketApp_listener_http_A9E227C2\\": {
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"default_action\\": [
+          {
+            \\"type\\": \\"redirect\\",
+            \\"redirect\\": [
+              {
+                \\"port\\": \\"443\\",
+                \\"protocol\\": \\"HTTPS\\",
+                \\"status_code\\": \\"HTTP_301\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/listener_http\\",
+            \\"uniqueId\\": \\"testPocketApp_listener_http_A9E227C2\\"
+          }
+        }
+      },
+      \\"testPocketApp_listener_https_7F49DE83\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 443,
+        \\"protocol\\": \\"HTTPS\\",
+        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\",
+        \\"default_action\\": [
+          {
+            \\"type\\": \\"fixed-response\\",
+            \\"fixed_response\\": [
+              {
+                \\"content_type\\": \\"text/plain\\",
+                \\"message_body\\": \\"\\",
+                \\"status_code\\": \\"503\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/listener_https\\",
+            \\"uniqueId\\": \\"testPocketApp_listener_https_7F49DE83\\"
+          }
+        }
+      }
+    },
+    \\"null_resource\\": {
+      \\"testPocketApp_ecs_service_8F213571\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_8F213571\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\": {
+        \\"triggers\\": {
+          \\"alwaysRun\\": \\"\${timestamp()}\\"
+        },
+        \\"depends_on\\": [
+          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+        ],
+        \\"provisioner\\": {
+          \\"local-exec\\": {
+            \\"command\\": \\"aws ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json\\"
+          }
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/create-task-definition-file\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskExecutionRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-execution-role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-iam/ecs-task-role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}\\",
+        \\"name\\": \\"testapp-ECSCodeDeployRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_code_deploy_role\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7.json}\\",
+        \\"name\\": \\"testapp-AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_role\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
+        \\"family\\": \\"testapp\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
+        \\"volume\\": [],
+        \\"depends_on\\": [],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-task\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_target_group\\": {
+      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
+        \\"deregistration_delay\\": 120,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"tags\\": {
+          \\"type\\": \\"blue\\"
+        },
+        \\"target_type\\": \\"ip\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"health_check\\": [
+          {
+            \\"healthy_threshold\\": 5,
+            \\"interval\\": 15,
+            \\"path\\": \\"/test\\",
+            \\"protocol\\": \\"HTTP\\",
+            \\"unhealthy_threshold\\": 3
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/blue_target_group/ecs_target_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\"
+          }
+        }
+      },
+      \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\": {
+        \\"deregistration_delay\\": 120,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"tags\\": {
+          \\"type\\": \\"green\\"
+        },
+        \\"target_type\\": \\"ip\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\",
+        \\"health_check\\": [
+          {
+            \\"healthy_threshold\\": 5,
+            \\"interval\\": 15,
+            \\"path\\": \\"/test\\",
+            \\"protocol\\": \\"HTTP\\",
+            \\"unhealthy_threshold\\": 3
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/green_target_group/ecs_target_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\"
+          }
+        }
+      }
+    },
+    \\"aws_alb_listener_rule\\": {
+      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
+        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
+        \\"priority\\": 1,
+        \\"action\\": [
+          {
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
+            \\"type\\": \\"forward\\"
+          }
+        ],
+        \\"condition\\": [
+          {
+            \\"path_pattern\\": [
+              {
+                \\"values\\": [
+                  \\"*\\"
+                ]
+              }
+            ]
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"action\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/listener_rule\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+          }
+        }
+      }
+    },
+    \\"aws_ecs_service\\": {
+      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
+        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"name\\": \\"testapp\\",
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",
+        \\"deployment_controller\\": [
+          {
+            \\"type\\": \\"CODE_DEPLOY\\"
+          }
+        ],
+        \\"load_balancer\\": [
+          {
+            \\"container_name\\": \\"main_container\\",
+            \\"container_port\\": 8675309,
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+          }
+        ],
+        \\"network_configuration\\": [
+          {
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+            ],
+            \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
+          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\",
+            \\"task_definition\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs-service\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\": {
+        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
+        \\"role\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_codedeploy_role_attachment\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\"
+          }
+        }
+      }
+    },
+    \\"aws_codedeploy_app\\": {
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\": {
+        \\"compute_platform\\": \\"ECS\\",
+        \\"name\\": \\"testapp-ECS\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_code_deploy\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\"
+          }
+        }
+      }
+    },
+    \\"aws_codedeploy_deployment_group\\": {
+      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\": {
+        \\"app_name\\": \\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\",
+        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
+        \\"deployment_group_name\\": \\"testapp-ECS\\",
+        \\"service_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}\\",
+        \\"auto_rollback_configuration\\": [
+          {
+            \\"enabled\\": true,
+            \\"events\\": [
+              \\"DEPLOYMENT_FAILURE\\"
+            ]
+          }
+        ],
+        \\"blue_green_deployment_config\\": [
+          {
+            \\"deployment_ready_option\\": [
+              {
+                \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+              }
+            ],
+            \\"terminate_blue_instances_on_deployment_success\\": [
+              {
+                \\"action\\": \\"TERMINATE\\",
+                \\"termination_wait_time_in_minutes\\": 5
+              }
+            ]
+          }
+        ],
+        \\"deployment_style\\": [
+          {
+            \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
+            \\"deployment_type\\": \\"BLUE_GREEN\\"
+          }
+        ],
+        \\"ecs_service\\": [
+          {
+            \\"cluster_name\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+            \\"service_name\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+          }
+        ],
+        \\"load_balancer_info\\": [
+          {
+            \\"target_group_pair_info\\": [
+              {
+                \\"prod_traffic_route\\": [
+                  {
+                    \\"listener_arns\\": [
+                      \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\"
+                    ]
+                  }
+                ],
+                \\"target_group\\": [
+                  {
+                    \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}\\"
+                  },
+                  {
+                    \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}\\"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/ecs_codedeploy/ecs_codedeploy_deployment_group\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\"
+          }
+        }
+      }
+    },
+    \\"local_file\\": {
+      \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\": {
+        \\"content\\": \\"{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}\\",
+        \\"filename\\": \\"appspec.json\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/ecs_service/appspec\\",
+            \\"uniqueId\\": \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\": {
+        \\"name\\": \\"testapp-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_role_policy_4E03A5E2.json}\\",
+        \\"role\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_role_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
+        \\"max_capacity\\": 2,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/autoscaling_target\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
+        \\"name\\": \\"testapp-ScaleOutPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_lower_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": 2
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_out_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
+        \\"name\\": \\"testapp-ScaleInPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_upper_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": -1
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_in_policy\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_name\\": \\"testapp Service High CPU\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 45,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_out_alarm\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\"
+          }
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
+        \\"alarm_name\\": \\"testapp Service Low CPU\\",
+        \\"comparison_operator\\": \\"LessThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 30,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/autoscaling/scale_in_alarm\\",
+            \\"uniqueId\\": \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Percentage of 5xx responses exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTP5xxErrorRate\\",
+        \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
+        \\"datapoints_to_alarm\\": 5,
+        \\"evaluation_periods\\": 5,
+        \\"insufficient_data_actions\\": [],
+        \\"ok_actions\\": [],
+        \\"threshold\\": 5,
+        \\"metric_query\\": [
+          {
+            \\"id\\": \\"requests\\",
+            \\"metric\\": [
+              {
+                \\"dimensions\\": {
+                  \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+                },
+                \\"metric_name\\": \\"RequestCount\\",
+                \\"namespace\\": \\"AWS/ApplicationELB\\",
+                \\"period\\": 60,
+                \\"stat\\": \\"Sum\\",
+                \\"unit\\": \\"Count\\"
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"errors\\",
+            \\"metric\\": [
+              {
+                \\"dimensions\\": {
+                  \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+                },
+                \\"metric_name\\": \\"HTTPCode_ELB_5XX_Count\\",
+                \\"namespace\\": \\"AWS/ApplicationELB\\",
+                \\"period\\": 60,
+                \\"stat\\": \\"Sum\\",
+                \\"unit\\": \\"Count\\"
+              }
+            ]
+          },
+          {
+            \\"expression\\": \\"errors/requests*100\\",
+            \\"id\\": \\"expression\\",
+            \\"label\\": \\"HTTP 5xx Error Rate\\",
+            \\"return_data\\": true
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-http5xxerrorrate\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-http5xxerrorrate_D956FCCD\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"TargetResponseTime\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 300,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-httpresponsetime\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httpresponsetime_327A4315\\"
+          }
+        }
+      },
+      \\"testPocketApp_alarm-httprequestcount_318DE72F\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Total HTTP request count exceeds threshold\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPRequestCount\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"RequestCount\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Sum\\",
+        \\"threshold\\": 500,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/alarm-httprequestcount\\",
+            \\"uniqueId\\": \\"testPocketApp_alarm-httprequestcount_318DE72F\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_dashboard\\": {
+      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
+        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#17becf\\\\\\",\\\\\\"label\\\\\\":\\\\\\"RequestCountThreshold\\\\\\",\\\\\\"value\\\\\\":500,\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\"}]},\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#17becf\\\\\\",\\\\\\"label\\\\\\":\\\\\\"RequestCountThreshold\\\\\\",\\\\\\"value\\\\\\":500,\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\"}]},\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
+        \\"dashboard_name\\": \\"testapp-ALBDashboard\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testPocketApp/cloudwatch-dashboard\\",
+            \\"uniqueId\\": \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`PocketALBApplication renders an application alarms 1`] = `
 "{
   \\"//\\": {


### PR DESCRIPTION
## Goal

Create `appspec.json` and `taskdef.json` when an alb configuration is provided


## In this PR
- Generate `appspec.json`
- Generate `taskdef.json`
- Add config option `useCodePipeline` on PocketALBApplication to be used when creating the ECS application
