### PR TITLE
feat(NPM): Publish terraform-modules to NPM

### DIFF
--- a/.github/workflows/publish_github.yml
+++ b/.github/workflows/publish_github.yml
@@ -1,4 +1,4 @@
-name: Node.js Package
+name: Node.js Github Package
 
 on:
   pull_request:

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,4 +1,4 @@
-name: Node.js Package
+name: Node.js NPM Package
 
 on:
   pull_request:

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@pocket-tools'
+      - run: echo $(jq '.name = "@pocket-tools/terraform-modules" | del(.publishConfig)' package.json) > package.json
+      - run: cat package.json
       - run: npm install
       - run: npm run get
       - run: npm run build

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,0 +1,33 @@
+name: Node.js Package
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.13.5
+          terraform_wrapper: false
+      - uses: actions/setup-node@v2.3.0
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@pocket-tools'
+      - run: npm install
+      - run: npm run get
+      - run: npm run build
+      - run: npm run test
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -22,8 +22,11 @@ jobs:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@pocket-tools'
+      # We need to replace the package name and remove the publishConfig that tells npm the registry (set to GitHub registry in source) to publish to
+      # in order to be able to be able to publish to npm's registry. 
+      # In the future, we plan to stop publishing to GitHub's registry.
+      # TODO: remove this next command when that is in effect and update package.json accordingly
       - run: echo $(jq '.name = "@pocket-tools/terraform-modules" | del(.publishConfig)' package.json) > package.json
-      - run: cat package.json
       - run: npm install
       - run: npm run get
       - run: npm run build


### PR DESCRIPTION
# Goal
Publish terraform-modules to the public NPM repository [pocket-tools](https://www.npmjs.com/settings/pocket-tools/packages).

## Reference

pocket-tools on NPM:
* https://www.npmjs.com/settings/pocket-tools/packages

## Implementation Decisions
- Support users who currently pull this package from Github by pushing to both repositories. We duplicate YML file to achieve this.