### PR TITLE
fix(lambda): Fix Lambda alias function version

### DIFF
--- a/src/base/ApplicationVersionedLambda.ts
+++ b/src/base/ApplicationVersionedLambda.ts
@@ -98,17 +98,15 @@ export class ApplicationVersionedLambda extends Resource {
       dependsOn: [lambda],
     });
 
-    const lambdaAlias = new LambdaFunction.LambdaAlias(this, 'alias', {
+    return new LambdaFunction.LambdaAlias(this, 'alias', {
       functionName: lambda.functionName,
-      functionVersion: Fn.element(Fn.split(':', lambda.fqn), 7),
+      functionVersion: Fn.element(Fn.split(':', lambda.qualifiedArn), 7),
       name: 'DEPLOYED',
       lifecycle: {
         ignoreChanges: ['function_version'],
       },
       dependsOn: [lambda],
     });
-
-    return lambdaAlias;
   }
 
   private shouldIgnorePublish() {
@@ -191,7 +189,7 @@ export class ApplicationVersionedLambda extends Resource {
     const functionName = handler.pop();
     const functionFilename = handler.join('.');
 
-    let content = `export const ${functionName} = (event, context) => { console.log(event) }`;
+    let content = `exports.${functionName} = (event, context) => { console.log(event) }`;
     let filename = `${functionFilename}.js`;
 
     if (runtime === 'python') {

--- a/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
         \\"output_path\\": \\"index.js.zip\\",
         \\"source\\": [
           {
-            \\"content\\": \\"export const handler = (event, context) => { console.log(event) }\\",
+            \\"content\\": \\"exports.handler = (event, context) => { console.log(event) }\\",
             \\"filename\\": \\"index.js\\"
           }
         ],
@@ -93,7 +93,7 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -231,7 +231,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -369,7 +369,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with description 
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -507,7 +507,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with environment 
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -660,7 +660,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with execution po
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -798,7 +798,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with log retentio
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -936,7 +936,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with publish igno
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1075,7 +1075,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1213,7 +1213,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1359,7 +1359,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] 
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1510,7 +1510,7 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with vpc 1`] = `
           \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-versioned-lambda_D818669D\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -111,7 +111,7 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
           \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -281,7 +281,7 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
           \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"

--- a/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
@@ -130,7 +130,7 @@ exports[`renders a lambda triggered by an existing sqs queue 1`] = `
           \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -306,7 +306,7 @@ exports[`renders a plain sqs queue and lambda target 1`] = `
           \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -488,7 +488,7 @@ exports[`renders a plain sqs queue with a deadletter and lambda target 1`] = `
           \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"

--- a/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -115,7 +115,7 @@ exports[`it can treat missing data as breaching 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -253,7 +253,7 @@ exports[`renders a lambda target 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -391,7 +391,7 @@ exports[`renders a lambda target with tags 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -639,7 +639,7 @@ exports[`renders a lambda with alarms 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -848,7 +848,7 @@ exports[`renders a lambda with code deploy 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -987,7 +987,7 @@ exports[`renders a lambda with environment variables 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1140,7 +1140,7 @@ exports[`renders a lambda with execution policy 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1278,7 +1278,7 @@ exports[`renders a lambda with lambda description 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1416,7 +1416,7 @@ exports[`renders a lambda with log retention 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1554,7 +1554,7 @@ exports[`renders a lambda with s3 bucket 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1692,7 +1692,7 @@ exports[`renders a lambda with timeout 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"
@@ -1843,7 +1843,7 @@ exports[`renders a lambda with vpc config 1`] = `
           \\"aws_lambda_function.test-lambda_8915D118\\"
         ],
         \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", \\\\\\"aws_lambda_function.test-lambda_8915D118\\\\\\"), 7)}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
         \\"lifecycle\\": {
           \\"ignore_changes\\": [
             \\"function_version\\"


### PR DESCRIPTION
## Goal
Get the function version correctly from the function's qualified arn instead of the FQN to avoid a validation error
![Screen Shot 2021-11-16 at 10 39 27 AM](https://user-images.githubusercontent.com/10347996/142045703-64293bd4-fbe0-41bc-9800-d4c9626ec3aa.png)

Qualified ARN format example: `arn:aws:lambda:aws-region:acct-id:function:helloworld:42` ([Source](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html#versioning-versions-using))
