### PR TITLE
chore(release): updating flows to use triggers

### DIFF
--- a/.github/workflows/pre_publish.yml
+++ b/.github/workflows/pre_publish.yml
@@ -1,0 +1,14 @@
+#Steps from https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
+
+name: Pre Publish
+on:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  pre-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deploy the code to another flow"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
 name: GitHub Publish
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - "Pre Publish"
+    types:
+      - completed
 
 jobs:
   publish:


### PR DESCRIPTION
# Goal

Based on the response from GitHub in https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544 let's separate our workflows to allow the main branch to access secrets when a dependabot auto merge has occurred.