### PR TITLE
feat(dynamodb): Protect DynamoDB tables from being destroyed

### DIFF
--- a/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/src/base/ApplicationDynamoDBTable.spec.ts
@@ -171,7 +171,14 @@ test('renders dynamo db table that is not protected from being destroyed', () =>
 
   BASE_CONFIG.preventDestroyTable = false;
 
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+  const applicationDynamoDBTable = new ApplicationDynamoDBTable(
+    stack,
+    'testDynamoDBTable',
+    BASE_CONFIG
+  );
 
+  expect(applicationDynamoDBTable.dynamodb.lifecycle.preventDestroy).toEqual(
+    false
+  );
   expect(Testing.synth(stack)).toMatchSnapshot();
 });

--- a/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/src/base/ApplicationDynamoDBTable.spec.ts
@@ -164,3 +164,14 @@ test('renders dynamo db table with 2 global secondary indexes', () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test('renders dynamo db table that is protected from being destroyed', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  BASE_CONFIG.preventDestroyTable = true;
+
+  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/src/base/ApplicationDynamoDBTable.spec.ts
@@ -165,11 +165,11 @@ test('renders dynamo db table with 2 global secondary indexes', () => {
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
 
-test('renders dynamo db table that is protected from being destroyed', () => {
+test('renders dynamo db table that is not protected from being destroyed', () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, 'test');
 
-  BASE_CONFIG.preventDestroyTable = true;
+  BASE_CONFIG.preventDestroyTable = false;
 
   new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
 

--- a/src/base/ApplicationDynamoDBTable.ts
+++ b/src/base/ApplicationDynamoDBTable.ts
@@ -11,7 +11,6 @@ import {
   IamRolePolicyAttachment,
 } from '../../.gen/providers/aws';
 import { Construct } from 'constructs';
-import {TerraformResourceLifecycle} from "cdktf/lib/terraform-resource";
 
 /**
  * Enum to determine the capacity type for autoscaling

--- a/src/base/ApplicationDynamoDBTable.ts
+++ b/src/base/ApplicationDynamoDBTable.ts
@@ -11,6 +11,7 @@ import {
   IamRolePolicyAttachment,
 } from '../../.gen/providers/aws';
 import { Construct } from 'constructs';
+import {TerraformResourceLifecycle} from "cdktf/lib/terraform-resource";
 
 /**
  * Enum to determine the capacity type for autoscaling
@@ -38,6 +39,8 @@ export interface ApplicationDynamoDBProps {
   tableConfig: ApplicationDynamoDBTableConfig;
   readCapacity?: ApplicationDynamoDBTableAutoScaleProps;
   writeCapacity?: ApplicationDynamoDBTableAutoScaleProps;
+  // If true, the DynamoDB table will be protected from being destroyed. Enabled by default.
+  preventDestroyTable?: boolean;
 }
 
 /**
@@ -59,6 +62,8 @@ export class ApplicationDynamoDBTable extends Resource {
       name: config.prefix,
       lifecycle: {
         ignoreChanges: ['read_capacity', 'write_capacity'],
+        // Protect the table from being removed, unless preventDestroyTable is explicitly set to false.
+        ...(config.preventDestroyTable !== false && { preventDestroy: true }),
       },
     });
 

--- a/src/base/ApplicationDynamoDBTable.ts
+++ b/src/base/ApplicationDynamoDBTable.ts
@@ -62,7 +62,7 @@ export class ApplicationDynamoDBTable extends Resource {
       lifecycle: {
         ignoreChanges: ['read_capacity', 'write_capacity'],
         // Protect the table from being removed, unless preventDestroyTable is explicitly set to false.
-        ...(config.preventDestroyTable !== false && { preventDestroy: true }),
+        preventDestroy: config.preventDestroyTable !== false,
       },
     });
 

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -429,6 +429,532 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
 }"
 `;
 
+exports[`renders dynamo db table that is protected from being destroyed 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"aws_dynamodb_table\\": {
+      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"hash_key\\": \\"123\\",
+        \\"name\\": \\"abides-\\",
+        \\"tags\\": {
+          \\"name\\": \\"thedude\\",
+          \\"hobby\\": \\"bowling\\"
+        },
+        \\"attribute\\": [
+          {
+            \\"name\\": \\"attribeautiful\\",
+            \\"type\\": \\"shrugs!\\"
+          }
+        ],
+        \\"global_secondary_index\\": [
+          {
+            \\"hash_key\\": \\"card-type\\",
+            \\"name\\": \\"card-index\\",
+            \\"projection_type\\": \\"ALL\\",
+            \\"range_key\\": \\"home_on_the_range\\",
+            \\"read_capacity\\": 5,
+            \\"write_capacity\\": 5
+          },
+          {
+            \\"hash_key\\": \\"card-type-123\\",
+            \\"name\\": \\"card-index-2\\",
+            \\"projection_type\\": \\"ALL\\",
+            \\"range_key\\": \\"home_home_on_the_range\\",
+            \\"read_capacity\\": 10,
+            \\"write_capacity\\": 10
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"read_capacity\\",
+            \\"write_capacity\\"
+          ],
+          \\"prevent_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/dynamodb_table\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
+        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_autoscaling_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
+        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_autoscaling_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
+        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
+        \\"tags\\": {
+          \\"name\\": \\"thedude\\",
+          \\"hobby\\": \\"bowling\\"
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
+        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
+        \\"tags\\": {
+          \\"name\\": \\"thedude\\",
+          \\"hobby\\": \\"bowling\\"
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
+        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
+          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role_attachment\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
+        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
+          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role_attachment\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 3,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 5,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 10,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 3,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 5,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 10,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\": {
+        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\": {
+        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\": {
+        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\": {
+        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\": {
+        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\": {
+        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"application-autoscaling:*\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:PutMetricAlarm\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"dynamodb:DescribeTable\\",
+              \\"dynamodb:UpdateTable\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_assume_role_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"application-autoscaling:*\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:PutMetricAlarm\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"dynamodb:DescribeTable\\",
+              \\"dynamodb:UpdateTable\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_assume_role_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
 "{
   \\"//\\": {

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -37,7 +37,8 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": true
         },
         \\"//\\": {
           \\"metadata\\": {
@@ -429,7 +430,532 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table that is protected from being destroyed 1`] = `
+exports[`renders dynamo db table that is not protected from being destroyed 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"aws_dynamodb_table\\": {
+      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"hash_key\\": \\"123\\",
+        \\"name\\": \\"abides-\\",
+        \\"tags\\": {
+          \\"name\\": \\"thedude\\",
+          \\"hobby\\": \\"bowling\\"
+        },
+        \\"attribute\\": [
+          {
+            \\"name\\": \\"attribeautiful\\",
+            \\"type\\": \\"shrugs!\\"
+          }
+        ],
+        \\"global_secondary_index\\": [
+          {
+            \\"hash_key\\": \\"card-type\\",
+            \\"name\\": \\"card-index\\",
+            \\"projection_type\\": \\"ALL\\",
+            \\"range_key\\": \\"home_on_the_range\\",
+            \\"read_capacity\\": 5,
+            \\"write_capacity\\": 5
+          },
+          {
+            \\"hash_key\\": \\"card-type-123\\",
+            \\"name\\": \\"card-index-2\\",
+            \\"projection_type\\": \\"ALL\\",
+            \\"range_key\\": \\"home_home_on_the_range\\",
+            \\"read_capacity\\": 10,
+            \\"write_capacity\\": 10
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"read_capacity\\",
+            \\"write_capacity\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/dynamodb_table\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
+        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_autoscaling_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
+        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_autoscaling_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
+        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
+        \\"tags\\": {
+          \\"name\\": \\"thedude\\",
+          \\"hobby\\": \\"bowling\\"
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
+        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
+        \\"tags\\": {
+          \\"name\\": \\"thedude\\",
+          \\"hobby\\": \\"bowling\\"
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
+        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
+          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role_attachment\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
+        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\",
+        \\"depends_on\\": [
+          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
+          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role_attachment\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 3,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 5,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 10,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 3,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 5,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\": {
+        \\"max_capacity\\": 10,
+        \\"min_capacity\\": 10,
+        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
+        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
+        \\"service_namespace\\": \\"dynamodb\\",
+        \\"depends_on\\": [
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_target\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\": {
+        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\": {
+        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\": {
+        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\": {
+        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\": {
+        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\": {
+        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
+        \\"policy_type\\": \\"TargetTrackingScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.service_namespace}\\",
+        \\"target_tracking_scaling_policy_configuration\\": [
+          {
+            \\"target_value\\": 1,
+            \\"predefined_metric_specification\\": [
+              {
+                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\",
+          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_policy\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"application-autoscaling:*\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:PutMetricAlarm\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"dynamodb:DescribeTable\\",
+              \\"dynamodb:UpdateTable\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_assume_role_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"application-autoscaling:*\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:PutMetricAlarm\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"dynamodb:DescribeTable\\",
+              \\"dynamodb:UpdateTable\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
+              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\"
+          }
+        }
+      },
+      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_assume_role_policy_document\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -955,531 +1481,6 @@ exports[`renders dynamo db table that is protected from being destroyed 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
-"{
-  \\"//\\": {
-    \\"metadata\\": {
-      \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
-    }
-  },
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"hash_key\\": \\"123\\",
-        \\"name\\": \\"abides-\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
-        \\"attribute\\": [
-          {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
-          }
-        ],
-        \\"global_secondary_index\\": [
-          {
-            \\"hash_key\\": \\"card-type\\",
-            \\"name\\": \\"card-index\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_on_the_range\\",
-            \\"read_capacity\\": 5,
-            \\"write_capacity\\": 5
-          },
-          {
-            \\"hash_key\\": \\"card-type-123\\",
-            \\"name\\": \\"card-index-2\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_home_on_the_range\\",
-            \\"read_capacity\\": 10,
-            \\"write_capacity\\": 10
-          }
-        ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
-          ]
-        },
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/dynamodb_table\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-          }
-        }
-      }
-    },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\",
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_autoscaling_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\",
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_autoscaling_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
-          }
-        }
-      }
-    },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\"
-          }
-        }
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\",
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role_attachment\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\",
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role_attachment\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\"
-          }
-        }
-      }
-    },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 10,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 10,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\"
-          }
-        }
-      }
-    },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\"
-          }
-        }
-      }
-    }
-  },
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
-            ]
-          },
-          {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_assume_role_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
-            ]
-          },
-          {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_assume_role_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\"
-          }
-        }
-      }
-    }
-  }
-}"
-`;
-
 exports[`renders dynamo db table with minimal config 1`] = `
 "{
   \\"//\\": {
@@ -1504,7 +1505,8 @@ exports[`renders dynamo db table with minimal config 1`] = `
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": true
         },
         \\"//\\": {
           \\"metadata\\": {
@@ -1542,7 +1544,8 @@ exports[`renders dynamo db table with read and write capacity 1`] = `
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": true
         },
         \\"//\\": {
           \\"metadata\\": {
@@ -1866,7 +1869,8 @@ exports[`renders dynamo db table with read and write capacity and tags 1`] = `
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": true
         },
         \\"//\\": {
           \\"metadata\\": {
@@ -2194,7 +2198,8 @@ exports[`renders dynamo db table with read capacity 1`] = `
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": true
         },
         \\"//\\": {
           \\"metadata\\": {
@@ -2380,7 +2385,8 @@ exports[`renders dynamo db table with write capacity 1`] = `
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": true
         },
         \\"//\\": {
           \\"metadata\\": {

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -475,7 +475,8 @@ exports[`renders dynamo db table that is not protected from being destroyed 1`] 
           \\"ignore_changes\\": [
             \\"read_capacity\\",
             \\"write_capacity\\"
-          ]
+          ],
+          \\"prevent_destroy\\": false
         },
         \\"//\\": {
           \\"metadata\\": {


### PR DESCRIPTION
# Goal
Prevent DynamoDB tables from being destroyed accidentally, for example by changing the primary key. 
- Tables are protected by default.
- Set 'preventDestroyTable' to `false` to disable this protection.

This was requested for our recommendation metrics tables. There haven't been any incidents yet were tables were accidentally removed; this is purely preventative.

Successfully tested in our development environment:

```
Error: Instance cannot be destroyed

  on cdk.tf.json line 25, in resource.aws_dynamodb_table:
  25:       "acmeexample_recommendationmetrics_dynamodbtable_3402FAB3": {

Resource
aws_dynamodb_table.acmeexample_recommendationmetrics_dynamodbtable_3402FAB3
has lifecycle.prevent_destroy set, but the plan calls for this resource to be
destroyed. To avoid this error and continue with the plan, either disable
lifecycle.prevent_destroy or reduce the scope of the plan using the -target
flag.
```

## Reference

Documentation here:
* https://www.terraform.io/docs/configuration-0-11/resources.html#prevent_destroy
* https://github.com/hashicorp/terraform-cdk/blob/main/packages/cdktf/lib/terraform-resource.ts#L23

## Implementation Decisions
- Enable this protection by default.