### PR TITLE
chore(CI): Increase number of workers to 3 for jest in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
     "watch": "tsc -w",
-    "test-ci": "npm test -- --no-cache --maxWorkers=2",
+    "test-ci": "npm test -- --no-cache --maxWorkers=3",
     "test:watch": "npm test -- --watch --watch-extensions ts -R min --watch-files src",
     "test": "jest",
     "upgrade": "npm i cdktf@latest cdktf-cli@latest",


### PR DESCRIPTION
## Goal
Increase the resources available to jest for tests. Set `maxWorkers` to 3
Reference: https://jestjs.io/docs/configuration#maxworkers-number--string


