### PR TITLE
feat(rds): Add an optional database URL to RDS secret

### DIFF
--- a/src/base/ApplicationRDSCluster.spec.ts
+++ b/src/base/ApplicationRDSCluster.spec.ts
@@ -21,3 +21,25 @@ test('renders a RDS cluster', () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test('renders a RDS cluster with a database URL', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new ApplicationRDSCluster(stack, 'testRDSCluster', {
+    prefix: 'bowling-',
+    vpcId: 'rug',
+    subnetIds: ['0', '1'],
+    rdsConfig: {
+      masterUsername: 'walter',
+      masterPassword: 'bowling',
+      databaseName: 'walter',
+      engine: 'aurora-mysql',
+    },
+    tags: {
+      whodis: 'walter',
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/src/base/ApplicationRDSCluster.ts
+++ b/src/base/ApplicationRDSCluster.ts
@@ -127,7 +127,8 @@ export class ApplicationRDSCluster extends Resource {
       this.rds,
       rdsPort,
       config.prefix,
-      config.tags
+      config.tags,
+      config.rdsConfig.engine
     );
 
     this.secretARN = secretARN;
@@ -148,7 +149,8 @@ export class ApplicationRDSCluster extends Resource {
     rds: RdsCluster,
     rdsPort: number,
     prefix: string,
-    tags?: { [key: string]: string }
+    tags?: { [key: string]: string },
+    engine?: ApplicationRDSClusterConfig['engine']
   ): { secretARN: string } {
     //Create the secret
     const secret = new SecretsmanagerSecret(scope, `rds_secret`, {
@@ -177,7 +179,7 @@ export class ApplicationRDSCluster extends Resource {
     };
 
     // Add a database URL to a MySQL-compatible Aurora instance
-    if (rds.engine === 'aurora-mysql') {
+    if (engine && engine === 'aurora-mysql') {
       secretValues.database_url = `mysql://${rds.masterUsername}:${rds.masterPassword}@${rds.endpoint}:${rdsPort}/${rds.databaseName}`;
     }
 

--- a/src/base/ApplicationRDSCluster.ts
+++ b/src/base/ApplicationRDSCluster.ts
@@ -36,11 +36,11 @@ export interface ApplicationRDSClusterProps {
 }
 
 /**
- * Generates a rds cluster
+ * Generates an RDS cluster
  *
- * The database will be intialized with a random password.
+ * The database will be initialized with a random password.
  *
- * If the database is aurua or mysql, a SecretsManager secret will be created with a rotation lambda
+ * If the database is Aurora or MySQL, a SecretsManager secret will be created with a rotation lambda
  * that you can invoke in the AWS console after creation to rotate the password
  */
 export class ApplicationRDSCluster extends Resource {
@@ -159,17 +159,32 @@ export class ApplicationRDSCluster extends Resource {
       dependsOn: [rds],
     });
 
+    const secretValues: {
+      engine: string;
+      host: string;
+      username: string;
+      password: string;
+      dbname: string;
+      port: number;
+      database_url?: string;
+    } = {
+      engine: rds.engine,
+      host: rds.endpoint,
+      username: rds.masterUsername,
+      password: rds.masterPassword,
+      dbname: rds.databaseName,
+      port: rdsPort,
+    };
+
+    // Add a database URL to a MySQL-compatible Aurora instance
+    if (rds.engine === 'aurora-mysql') {
+      secretValues.database_url = `mysql://${rds.masterUsername}:${rds.masterPassword}@${rds.endpoint}:${rdsPort}/${rds.databaseName}`;
+    }
+
     //Create the initial secret version
     new SecretsmanagerSecretVersion(scope, `rds_secret_version`, {
       secretId: secret.id,
-      secretString: JSON.stringify({
-        engine: rds.engine,
-        host: rds.endpoint,
-        username: rds.masterUsername,
-        password: rds.masterPassword,
-        dbname: rds.databaseName,
-        port: rdsPort,
-      }),
+      secretString: JSON.stringify(secretValues),
       dependsOn: [secret],
     });
 

--- a/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
@@ -149,3 +149,154 @@ exports[`renders a RDS cluster 1`] = `
   }
 }"
 `;
+
+exports[`renders a RDS cluster with a database URL 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
+    }
+  },
+  \\"data\\": {
+    \\"aws_vpc\\": {
+      \\"testRDSCluster_vpc_F47EEEFE\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"rug\\"
+            ]
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSCluster/vpc\\",
+            \\"uniqueId\\": \\"testRDSCluster_vpc_F47EEEFE\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_security_group\\": {
+      \\"testRDSCluster_rds_security_group_4A9D257E\\": {
+        \\"description\\": \\"Managed by Terraform\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.cidr_block}\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 3306,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"tcp\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 3306
+          }
+        ],
+        \\"name_prefix\\": \\"bowling-\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSCluster/rds_security_group\\",
+            \\"uniqueId\\": \\"testRDSCluster_rds_security_group_4A9D257E\\"
+          }
+        }
+      }
+    },
+    \\"aws_db_subnet_group\\": {
+      \\"testRDSCluster_rds_subnet_group_88022457\\": {
+        \\"name_prefix\\": \\"bowling-\\",
+        \\"subnet_ids\\": [
+          \\"0\\",
+          \\"1\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSCluster/rds_subnet_group\\",
+            \\"uniqueId\\": \\"testRDSCluster_rds_subnet_group_88022457\\"
+          }
+        }
+      }
+    },
+    \\"aws_rds_cluster\\": {
+      \\"testRDSCluster_rds_cluster_B5FD08B5\\": {
+        \\"cluster_identifier_prefix\\": \\"bowling-\\",
+        \\"copy_tags_to_snapshot\\": true,
+        \\"database_name\\": \\"walter\\",
+        \\"db_subnet_group_name\\": \\"\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}\\",
+        \\"engine\\": \\"aurora-mysql\\",
+        \\"master_password\\": \\"bowling\\",
+        \\"master_username\\": \\"walter\\",
+        \\"tags\\": {
+          \\"whodis\\": \\"walter\\"
+        },
+        \\"vpc_security_group_ids\\": [
+          \\"\${aws_security_group.testRDSCluster_rds_security_group_4A9D257E.id}\\"
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"master_username\\",
+            \\"master_password\\"
+          ]
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSCluster/rds_cluster\\",
+            \\"uniqueId\\": \\"testRDSCluster_rds_cluster_B5FD08B5\\"
+          }
+        }
+      }
+    },
+    \\"aws_secretsmanager_secret\\": {
+      \\"testRDSCluster_rds_secret_A2014138\\": {
+        \\"description\\": \\"Secret For \${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}\\",
+        \\"name\\": \\"bowling-/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}\\",
+        \\"depends_on\\": [
+          \\"aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSCluster/rds_secret\\",
+            \\"uniqueId\\": \\"testRDSCluster_rds_secret_A2014138\\"
+          }
+        }
+      }
+    },
+    \\"aws_secretsmanager_secret_version\\": {
+      \\"testRDSCluster_rds_secret_version_55C44893\\": {
+        \\"secret_id\\": \\"\${aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138.id}\\",
+        \\"secret_string\\": \\"{\\\\\\"engine\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.engine}\\\\\\",\\\\\\"host\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}\\\\\\",\\\\\\"username\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}\\\\\\",\\\\\\"password\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}\\\\\\",\\\\\\"dbname\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\\\\\",\\\\\\"port\\\\\\":3306,\\\\\\"database_url\\\\\\":\\\\\\"mysql://\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}:\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}@\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}:3306/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\\\\\"}\\",
+        \\"depends_on\\": [
+          \\"aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/testRDSCluster/rds_secret_version\\",
+            \\"uniqueId\\": \\"testRDSCluster_rds_secret_version_55C44893\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;


### PR DESCRIPTION
# Goal

Have the package generate the value for database URL in RDS secrets. Since I'm not sure what the connection URL is for `aurora` and `aurora-postgresql` engines, I'm only setting it if the engine is `aurora-mysql` so as not to affect anything else downstream. Would love to be able to implement it for all engine types though.

## Implementation Decisions

- Add a database URL for MySQL-compatible Aurora instances.

- Fix typos in comments.

