### PR TITLE
fix(npm publish): update package.json repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Pocket/terraform-modules.git"
+    "url": "https://github.com/Pocket/terraform-modules.git"
   }
 }


### PR DESCRIPTION
# Goal

Change repository URL in `package.json` to HTTP option.
From https://github.com/Pocket/terraform-modules/runs/3236210614. The workflow requires a github token to access the repository because the repository URL is set as the `ssh` options.