### PR TITLE
refactor(ApplicationAutoscaling) - move logic to static functions

### DIFF
--- a/src/base/ApplicationAutoscaling.spec.ts
+++ b/src/base/ApplicationAutoscaling.spec.ts
@@ -1,11 +1,14 @@
 import { Testing, TerraformStack } from 'cdktf';
-import { ApplicationAutoscaling } from './ApplicationAutoscaling';
+import { TestResource } from '../testHelpers';
+import {
+  ApplicationAutoscaling,
+  ApplicationAutoscalingProps,
+} from './ApplicationAutoscaling';
 
-test('renders autoscaling without tags', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  new ApplicationAutoscaling(stack, 'testAutoscaling', {
+describe('ApplicationAutoscaling', () => {
+  let app;
+  let stack;
+  const props: ApplicationAutoscalingProps = {
     prefix: 'test-',
     targetMinCapacity: 1,
     targetMaxCapacity: 5,
@@ -16,7 +19,154 @@ test('renders autoscaling without tags', () => {
     stepScaleInAdjustment: -1,
     scaleInThreshold: 30,
     scaleOutThreshold: 45,
+  };
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new TerraformStack(app, 'test');
   });
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
+  describe('generateIamRole', () => {
+    it('renders an IamRole', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      ApplicationAutoscaling.generateIamRole(construct, props);
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+  });
+
+  describe('generateIamRolePolicy', () => {
+    it('renders an IamRolePolicy', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      const role = ApplicationAutoscaling.generateIamRole(construct, props);
+      ApplicationAutoscaling.generateIamRolePolicy(construct, props, role);
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+  });
+
+  describe('generateAutoScalingTarget', () => {
+    it('renders an AutoscalingTarget', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      const role = ApplicationAutoscaling.generateIamRole(construct, props);
+      ApplicationAutoscaling.generateAutoScalingTarget(construct, props, role);
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+  });
+
+  describe('generateAutoScalingPolicy', () => {
+    it('renders a scale-in AutoscalingPolicy', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      const role = ApplicationAutoscaling.generateIamRole(construct, props);
+      const target = ApplicationAutoscaling.generateAutoScalingTarget(
+        construct,
+        props,
+        role
+      );
+      ApplicationAutoscaling.generateAutoSclaingPolicy(
+        construct,
+        props,
+        target,
+        'In'
+      );
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+
+    it('renders a scale-out AutoscalingPolicy', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      const role = ApplicationAutoscaling.generateIamRole(construct, props);
+      const target = ApplicationAutoscaling.generateAutoScalingTarget(
+        construct,
+        props,
+        role
+      );
+      ApplicationAutoscaling.generateAutoSclaingPolicy(
+        construct,
+        props,
+        target,
+        'Out'
+      );
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+  });
+
+  describe('generateCloudwatchMetricAlarm', () => {
+    it('renders a scale-in Cloudwatch Alarm', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      const role = ApplicationAutoscaling.generateIamRole(construct, props);
+      const target = ApplicationAutoscaling.generateAutoScalingTarget(
+        construct,
+        props,
+        role
+      );
+
+      const policy = ApplicationAutoscaling.generateAutoSclaingPolicy(
+        construct,
+        props,
+        target,
+        'In'
+      );
+
+      ApplicationAutoscaling.generateCloudwatchMetricAlarm(
+        construct,
+        props,
+        'scale_in_alarm',
+        `${props.prefix} Service Low CPU`,
+        'Alarm to reduce capacity if container CPU is low',
+        'LessThanThreshold',
+        props.scaleInThreshold,
+        policy.arn
+      );
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+
+    it('renders a scale-out Cloudwatch Alarm', () => {
+      const construct = new TestResource(stack, 'test-resource');
+
+      const role = ApplicationAutoscaling.generateIamRole(construct, props);
+      const target = ApplicationAutoscaling.generateAutoScalingTarget(
+        construct,
+        props,
+        role
+      );
+
+      const policy = ApplicationAutoscaling.generateAutoSclaingPolicy(
+        construct,
+        props,
+        target,
+        'Out'
+      );
+
+      ApplicationAutoscaling.generateCloudwatchMetricAlarm(
+        construct,
+        props,
+        'scale_out_alarm',
+        `${props.prefix} Service High CPU`,
+        'Alarm to add capacity if container CPU is high',
+        'GreaterThanThreshold',
+        props.scaleOutThreshold,
+        policy.arn
+      );
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+  });
+
+  describe('constructor', () => {
+    it('renders autoscaling without tags', () => {
+      new ApplicationAutoscaling(stack, 'testAutoscaling', props);
+
+      expect(Testing.synth(stack)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/base/ApplicationAutoscaling.ts
+++ b/src/base/ApplicationAutoscaling.ts
@@ -10,17 +10,17 @@ import {
 import { Construct } from 'constructs';
 
 export interface ApplicationAutoscalingProps {
-  prefix: string;
-  targetMinCapacity: number;
-  targetMaxCapacity: number;
   ecsClusterName: string;
   ecsServiceName: string;
+  prefix: string;
   scalableDimension: string;
-  stepScaleInAdjustment: number;
-  stepScaleOutAdjustment: number;
   scaleInThreshold: number;
   scaleOutThreshold: number;
+  stepScaleInAdjustment: number;
+  stepScaleOutAdjustment: number;
   tags?: { [key: string]: string };
+  targetMaxCapacity: number;
+  targetMinCapacity: number;
 }
 
 /*
@@ -28,156 +28,6 @@ export interface ApplicationAutoscalingProps {
  */
 
 export class ApplicationAutoscaling extends Resource {
-  static generateIamRolePolicy(
-    construct: Resource,
-    config: ApplicationAutoscalingProps,
-    iamRole: IamRole
-  ): void {
-    new IamRolePolicy(construct, `autoscaling_role_policy`, {
-      name: `${config.prefix}-AutoScalingPolicy`,
-      role: iamRole.id,
-      policy: new DataAwsIamPolicyDocument(construct, `role_policy`, {
-        statement: [
-          {
-            effect: 'Allow',
-            actions: [
-              'cloudwatch:PutMetricAlarm',
-              'cloudwatch:DescribeAlarms',
-              'cloudwatch:DeleteAlarms',
-            ],
-            resources: [
-              `arn:aws:cloudwatch:*:*:alarm:/${config.ecsServiceName}*`,
-            ],
-          },
-          {
-            effect: 'Allow',
-            actions: ['ecs:DescribeServices', 'ecs:UpdateService'],
-            resources: [`arn:aws:ecs:*:*:service/${config.ecsServiceName}*`],
-          },
-        ],
-      }).json,
-    });
-  }
-
-  static generateIamRole(
-    construct: Resource,
-    config: ApplicationAutoscalingProps
-  ): IamRole {
-    return new IamRole(construct, `autoscaling_role`, {
-      name: `${config.prefix}-AutoScalingRole`,
-      assumeRolePolicy: new DataAwsIamPolicyDocument(
-        construct,
-        `autoscaling_assume`,
-        {
-          statement: [
-            {
-              effect: 'Allow',
-              actions: ['sts:AssumeRole'],
-              principals: [
-                {
-                  identifiers: ['ecs.application-autoscaling.amazonaws.com'],
-                  type: 'Service',
-                },
-              ],
-            },
-          ],
-        }
-      ).json,
-    });
-  }
-
-  static generateAutoScalingTarget(
-    construct: Resource,
-    config: ApplicationAutoscalingProps,
-    iamRole: IamRole
-  ): AppautoscalingTarget {
-    return new AppautoscalingTarget(construct, `autoscaling_target`, {
-      maxCapacity: config.targetMaxCapacity,
-      minCapacity: config.targetMinCapacity,
-      resourceId: `service/${config.ecsClusterName}/${config.ecsServiceName}`,
-      roleArn: iamRole.arn,
-      scalableDimension: 'ecs:service:DesiredCount',
-      serviceNamespace: 'ecs',
-    });
-  }
-
-  static generateAutoSclaingPolicy(
-    construct: Resource,
-    config: ApplicationAutoscalingProps,
-    target: AppautoscalingTarget,
-    type: 'In' | 'Out'
-  ): AppautoscalingPolicy {
-    let stepAdjustment;
-
-    if (type === 'In') {
-      stepAdjustment = [
-        {
-          metricIntervalUpperBound: '0',
-          scalingAdjustment: config.stepScaleInAdjustment,
-        },
-      ];
-    } else {
-      stepAdjustment = [
-        {
-          metricIntervalLowerBound: '0',
-          scalingAdjustment: config.stepScaleOutAdjustment,
-        },
-      ];
-    }
-
-    return new AppautoscalingPolicy(
-      construct,
-      `scale_${type.toLowerCase()}_policy`,
-      {
-        name: `${config.prefix}-Scale${type}Policy`,
-        policyType: 'StepScaling',
-        resourceId: target.resourceId,
-        scalableDimension: target.scalableDimension,
-        serviceNamespace: target.serviceNamespace,
-
-        stepScalingPolicyConfiguration: [
-          {
-            adjustmentType: `ChangeInCapacity`,
-            cooldown: 60,
-            metricAggregationType: 'Average',
-            stepAdjustment,
-          },
-        ],
-        dependsOn: [target],
-      }
-    );
-  }
-
-  static generateCloudwatchMetricAlarm(
-    construct: Resource,
-    config: ApplicationAutoscalingProps,
-    id: string,
-    name: string,
-    desc: string,
-    operator: string,
-    threshold: number,
-    arn: string
-  ): void {
-    new CloudwatchMetricAlarm(construct, id, {
-      alarmName: name,
-      alarmDescription: desc,
-      comparisonOperator: operator,
-      evaluationPeriods: 2,
-      threshold,
-      statistic: 'Average',
-      period: 60,
-      namespace: 'AWS/ECS',
-      metricName: 'CPUUtilization',
-      treatMissingData: 'notBreaching',
-      dimensions: {
-        ClusterName: config.ecsClusterName,
-        ServiceName: config.ecsServiceName,
-      },
-      alarmActions: [arn],
-      tags: config.tags,
-    });
-  }
-
   constructor(
     scope: Construct,
     name: string,
@@ -232,5 +82,194 @@ export class ApplicationAutoscaling extends Resource {
       config.scaleInThreshold,
       applicationScaleIn.arn
     );
+  }
+
+  /**
+   * Creates an IAM Role
+   * @param construct
+   * @param config
+   * @returns IamRole
+   */
+  static generateIamRole(
+    construct: Resource,
+    config: ApplicationAutoscalingProps
+  ): IamRole {
+    return new IamRole(construct, `autoscaling_role`, {
+      name: `${config.prefix}-AutoScalingRole`,
+      assumeRolePolicy: new DataAwsIamPolicyDocument(
+        construct,
+        `autoscaling_assume`,
+        {
+          statement: [
+            {
+              effect: 'Allow',
+              actions: ['sts:AssumeRole'],
+              principals: [
+                {
+                  identifiers: ['ecs.application-autoscaling.amazonaws.com'],
+                  type: 'Service',
+                },
+              ],
+            },
+          ],
+        }
+      ).json,
+    });
+  }
+
+  /**
+   * Creates an IAM Role Policy
+   *
+   * @param construct
+   * @param config
+   * @param iamRole
+   */
+  static generateIamRolePolicy(
+    construct: Resource,
+    config: ApplicationAutoscalingProps,
+    iamRole: IamRole
+  ): void {
+    new IamRolePolicy(construct, `autoscaling_role_policy`, {
+      name: `${config.prefix}-AutoScalingPolicy`,
+      role: iamRole.id,
+      policy: new DataAwsIamPolicyDocument(construct, `role_policy`, {
+        statement: [
+          {
+            effect: 'Allow',
+            actions: [
+              'cloudwatch:PutMetricAlarm',
+              'cloudwatch:DescribeAlarms',
+              'cloudwatch:DeleteAlarms',
+            ],
+            resources: [
+              `arn:aws:cloudwatch:*:*:alarm:/${config.ecsServiceName}*`,
+            ],
+          },
+          {
+            effect: 'Allow',
+            actions: ['ecs:DescribeServices', 'ecs:UpdateService'],
+            resources: [`arn:aws:ecs:*:*:service/${config.ecsServiceName}*`],
+          },
+        ],
+      }).json,
+    });
+  }
+
+  /**
+   * Creates an Auto Scaling Target
+   * @param construct
+   * @param config
+   * @param iamRole
+   * @returns AppautoscalingTarget
+   */
+  static generateAutoScalingTarget(
+    construct: Resource,
+    config: ApplicationAutoscalingProps,
+    iamRole: IamRole
+  ): AppautoscalingTarget {
+    return new AppautoscalingTarget(construct, `autoscaling_target`, {
+      maxCapacity: config.targetMaxCapacity,
+      minCapacity: config.targetMinCapacity,
+      resourceId: `service/${config.ecsClusterName}/${config.ecsServiceName}`,
+      roleArn: iamRole.arn,
+      scalableDimension: 'ecs:service:DesiredCount',
+      serviceNamespace: 'ecs',
+    });
+  }
+
+  /**
+   * Creates an Autoscaling Policy
+   * @param construct
+   * @param config
+   * @param target
+   * @param type
+   * @returns AppautoscalingPolicy
+   */
+  static generateAutoSclaingPolicy(
+    construct: Resource,
+    config: ApplicationAutoscalingProps,
+    target: AppautoscalingTarget,
+    type: 'In' | 'Out'
+  ): AppautoscalingPolicy {
+    let stepAdjustment;
+
+    if (type === 'In') {
+      stepAdjustment = [
+        {
+          metricIntervalUpperBound: '0',
+          scalingAdjustment: config.stepScaleInAdjustment,
+        },
+      ];
+    } else {
+      stepAdjustment = [
+        {
+          metricIntervalLowerBound: '0',
+          scalingAdjustment: config.stepScaleOutAdjustment,
+        },
+      ];
+    }
+
+    return new AppautoscalingPolicy(
+      construct,
+      `scale_${type.toLowerCase()}_policy`,
+      {
+        name: `${config.prefix}-Scale${type}Policy`,
+        policyType: 'StepScaling',
+        resourceId: target.resourceId,
+        scalableDimension: target.scalableDimension,
+        serviceNamespace: target.serviceNamespace,
+
+        stepScalingPolicyConfiguration: [
+          {
+            adjustmentType: `ChangeInCapacity`,
+            cooldown: 60,
+            metricAggregationType: 'Average',
+            stepAdjustment,
+          },
+        ],
+        dependsOn: [target],
+      }
+    );
+  }
+
+  /**
+   * Creates a Cloudwatch Metric Alarm
+   * @param construct
+   * @param config
+   * @param id
+   * @param name
+   * @param desc
+   * @param operator
+   * @param threshold
+   * @param arn
+   */
+  static generateCloudwatchMetricAlarm(
+    construct: Resource,
+    config: ApplicationAutoscalingProps,
+    id: string,
+    name: string,
+    desc: string,
+    operator: string,
+    threshold: number,
+    arn: string
+  ): void {
+    new CloudwatchMetricAlarm(construct, id, {
+      alarmName: name,
+      alarmDescription: desc,
+      comparisonOperator: operator,
+      evaluationPeriods: 2,
+      threshold,
+      statistic: 'Average',
+      period: 60,
+      namespace: 'AWS/ECS',
+      metricName: 'CPUUtilization',
+      treatMissingData: 'notBreaching',
+      dimensions: {
+        ClusterName: config.ecsClusterName,
+        ServiceName: config.ecsServiceName,
+      },
+      alarmActions: [arn],
+      tags: config.tags,
+    });
   }
 }

--- a/src/base/__snapshots__/ApplicationAutoscaling.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationAutoscaling.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders autoscaling without tags 1`] = `
+exports[`ApplicationAutoscaling constructor renders autoscaling without tags 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -174,7 +174,7 @@ exports[`renders autoscaling without tags 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testAutoscaling_scale_out_policy_DE69B04C.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"test- Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -217,6 +217,679 @@ exports[`renders autoscaling without tags 1`] = `
           \\"metadata\\": {
             \\"path\\": \\"test/testAutoscaling/scale_in_alarm\\",
             \\"uniqueId\\": \\"testAutoscaling_scale_in_alarm_D552E48E\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateAutoScalingPolicy renders a scale-in AutoscalingPolicy 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"test-resource_autoscaling_target_50BC4A94\\": {
+        \\"max_capacity\\": 5,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-resource_autoscaling_role_5C86EA80.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_target\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_target_50BC4A94\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"test-resource_scale_in_policy_FC19C991\\": {
+        \\"name\\": \\"test--ScaleInPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_upper_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": -1
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/scale_in_policy\\",
+            \\"uniqueId\\": \\"test-resource_scale_in_policy_FC19C991\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateAutoScalingPolicy renders a scale-out AutoscalingPolicy 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"test-resource_autoscaling_target_50BC4A94\\": {
+        \\"max_capacity\\": 5,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-resource_autoscaling_role_5C86EA80.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_target\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_target_50BC4A94\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"test-resource_scale_out_policy_CE22053C\\": {
+        \\"name\\": \\"test--ScaleOutPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_lower_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": 2
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/scale_out_policy\\",
+            \\"uniqueId\\": \\"test-resource_scale_out_policy_CE22053C\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateAutoScalingTarget renders an AutoscalingTarget 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"test-resource_autoscaling_target_50BC4A94\\": {
+        \\"max_capacity\\": 5,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-resource_autoscaling_role_5C86EA80.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_target\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_target_50BC4A94\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-in Cloudwatch Alarm 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"test-resource_autoscaling_target_50BC4A94\\": {
+        \\"max_capacity\\": 5,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-resource_autoscaling_role_5C86EA80.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_target\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_target_50BC4A94\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"test-resource_scale_in_policy_FC19C991\\": {
+        \\"name\\": \\"test--ScaleInPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_upper_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": -1
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/scale_in_policy\\",
+            \\"uniqueId\\": \\"test-resource_scale_in_policy_FC19C991\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"test-resource_scale_in_alarm_73254138\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.test-resource_scale_in_policy_FC19C991.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
+        \\"alarm_name\\": \\"test- Service Low CPU\\",
+        \\"comparison_operator\\": \\"LessThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"ecs-cluster-test\\",
+          \\"ServiceName\\": \\"ecs-service-test\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 30,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/scale_in_alarm\\",
+            \\"uniqueId\\": \\"test-resource_scale_in_alarm_73254138\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-out Cloudwatch Alarm 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"test-resource_autoscaling_target_50BC4A94\\": {
+        \\"max_capacity\\": 5,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-resource_autoscaling_role_5C86EA80.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_target\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_target_50BC4A94\\"
+          }
+        }
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"test-resource_scale_out_policy_CE22053C\\": {
+        \\"name\\": \\"test--ScaleOutPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": [
+          {
+            \\"adjustment_type\\": \\"ChangeInCapacity\\",
+            \\"cooldown\\": 60,
+            \\"metric_aggregation_type\\": \\"Average\\",
+            \\"step_adjustment\\": [
+              {
+                \\"metric_interval_lower_bound\\": \\"0\\",
+                \\"scaling_adjustment\\": 2
+              }
+            ]
+          }
+        ],
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/scale_out_policy\\",
+            \\"uniqueId\\": \\"test-resource_scale_out_policy_CE22053C\\"
+          }
+        }
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"test-resource_scale_out_alarm_5BADC0D8\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.test-resource_scale_out_policy_CE22053C.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
+        \\"alarm_name\\": \\"test- Service High CPU\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"ecs-cluster-test\\",
+          \\"ServiceName\\": \\"ecs-service-test\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 45,
+        \\"treat_missing_data\\": \\"notBreaching\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/scale_out_alarm\\",
+            \\"uniqueId\\": \\"test-resource_scale_out_alarm_5BADC0D8\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateIamRole renders an IamRole 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationAutoscaling generateIamRolePolicy renders an IamRolePolicy 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-resource_autoscaling_assume_94B7604F\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_assume\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_assume_94B7604F\\"
+          }
+        }
+      },
+      \\"test-resource_role_policy_21B9F22E\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"cloudwatch:PutMetricAlarm\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:DeleteAlarms\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:cloudwatch:*:*:alarm:/ecs-service-test*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:DescribeServices\\",
+              \\"ecs:UpdateService\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:ecs:*:*:service/ecs-service-test*\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/role_policy\\",
+            \\"uniqueId\\": \\"test-resource_role_policy_21B9F22E\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_iam_role\\": {
+      \\"test-resource_autoscaling_role_5C86EA80\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-resource_autoscaling_assume_94B7604F.json}\\",
+        \\"name\\": \\"test--AutoScalingRole\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_5C86EA80\\"
+          }
+        }
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-resource_autoscaling_role_policy_8E791CA3\\": {
+        \\"name\\": \\"test--AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-resource_role_policy_21B9F22E.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-resource_autoscaling_role_5C86EA80.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test-resource/autoscaling_role_policy\\",
+            \\"uniqueId\\": \\"test-resource_autoscaling_role_policy_8E791CA3\\"
           }
         }
       }

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -1016,7 +1016,7 @@ exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -2177,7 +2177,7 @@ exports[`PocketALBApplication renders an Pocket App with code deploy and creates
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -3144,7 +3144,7 @@ exports[`PocketALBApplication renders an application alarms 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -4119,7 +4119,7 @@ exports[`PocketALBApplication renders an application custom default alarms 1`] =
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -5145,7 +5145,7 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -6132,7 +6132,7 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -7139,7 +7139,7 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -8126,7 +8126,7 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -9139,7 +9139,7 @@ exports[`PocketALBApplication renders an application with modified container def
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -10267,7 +10267,7 @@ exports[`PocketALBApplication renders an external application 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -11234,7 +11234,7 @@ exports[`PocketALBApplication renders an internal application 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {
@@ -12241,7 +12241,7 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
         \\"alarm_actions\\": [
           \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if CPU is high\\",
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
         \\"alarm_name\\": \\"testapp Service High CPU\\",
         \\"comparison_operator\\": \\"GreaterThanThreshold\\",
         \\"dimensions\\": {

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -1,0 +1,9 @@
+import { Resource, TerraformStack } from 'cdktf';
+
+// used to test individual static functions within component classes
+// generates a basic/empty construct Resource to provide context
+export class TestResource extends Resource {
+  constructor(scope: TerraformStack, name: string) {
+    super(scope, name);
+  }
+}


### PR DESCRIPTION
# Goal

move logic to static functions.

- move code out of constructor into static functions
- make code a bit more DRY
- add tests for all static functions
- add a test helper for an empty/blank construct

## Implementation Decisions

attempting to make the code more modular and easier to test in pieces. if we like this pattern (and we don't have to), i'll continue into the rest of the components.