### PR TITLE
chore(learning) Adding some tests for RDS

### DIFF
--- a/src/base/ApplicationRDSCluster.spec.ts
+++ b/src/base/ApplicationRDSCluster.spec.ts
@@ -21,3 +21,40 @@ test('renders a RDS cluster', () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test('renders RDS without tags', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new ApplicationRDSCluster(stack, 'testRDSClusterNoTags', {
+    prefix: 'bowling-',
+    vpcId: 'rug',
+    subnetIds: ['0', '1'],
+    rdsConfig: {
+      masterUsername: 'walter',
+      masterPassword: 'bowling',
+      databaseName: 'walter',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders RDS for mysql', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new ApplicationRDSCluster(stack, 'testRDSMysql', {
+    prefix: 'bowling-',
+    vpcId: 'rug',
+    subnetIds: ['0', '1'],
+    rdsConfig: {
+      masterUsername: 'walter',
+      masterPassword: 'bowling',
+      databaseName: 'walter',
+      engine: 'aurora-mysql',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
@@ -1,5 +1,300 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders RDS for mysql 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_vpc\\": {
+      \\"testRDSMysql_vpc_0F718DFC\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"rug\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSMysql/vpc\\",
+            \\"uniqueId\\": \\"testRDSMysql_vpc_0F718DFC\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_security_group\\": {
+      \\"testRDSMysql_rds_security_group_9F25C5EA\\": {
+        \\"description\\": \\"Managed by Terraform\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"\${data.aws_vpc.testRDSMysql_vpc_0F718DFC.cidr_block}\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 3306,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"tcp\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 3306
+          }
+        ],
+        \\"name_prefix\\": \\"bowling-\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testRDSMysql_vpc_0F718DFC.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSMysql/rds_security_group\\",
+            \\"uniqueId\\": \\"testRDSMysql_rds_security_group_9F25C5EA\\"
+          }
+        }
+      }
+    },
+    \\"aws_db_subnet_group\\": {
+      \\"testRDSMysql_rds_subnet_group_436C9689\\": {
+        \\"name_prefix\\": \\"bowling-\\",
+        \\"subnet_ids\\": [
+          \\"0\\",
+          \\"1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSMysql/rds_subnet_group\\",
+            \\"uniqueId\\": \\"testRDSMysql_rds_subnet_group_436C9689\\"
+          }
+        }
+      }
+    },
+    \\"aws_rds_cluster\\": {
+      \\"testRDSMysql_rds_cluster_FBC506B5\\": {
+        \\"cluster_identifier_prefix\\": \\"bowling-\\",
+        \\"copy_tags_to_snapshot\\": true,
+        \\"database_name\\": \\"walter\\",
+        \\"db_subnet_group_name\\": \\"\${aws_db_subnet_group.testRDSMysql_rds_subnet_group_436C9689.name}\\",
+        \\"engine\\": \\"aurora-mysql\\",
+        \\"master_password\\": \\"bowling\\",
+        \\"master_username\\": \\"walter\\",
+        \\"vpc_security_group_ids\\": [
+          \\"\${aws_security_group.testRDSMysql_rds_security_group_9F25C5EA.id}\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"master_username\\",
+            \\"master_password\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSMysql/rds_cluster\\",
+            \\"uniqueId\\": \\"testRDSMysql_rds_cluster_FBC506B5\\"
+          }
+        }
+      }
+    },
+    \\"aws_secretsmanager_secret\\": {
+      \\"testRDSMysql_rds_secret_4844BE15\\": {
+        \\"description\\": \\"Secret For \${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.cluster_identifier}\\",
+        \\"name\\": \\"bowling-/\${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.cluster_identifier}\\",
+        \\"depends_on\\": [
+          \\"aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSMysql/rds_secret\\",
+            \\"uniqueId\\": \\"testRDSMysql_rds_secret_4844BE15\\"
+          }
+        }
+      }
+    },
+    \\"aws_secretsmanager_secret_version\\": {
+      \\"testRDSMysql_rds_secret_version_D9E2E204\\": {
+        \\"secret_id\\": \\"\${aws_secretsmanager_secret.testRDSMysql_rds_secret_4844BE15.id}\\",
+        \\"secret_string\\": \\"{\\\\\\"engine\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.engine}\\\\\\",\\\\\\"host\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.endpoint}\\\\\\",\\\\\\"username\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.master_username}\\\\\\",\\\\\\"password\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.master_password}\\\\\\",\\\\\\"dbname\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSMysql_rds_cluster_FBC506B5.database_name}\\\\\\",\\\\\\"port\\\\\\":3306}\\",
+        \\"depends_on\\": [
+          \\"aws_secretsmanager_secret.testRDSMysql_rds_secret_4844BE15\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSMysql/rds_secret_version\\",
+            \\"uniqueId\\": \\"testRDSMysql_rds_secret_version_D9E2E204\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders RDS without tags 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_vpc\\": {
+      \\"testRDSClusterNoTags_vpc_C1E8C7A8\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"rug\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSClusterNoTags/vpc\\",
+            \\"uniqueId\\": \\"testRDSClusterNoTags_vpc_C1E8C7A8\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_security_group\\": {
+      \\"testRDSClusterNoTags_rds_security_group_18A73219\\": {
+        \\"description\\": \\"Managed by Terraform\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"\${data.aws_vpc.testRDSClusterNoTags_vpc_C1E8C7A8.cidr_block}\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 3306,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"tcp\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 3306
+          }
+        ],
+        \\"name_prefix\\": \\"bowling-\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testRDSClusterNoTags_vpc_C1E8C7A8.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSClusterNoTags/rds_security_group\\",
+            \\"uniqueId\\": \\"testRDSClusterNoTags_rds_security_group_18A73219\\"
+          }
+        }
+      }
+    },
+    \\"aws_db_subnet_group\\": {
+      \\"testRDSClusterNoTags_rds_subnet_group_465E71B0\\": {
+        \\"name_prefix\\": \\"bowling-\\",
+        \\"subnet_ids\\": [
+          \\"0\\",
+          \\"1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSClusterNoTags/rds_subnet_group\\",
+            \\"uniqueId\\": \\"testRDSClusterNoTags_rds_subnet_group_465E71B0\\"
+          }
+        }
+      }
+    },
+    \\"aws_rds_cluster\\": {
+      \\"testRDSClusterNoTags_rds_cluster_23E2E03B\\": {
+        \\"cluster_identifier_prefix\\": \\"bowling-\\",
+        \\"copy_tags_to_snapshot\\": true,
+        \\"database_name\\": \\"walter\\",
+        \\"db_subnet_group_name\\": \\"\${aws_db_subnet_group.testRDSClusterNoTags_rds_subnet_group_465E71B0.name}\\",
+        \\"master_password\\": \\"bowling\\",
+        \\"master_username\\": \\"walter\\",
+        \\"vpc_security_group_ids\\": [
+          \\"\${aws_security_group.testRDSClusterNoTags_rds_security_group_18A73219.id}\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"master_username\\",
+            \\"master_password\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSClusterNoTags/rds_cluster\\",
+            \\"uniqueId\\": \\"testRDSClusterNoTags_rds_cluster_23E2E03B\\"
+          }
+        }
+      }
+    },
+    \\"aws_secretsmanager_secret\\": {
+      \\"testRDSClusterNoTags_rds_secret_17BCD98A\\": {
+        \\"description\\": \\"Secret For \${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.cluster_identifier}\\",
+        \\"name\\": \\"bowling-/\${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.cluster_identifier}\\",
+        \\"depends_on\\": [
+          \\"aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSClusterNoTags/rds_secret\\",
+            \\"uniqueId\\": \\"testRDSClusterNoTags_rds_secret_17BCD98A\\"
+          }
+        }
+      }
+    },
+    \\"aws_secretsmanager_secret_version\\": {
+      \\"testRDSClusterNoTags_rds_secret_version_C8E77601\\": {
+        \\"secret_id\\": \\"\${aws_secretsmanager_secret.testRDSClusterNoTags_rds_secret_17BCD98A.id}\\",
+        \\"secret_string\\": \\"{\\\\\\"engine\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.engine}\\\\\\",\\\\\\"host\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.endpoint}\\\\\\",\\\\\\"username\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.master_username}\\\\\\",\\\\\\"password\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.master_password}\\\\\\",\\\\\\"dbname\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSClusterNoTags_rds_cluster_23E2E03B.database_name}\\\\\\",\\\\\\"port\\\\\\":3306}\\",
+        \\"depends_on\\": [
+          \\"aws_secretsmanager_secret.testRDSClusterNoTags_rds_secret_17BCD98A\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSClusterNoTags/rds_secret_version\\",
+            \\"uniqueId\\": \\"testRDSClusterNoTags_rds_secret_version_C8E77601\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders a RDS cluster 1`] = `
 "{
   \\"//\\": {


### PR DESCRIPTION
# Goal
Learning about cdktf and Jest. Added some tests, this could be helpful *or not*! Feel free to close.

## Todos
None that I am aware of

## Implementation Decisions
I was curious how, or if, you would test things explicitly with `jest` in the snapshot. For example in the mysql test, if I wanted to have something where I ensure that ingress port is correct in the security group. I tried a couple ways to get at that data and wasn't sure what the best approach is there?

```js
expect(Testing.synth(stack)).aws_security_group[0].ingress.from_port).toEqual(3306);
```
