### PR TITLE
Dynamodb on demand mode

### DIFF
--- a/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/src/base/ApplicationDynamoDBTable.spec.ts
@@ -2,6 +2,7 @@ import { Testing, TerraformStack } from 'cdktf';
 import {
   ApplicationDynamoDBTable,
   ApplicationDynamoDBProps,
+  ApplicationDynamoDBTableCapacityMode,
 } from './ApplicationDynamoDBTable';
 
 const BASE_CONFIG: ApplicationDynamoDBProps = {
@@ -180,5 +181,16 @@ test('renders dynamo db table that is not protected from being destroyed', () =>
   expect(applicationDynamoDBTable.dynamodb.lifecycle.preventDestroy).toEqual(
     false
   );
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('renders dynamo db table with on-demand capacity', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  BASE_CONFIG.capacityMode = ApplicationDynamoDBTableCapacityMode.ON_DEMAND;
+
+  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
   expect(Testing.synth(stack)).toMatchSnapshot();
 });

--- a/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/src/base/ApplicationDynamoDBTable.spec.ts
@@ -5,192 +5,198 @@ import {
   ApplicationDynamoDBTableCapacityMode,
 } from './ApplicationDynamoDBTable';
 
-const BASE_CONFIG: ApplicationDynamoDBProps = {
-  prefix: 'abides-',
-  tableConfig: {
-    hashKey: '123',
-    attribute: [
-      {
-        name: 'attribeautiful',
-        type: 'shrugs!',
+describe('ApplicationDynamoDBTable', () => {
+  let BASE_CONFIG: ApplicationDynamoDBProps;
+
+  beforeEach(() => {
+    BASE_CONFIG = {
+      prefix: 'abides-',
+      tableConfig: {
+        hashKey: '123',
+        attribute: [
+          {
+            name: 'attribeautiful',
+            type: 'shrugs!',
+          },
+        ],
+        globalSecondaryIndex: [],
       },
-    ],
-    globalSecondaryIndex: [],
-  },
-};
-
-test('renders dynamo db table with minimal config', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
-
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test('renders dynamo db table with read capacity', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  BASE_CONFIG.readCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
-
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test('renders dynamo db table with write capacity', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  BASE_CONFIG.writeCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
-
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test('renders dynamo db table with read and write capacity', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  BASE_CONFIG.writeCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  BASE_CONFIG.readCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
-
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test('renders dynamo db table with read and write capacity and tags', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  BASE_CONFIG.writeCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  BASE_CONFIG.readCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  BASE_CONFIG.tags = {
-    name: 'thedude',
-    hobby: 'bowling',
-  };
-
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
-
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test('renders dynamo db table global secondary indexes', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  BASE_CONFIG.writeCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  BASE_CONFIG.readCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  BASE_CONFIG.tableConfig.globalSecondaryIndex.push({
-    name: 'card-index',
-    hashKey: 'card-type',
-    rangeKey: 'home_on_the_range',
-    projectionType: 'ALL',
-    readCapacity: 5,
-    writeCapacity: 5,
+    };
   });
 
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+  it('renders dynamo db table with minimal config', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
 
-test('renders dynamo db table with 2 global secondary indexes', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
-
-  BASE_CONFIG.writeCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  BASE_CONFIG.readCapacity = {
-    tracking: 1,
-    max: 10,
-    min: 3,
-  };
-
-  //This test runs after the first secondary index test, so here we just add another index which gives us 2
-  BASE_CONFIG.tableConfig.globalSecondaryIndex.push({
-    name: 'card-index-2',
-    hashKey: 'card-type-123',
-    rangeKey: 'home_home_on_the_range',
-    projectionType: 'ALL',
-    readCapacity: 10,
-    writeCapacity: 10,
+    expect(Testing.synth(stack)).toMatchSnapshot();
   });
 
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+  it('renders dynamo db table with read capacity', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
+    BASE_CONFIG.readCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
 
-test('renders dynamo db table that is not protected from being destroyed', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
 
-  BASE_CONFIG.preventDestroyTable = false;
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
 
-  const applicationDynamoDBTable = new ApplicationDynamoDBTable(
-    stack,
-    'testDynamoDBTable',
-    BASE_CONFIG
-  );
+  it('renders dynamo db table with write capacity', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
 
-  expect(applicationDynamoDBTable.dynamodb.lifecycle.preventDestroy).toEqual(
-    false
-  );
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
+    BASE_CONFIG.writeCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
 
-test('renders dynamo db table with on-demand capacity', () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, 'test');
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
 
-  BASE_CONFIG.capacityMode = ApplicationDynamoDBTableCapacityMode.ON_DEMAND;
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
 
-  new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+  it('renders dynamo db table with read and write capacity', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
+    BASE_CONFIG.writeCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    BASE_CONFIG.readCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders dynamo db table with read and write capacity and tags', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    BASE_CONFIG.writeCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    BASE_CONFIG.readCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    BASE_CONFIG.tags = {
+      name: 'thedude',
+      hobby: 'bowling',
+    };
+
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders dynamo db table global secondary indexes', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    BASE_CONFIG.writeCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    BASE_CONFIG.readCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    BASE_CONFIG.tableConfig.globalSecondaryIndex.push({
+      name: 'card-index',
+      hashKey: 'card-type',
+      rangeKey: 'home_on_the_range',
+      projectionType: 'ALL',
+      readCapacity: 5,
+      writeCapacity: 5,
+    });
+
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders dynamo db table with 2 global secondary indexes', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    BASE_CONFIG.writeCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    BASE_CONFIG.readCapacity = {
+      tracking: 1,
+      max: 10,
+      min: 3,
+    };
+
+    //This test runs after the first secondary index test, so here we just add another index which gives us 2
+    BASE_CONFIG.tableConfig.globalSecondaryIndex.push({
+      name: 'card-index-2',
+      hashKey: 'card-type-123',
+      rangeKey: 'home_home_on_the_range',
+      projectionType: 'ALL',
+      readCapacity: 10,
+      writeCapacity: 10,
+    });
+
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders dynamo db table that is not protected from being destroyed', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    BASE_CONFIG.preventDestroyTable = false;
+
+    const applicationDynamoDBTable = new ApplicationDynamoDBTable(
+      stack,
+      'testDynamoDBTable',
+      BASE_CONFIG
+    );
+
+    expect(applicationDynamoDBTable.dynamodb.lifecycle.preventDestroy).toEqual(
+      false
+    );
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  it('renders dynamo db table with on-demand capacity', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    BASE_CONFIG.capacityMode = ApplicationDynamoDBTableCapacityMode.ON_DEMAND;
+
+    new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
 });

--- a/src/base/ApplicationDynamoDBTable.ts
+++ b/src/base/ApplicationDynamoDBTable.ts
@@ -66,7 +66,7 @@ export class ApplicationDynamoDBTable extends Resource {
     super(scope, name);
 
     const billingMode: string = (
-      config.capacityMode || ApplicationDynamoDBTableCapacityMode.PROVISIONED
+      config.capacityMode ?? ApplicationDynamoDBTableCapacityMode.PROVISIONED
     ).valueOf();
 
     this.dynamodb = new DynamodbTable(this, `dynamodb_table`, {

--- a/src/base/ApplicationDynamoDBTable.ts
+++ b/src/base/ApplicationDynamoDBTable.ts
@@ -46,7 +46,7 @@ export interface ApplicationDynamoDBProps {
   // If capacityMode is ON_DEMAND, the DynamoDB table will have on-demand capacity. By default this is PROVISIONED.
   // On-demand capacity mode is capable of serving thousands of requests per second without capacity planning.
   // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
-  // The readCapacity and writeCapacity properties are ignored if capacityMode is set to ON_DEMAND
+  // The readCapacity and writeCapacity properties should not be used if capacityMode is set to ON_DEMAND.
   capacityMode?: ApplicationDynamoDBTableCapacityMode;
   // If true, the DynamoDB table will be protected from being destroyed. Enabled by default.
   preventDestroyTable?: boolean;

--- a/src/base/ApplicationDynamoDBTable.ts
+++ b/src/base/ApplicationDynamoDBTable.ts
@@ -20,6 +20,11 @@ export enum ApplicationDynamoDBTableCapacityType {
   Write = 'WriteCapacity',
 }
 
+export enum ApplicationDynamoDBTableCapacityMode {
+  PROVISIONED = 'PROVISIONED',
+  ON_DEMAND = 'PAY_PER_REQUEST', // Confusingly, on-demand is called "PAY_PER_REQUEST" in TF and CloudFormation.
+}
+
 export interface ApplicationDynamoDBTableAutoScaleProps {
   tracking: number;
   max: number;
@@ -38,6 +43,11 @@ export interface ApplicationDynamoDBProps {
   tableConfig: ApplicationDynamoDBTableConfig;
   readCapacity?: ApplicationDynamoDBTableAutoScaleProps;
   writeCapacity?: ApplicationDynamoDBTableAutoScaleProps;
+  // If capacityMode is ON_DEMAND, the DynamoDB table will have on-demand capacity. By default this is PROVISIONED.
+  // On-demand capacity mode is capable of serving thousands of requests per second without capacity planning.
+  // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html
+  // The readCapacity and writeCapacity properties are ignored if capacityMode is set to ON_DEMAND
+  capacityMode?: ApplicationDynamoDBTableCapacityMode;
   // If true, the DynamoDB table will be protected from being destroyed. Enabled by default.
   preventDestroyTable?: boolean;
 }
@@ -55,8 +65,13 @@ export class ApplicationDynamoDBTable extends Resource {
   ) {
     super(scope, name);
 
+    const billingMode: string = (
+      config.capacityMode || ApplicationDynamoDBTableCapacityMode.PROVISIONED
+    ).valueOf();
+
     this.dynamodb = new DynamodbTable(this, `dynamodb_table`, {
       ...config.tableConfig,
+      billingMode: billingMode,
       tags: config.tags,
       name: config.prefix,
       lifecycle: {

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders dynamo db table global secondary indexes 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table global secondary indexes 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -15,10 +15,6 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
         \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"attribute\\": [
           {
             \\"name\\": \\"attribeautiful\\",
@@ -76,10 +72,6 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
       \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
         \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
         \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
@@ -90,10 +82,6 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
       \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
         \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
         \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role\\",
@@ -432,7 +420,7 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table that is not protected from being destroyed 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table that is not protected from being destroyed 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -447,34 +435,13 @@ exports[`renders dynamo db table that is not protected from being destroyed 1`] 
         \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"attribute\\": [
           {
             \\"name\\": \\"attribeautiful\\",
             \\"type\\": \\"shrugs!\\"
           }
         ],
-        \\"global_secondary_index\\": [
-          {
-            \\"hash_key\\": \\"card-type\\",
-            \\"name\\": \\"card-index\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_on_the_range\\",
-            \\"read_capacity\\": 5,
-            \\"write_capacity\\": 5
-          },
-          {
-            \\"hash_key\\": \\"card-type-123\\",
-            \\"name\\": \\"card-index-2\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_home_on_the_range\\",
-            \\"read_capacity\\": 10,
-            \\"write_capacity\\": 10
-          }
-        ],
+        \\"global_secondary_index\\": [],
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"read_capacity\\",
@@ -489,478 +456,12 @@ exports[`renders dynamo db table that is not protected from being destroyed 1`] 
           }
         }
       }
-    },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\",
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_autoscaling_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\",
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_autoscaling_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
-          }
-        }
-      }
-    },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\"
-          }
-        }
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\",
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role_attachment\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\",
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role_attachment\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\"
-          }
-        }
-      }
-    },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 10,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 10,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\"
-          }
-        }
-      }
-    },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_ReadCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index-2_WriteCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\"
-          }
-        }
-      }
-    }
-  },
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
-            ]
-          },
-          {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_assume_role_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
-            ]
-          },
-          {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_assume_role_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\"
-          }
-        }
-      }
     }
   }
 }"
 `;
 
-exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with 2 global secondary indexes 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -975,10 +476,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
         \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"attribute\\": [
           {
             \\"name\\": \\"attribeautiful\\",
@@ -986,14 +483,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
           }
         ],
         \\"global_secondary_index\\": [
-          {
-            \\"hash_key\\": \\"card-type\\",
-            \\"name\\": \\"card-index\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_on_the_range\\",
-            \\"read_capacity\\": 5,
-            \\"write_capacity\\": 5
-          },
           {
             \\"hash_key\\": \\"card-type-123\\",
             \\"name\\": \\"card-index-2\\",
@@ -1044,10 +533,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
       \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
         \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
         \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
@@ -1058,10 +543,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
       \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
         \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
         \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"name\\": \\"thedude\\",
-          \\"hobby\\": \\"bowling\\"
-        },
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/WriteCapacity_role\\",
@@ -1118,23 +599,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
           }
         }
       },
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\": {
         \\"max_capacity\\": 10,
         \\"min_capacity\\": 10,
@@ -1166,23 +630,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_target\\",
             \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\"
           }
         }
       },
@@ -1229,33 +676,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_policy\\",
             \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_ReadCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\"
           }
         }
       },
@@ -1310,33 +730,6 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
           \\"metadata\\": {
             \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_WriteCapacity_table_policy\\",
             \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\": {
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/card-index_WriteCapacity_index_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\"
           }
         }
       },
@@ -1488,7 +881,7 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with minimal config 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with minimal config 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -1529,7 +922,7 @@ exports[`renders dynamo db table with minimal config 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with on-demand capacity 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with on-demand capacity 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -1570,7 +963,7 @@ exports[`renders dynamo db table with on-demand capacity 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with read and write capacity 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with read and write capacity 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -1893,7 +1286,7 @@ exports[`renders dynamo db table with read and write capacity 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with read and write capacity and tags 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with read and write capacity and tags 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -2228,7 +1621,7 @@ exports[`renders dynamo db table with read and write capacity and tags 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with read capacity 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with read capacity 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -2417,7 +1810,7 @@ exports[`renders dynamo db table with read capacity 1`] = `
 }"
 `;
 
-exports[`renders dynamo db table with write capacity 1`] = `
+exports[`ApplicationDynamoDBTable renders dynamo db table with write capacity 1`] = `
 "{
   \\"//\\": {
     \\"metadata\\": {
@@ -2455,16 +1848,6 @@ exports[`renders dynamo db table with write capacity 1`] = `
       }
     },
     \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\",
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_autoscaling_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
         \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
         \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\",
@@ -2477,16 +1860,6 @@ exports[`renders dynamo db table with write capacity 1`] = `
       }
     },
     \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
         \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
         \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
@@ -2499,20 +1872,6 @@ exports[`renders dynamo db table with write capacity 1`] = `
       }
     },
     \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\",
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_role_attachment\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
         \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
         \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\",
@@ -2529,23 +1888,6 @@ exports[`renders dynamo db table with write capacity 1`] = `
       }
     },
     \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\": {
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\",
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_target\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9\\": {
         \\"max_capacity\\": 10,
         \\"min_capacity\\": 3,
@@ -2565,33 +1907,6 @@ exports[`renders dynamo db table with write capacity 1`] = `
       }
     },
     \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\": {
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": [
-          {
-            \\"target_value\\": 1,
-            \\"predefined_metric_specification\\": [
-              {
-                \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
-              }
-            ]
-          }
-        ],
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_target_03D4A1F8\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}_ReadCapacity_table_policy\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_ReadCapacity_table_policy_241DE9BD\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_policy_BF7F6E3E\\": {
         \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_aws_dynamodb_tabletestDynamoDBTable_dynamodb_table_A3DD49A4name_WriteCapacity_table_target_8AAAA7D9.resource_id}\\",
         \\"policy_type\\": \\"TargetTrackingScaling\\",
@@ -2623,62 +1938,6 @@ exports[`renders dynamo db table with write capacity 1`] = `
   },
   \\"data\\": {
     \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
-            ]
-          },
-          {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\"
-          }
-        }
-      },
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"//\\": {
-          \\"metadata\\": {
-            \\"path\\": \\"test/testDynamoDBTable/ReadCapacity_assume_role_policy_document\\",
-            \\"uniqueId\\": \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\"
-          }
-        }
-      },
       \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
         \\"statement\\": [
           {

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -1529,6 +1529,47 @@ exports[`renders dynamo db table with minimal config 1`] = `
 }"
 `;
 
+exports[`renders dynamo db table with on-demand capacity 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
+    }
+  },
+  \\"resource\\": {
+    \\"aws_dynamodb_table\\": {
+      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
+        \\"hash_key\\": \\"123\\",
+        \\"name\\": \\"abides-\\",
+        \\"attribute\\": [
+          {
+            \\"name\\": \\"attribeautiful\\",
+            \\"type\\": \\"shrugs!\\"
+          }
+        ],
+        \\"global_secondary_index\\": [],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"read_capacity\\",
+            \\"write_capacity\\"
+          ],
+          \\"prevent_destroy\\": true
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testDynamoDBTable/dynamodb_table\\",
+            \\"uniqueId\\": \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders dynamo db table with read and write capacity 1`] = `
 "{
   \\"//\\": {

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -12,6 +12,7 @@ exports[`renders dynamo db table global secondary indexes 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"tags\\": {
@@ -443,6 +444,7 @@ exports[`renders dynamo db table that is not protected from being destroyed 1`] 
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"tags\\": {
@@ -970,6 +972,7 @@ exports[`renders dynamo db table with 2 global secondary indexes 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"tags\\": {
@@ -1497,6 +1500,7 @@ exports[`renders dynamo db table with minimal config 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"attribute\\": [
@@ -1537,6 +1541,7 @@ exports[`renders dynamo db table with read and write capacity 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"attribute\\": [
@@ -1859,6 +1864,7 @@ exports[`renders dynamo db table with read and write capacity and tags 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"tags\\": {
@@ -2193,6 +2199,7 @@ exports[`renders dynamo db table with read capacity 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"attribute\\": [
@@ -2381,6 +2388,7 @@ exports[`renders dynamo db table with write capacity 1`] = `
   \\"resource\\": {
     \\"aws_dynamodb_table\\": {
       \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
         \\"hash_key\\": \\"123\\",
         \\"name\\": \\"abides-\\",
         \\"attribute\\": [


### PR DESCRIPTION
# Goal
Add an option to ApplicationDynamoDBTable set the capacity mode to [on-demand](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html). The default will remain provisioned capacity.

## Review
See Implementation Decisions below.

## Reference

Documentation here:
* https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html

Tickets:
* https://getpocket.atlassian.net/browse/HOMPER-42

## Implementation Decisions
- AWS is inconsistent about how it calls 'on-demand' capacity. In the AWS Console and in documentation the capacity mode is called 'on-demand', but in CloudFormation (which Terraform is based on) it is called 'PAY_PER_REQUEST'. Additionally 'capacity mode' is called 'billing mode'. I'd like the Terraform-Modules interface to use the more readable on-demand language, and used an `enum` to map the terminology. Is there a better way to do this than through an `enum`?