### PR TITLE
feat(providers): Add providers in resource constructs

### DIFF
--- a/src/base/ApplicationECSService.ts
+++ b/src/base/ApplicationECSService.ts
@@ -1,5 +1,5 @@
-import { ECS, ECR, CloudWatch, VPC, ELB } from '@cdktf/provider-aws';
-import { Resource } from '@cdktf/provider-null';
+import { CloudWatch, ECR, ECS, ELB, VPC } from '@cdktf/provider-aws';
+import { NullProvider, Resource } from '@cdktf/provider-null';
 import { Construct } from 'constructs';
 import { ApplicationECR, ECRProps } from './ApplicationECR';
 import { ApplicationECSIAM, ApplicationECSIAMProps } from './ApplicationECSIAM';
@@ -11,7 +11,7 @@ import { ApplicationTargetGroup } from './ApplicationTargetGroup';
 import { ApplicationECSAlbCodeDeploy } from './ApplicationECSAlbCodeDeploy';
 import { TerraformResource } from 'cdktf';
 import { truncateString } from '../utilities';
-import { File } from '@cdktf/provider-local';
+import { File, LocalProvider } from '@cdktf/provider-local';
 
 export interface ApplicationECSServiceProps {
   prefix: string;
@@ -64,6 +64,9 @@ export class ApplicationECSService extends Resource {
     config: ApplicationECSServiceProps
   ) {
     super(scope, name);
+
+    new NullProvider(this, 'ecs-null-provider');
+    new LocalProvider(this, 'ecs-local-provider');
 
     // populate defaults for some values if not provided
     this.config = ApplicationECSService.hydrateConfig(config);

--- a/src/base/ApplicationVersionedLambda.ts
+++ b/src/base/ApplicationVersionedLambda.ts
@@ -2,6 +2,7 @@ import { Fn, Resource } from 'cdktf';
 import { Construct } from 'constructs';
 import { CloudWatch, IAM, LambdaFunction, S3 } from '@cdktf/provider-aws';
 import {
+  ArchiveProvider,
   DataArchiveFile,
   DataArchiveFileSource,
 } from '@cdktf/provider-archive';
@@ -40,6 +41,8 @@ export class ApplicationVersionedLambda extends Resource {
     private config: ApplicationVersionedLambdaProps
   ) {
     super(scope, name);
+
+    new ArchiveProvider(this, 'archive');
 
     this.createCodeBucket();
     this.versionedLambda = this.createLambdaFunction();

--- a/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -25,129 +25,13 @@ exports[`ApplicationECSService renders an ECS service with code deploy 1`] = `
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
-        },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
-          ]
-        },
-        \\"load_balancer\\": [],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
-          ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
-          ]
-        },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
-      }
-    },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
-        ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": []
-      }
-    },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
-      },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
-      }
-    },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
-          {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
-            ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [],
-            \\"prefix_list_ids\\": [],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [],
-            \\"self\\": null,
-            \\"to_port\\": 0
-          }
-        ],
-        \\"ingress\\": [],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
-        },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
-      }
-    },
-    \\"null_resource\\": {
-      \\"testECSService\\": {}
-    }
-  }
-}"
-`;
-
-exports[`ApplicationECSService renders an ECS service with code deploy and excludes the code deployment command resource when useCodePipeline is true 1`] = `
-"{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"version\\": \\"2012-10-17\\"
-      }
-    }
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_ecs_service\\": {
@@ -244,6 +128,162 @@ exports[`ApplicationECSService renders an ECS service with code deploy and exclu
     \\"null_resource\\": {
       \\"testECSService\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationECSService renders an ECS service with code deploy and excludes the code deployment command resource when useCodePipeline is true 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      }
+    }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"aws_ecs_service\\": {
+      \\"testECSService_ecs-service_33F309B3\\": {
+        \\"cluster\\": \\"gorp\\",
+        \\"depends_on\\": [],
+        \\"deployment_controller\\": {
+          \\"type\\": \\"CODE_DEPLOY\\"
+        },
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\",
+            \\"task_definition\\"
+          ]
+        },
+        \\"load_balancer\\": [],
+        \\"name\\": \\"abides-dev\\",
+        \\"network_configuration\\": {
+          \\"security_groups\\": [
+            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+          ],
+          \\"subnets\\": [
+            \\"1.1.1.1\\",
+            \\"2.2.2.2\\"
+          ]
+        },
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testECSService_ecs-task_A268C927\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"depends_on\\": [],
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
+        \\"family\\": \\"abides-dev\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
+        \\"volume\\": []
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
+        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+      },
+      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
+        \\"name\\": \\"abides-dev-TaskRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
+        \\"policy_arn\\": \\"someArn\\",
+        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testECSService_ecs_security_group_67979722\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"myhouse\\"
+      }
+    },
+    \\"null_resource\\": {
+      \\"testECSService\\": {}
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -272,6 +312,14 @@ exports[`ApplicationECSService renders an ECS service with full container defini
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_ecs_service\\": {
@@ -368,6 +416,18 @@ exports[`ApplicationECSService renders an ECS service with full container defini
     \\"null_resource\\": {
       \\"testECSService\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -396,6 +456,14 @@ exports[`ApplicationECSService renders an ECS service with full container defini
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_alb_listener_rule\\": {
@@ -560,6 +628,18 @@ exports[`ApplicationECSService renders an ECS service with full container defini
     \\"null_resource\\": {
       \\"testECSService\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -588,6 +668,14 @@ exports[`ApplicationECSService renders an ECS service with minimal config 1`] = 
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_ecs_service\\": {
@@ -683,6 +771,18 @@ exports[`ApplicationECSService renders an ECS service with minimal config 1`] = 
     \\"null_resource\\": {
       \\"testECSService\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -711,6 +811,14 @@ exports[`ApplicationECSService renders an ECS service with mountPoints deduplica
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -881,6 +989,18 @@ exports[`ApplicationECSService renders an ECS service with mountPoints deduplica
     \\"null_resource\\": {
       \\"testECSService\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -909,6 +1029,14 @@ exports[`ApplicationECSService renders an ECS service without a log group contai
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1011,6 +1139,18 @@ exports[`ApplicationECSService renders an ECS service without a log group contai
     \\"null_resource\\": {
       \\"testECSService\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -1039,6 +1179,14 @@ exports[`ApplicationECSService renders an ECS service without an image container
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_ecr_lifecycle_policy\\": {
@@ -1155,6 +1303,18 @@ exports[`ApplicationECSService renders an ECS service without an image container
     },
     \\"null_resource\\": {
       \\"testECSService\\": {}
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
     }
   }
 }"

--- a/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
@@ -55,6 +55,11 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
       }
     }
   },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
+  },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
       \\"test-versioned-lambda_log-group_CB8A67E7\\": {
@@ -134,6 +139,14 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -192,6 +205,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -270,6 +288,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
         \\"block_public_acls\\": true,
         \\"block_public_policy\\": true,
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
       }
     }
   }
@@ -331,6 +357,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with description 
       }
     }
   },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
+  },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
       \\"test-versioned-lambda_log-group_CB8A67E7\\": {
@@ -410,6 +441,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with description 
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -468,6 +507,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with environment 
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -554,6 +598,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with environment 
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -621,6 +673,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with execution po
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -701,6 +758,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with execution po
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -759,6 +824,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with log retentio
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -839,6 +909,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with log retentio
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -897,6 +975,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with publish igno
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -978,6 +1061,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with publish igno
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1036,6 +1127,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1116,6 +1212,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1174,6 +1278,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1262,6 +1371,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1320,6 +1437,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] 
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1400,6 +1522,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] 
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1471,6 +1601,11 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with vpc 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1559,6 +1694,14 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with vpc 1`] = `
         \\"block_public_acls\\": true,
         \\"block_public_policy\\": true,
         \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
       }
     }
   }

--- a/src/example.ts
+++ b/src/example.ts
@@ -13,8 +13,6 @@ class Example extends TerraformStack {
     new AwsProvider(this, 'aws', {
       region: 'us-east-1',
     });
-    new LocalProvider(this, 'local', {});
-    new NullProvider(this, 'null', {});
 
     const containerConfigBlue: ApplicationECSContainerDefinitionProps = {
       name: 'blueContainer',

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -163,6 +163,14 @@ exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
       }
     }
   },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
+  },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
       \\"testPocketApp_alb_certificate_417C14FF\\": {
@@ -730,6 +738,18 @@ exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
         }
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -896,6 +916,14 @@ exports[`PocketALBApplication renders an Pocket App with code deploy and creates
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -1449,6 +1477,18 @@ exports[`PocketALBApplication renders an Pocket App with code deploy and creates
         }
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -1597,6 +1637,14 @@ exports[`PocketALBApplication renders an Pocket App with logs and dashboard in a
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -2042,6 +2090,18 @@ exports[`PocketALBApplication renders an Pocket App with logs and dashboard in a
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -2190,6 +2250,14 @@ exports[`PocketALBApplication renders an application alarms 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -2657,6 +2725,18 @@ exports[`PocketALBApplication renders an application alarms 1`] = `
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -2805,6 +2885,14 @@ exports[`PocketALBApplication renders an application custom default alarms 1`] =
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -3263,6 +3351,18 @@ exports[`PocketALBApplication renders an application custom default alarms 1`] =
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -3411,6 +3511,14 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -3904,6 +4012,18 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -4052,6 +4172,14 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -4497,6 +4625,18 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -4645,6 +4785,14 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -5138,6 +5286,18 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -5286,6 +5446,14 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -5731,6 +5899,18 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -5879,6 +6059,14 @@ exports[`PocketALBApplication renders an application with modified container def
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -6350,6 +6538,18 @@ exports[`PocketALBApplication renders an application with modified container def
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -6498,6 +6698,14 @@ exports[`PocketALBApplication renders an external application 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -7063,6 +7271,18 @@ exports[`PocketALBApplication renders an external application 1`] = `
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -7211,6 +7431,14 @@ exports[`PocketALBApplication renders an internal application 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -7656,6 +7884,18 @@ exports[`PocketALBApplication renders an internal application 1`] = `
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
   }
 }"
 `;
@@ -7804,6 +8044,14 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"local\\": [
+      {}
+    ],
+    \\"null\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_acm_certificate\\": {
@@ -8296,6 +8544,18 @@ exports[`PocketALBApplication renders an internal application with tags 1`] = `
     },
     \\"null_resource\\": {
       \\"testPocketApp_ecs_service_8F213571\\": {}
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"local\\": {
+        \\"source\\": \\"hashicorp/local\\",
+        \\"version\\": \\"~> 2.1\\"
+      },
+      \\"null\\": {
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"~> 2.0\\"
+      }
     }
   }
 }"

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -55,6 +55,11 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
       }
     }
   },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
+  },
   \\"resource\\": {
     \\"aws_cloudwatch_event_rule\\": {
       \\"test-event-bridge-lambda_event-bridge-rule_529FF7C2\\": {
@@ -165,6 +170,14 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -223,6 +236,11 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_event_rule\\": {
@@ -333,6 +351,14 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
         \\"block_public_acls\\": true,
         \\"block_public_policy\\": true,
         \\"bucket\\": \\"\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
@@ -77,6 +77,11 @@ exports[`renders a lambda triggered by an existing sqs queue 1`] = `
       }
     }
   },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
+  },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
       \\"test-sqs-lambda_log-group_F69AB78F\\": {
@@ -177,6 +182,14 @@ exports[`renders a lambda triggered by an existing sqs queue 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -252,6 +265,11 @@ exports[`renders a plain sqs queue and lambda target 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -359,6 +377,14 @@ exports[`renders a plain sqs queue and lambda target 1`] = `
         \\"name\\": \\"test-sqs-lambda-Queue\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -434,6 +460,11 @@ exports[`renders a plain sqs queue with a deadletter and lambda target 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -544,6 +575,14 @@ exports[`renders a plain sqs queue with a deadletter and lambda target 1`] = `
       \\"test-sqs-lambda_lambda_sqs_queue_redrive_sqs_queue_EBFF9A33\\": {
         \\"fifo_queue\\": false,
         \\"name\\": \\"test-sqs-lambda-Queue-Deadletter\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -55,6 +55,11 @@ exports[`it can treat missing data as breaching 1`] = `
       }
     }
   },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
+  },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
       \\"test-lambda_log-group_ACC182B5\\": {
@@ -156,6 +161,14 @@ exports[`it can treat missing data as breaching 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -214,6 +227,11 @@ exports[`renders a lambda target 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -294,6 +312,14 @@ exports[`renders a lambda target 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -352,6 +378,11 @@ exports[`renders a lambda target with tags 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -440,6 +471,14 @@ exports[`renders a lambda target with tags 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -498,6 +537,11 @@ exports[`renders a lambda with alarms 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -680,6 +724,14 @@ exports[`renders a lambda with alarms 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -756,6 +808,11 @@ exports[`renders a lambda with code deploy 1`] = `
         ]
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -890,6 +947,14 @@ exports[`renders a lambda with code deploy 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -948,6 +1013,11 @@ exports[`renders a lambda with environment variables 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1034,6 +1104,14 @@ exports[`renders a lambda with environment variables 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1102,143 +1180,10 @@ exports[`renders a lambda with execution policy 1`] = `
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
-        ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
-      }
-    },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
-      }
-    },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
-      }
-    },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
-        ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
-      }
-    },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
-        ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
-          ]
-        },
-        \\"name\\": \\"DEPLOYED\\"
-      }
-    },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
-          ]
-        },
-        \\"publish\\": true,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
-      }
-    },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
-      }
-    },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
-      }
-    }
-  }
-}"
-`;
-
-exports[`renders a lambda with lambda description 1`] = `
-"{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
-          {
-            \\"content\\": \\"handler(event, context):\\\\n\\\\t print(event)\\",
-            \\"filename\\": \\"index.py\\"
-          }
-        ],
-        \\"type\\": \\"zip\\"
-      }
-    },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
-              {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
-                ],
-                \\"type\\": \\"Service\\"
-              }
-            ]
-          }
-        ],
-        \\"version\\": \\"2012-10-17\\"
-      },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
-          {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
-            ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
-            ]
-          }
-        ],
-        \\"version\\": \\"2012-10-17\\"
-      }
-    }
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1319,6 +1264,165 @@ exports[`renders a lambda with lambda description 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a lambda with lambda description 1`] = `
+"{
+  \\"data\\": {
+    \\"archive_file\\": {
+      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
+        \\"output_path\\": \\"index.py.zip\\",
+        \\"source\\": [
+          {
+            \\"content\\": \\"handler(event, context):\\\\n\\\\t print(event)\\",
+            \\"filename\\": \\"index.py\\"
+          }
+        ],
+        \\"type\\": \\"zip\\"
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda_assume-policy-document_D538087D\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"lambda.amazonaws.com\\",
+                  \\"edgelambda.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      },
+      \\"test-lambda_execution-policy-document_D94D17B4\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"logs:CreateLogGroup\\",
+              \\"logs:CreateLogStream\\",
+              \\"logs:PutLogEvents\\",
+              \\"logs:DescribeLogStreams\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:logs:*:*:*\\"
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      }
+    }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"aws_cloudwatch_log_group\\": {
+      \\"test-lambda_log-group_ACC182B5\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"retention_in_days\\": 14
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"test-lambda_execution-policy_19C785A8\\": {
+        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda_execution-role_9D4EE856\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
+        \\"name\\": \\"test-lambda-ExecutionRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
+          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+        ],
+        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+      }
+    },
+    \\"aws_lambda_alias\\": {
+      \\"test-lambda_alias_CCFDFCE9\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"function_version\\"
+          ]
+        },
+        \\"name\\": \\"DEPLOYED\\"
+      }
+    },
+    \\"aws_lambda_function\\": {
+      \\"test-lambda_8915D118\\": {
+        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
+        \\"function_name\\": \\"test-lambda-Function\\",
+        \\"handler\\": \\"index.handler\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"filename\\",
+            \\"source_code_hash\\"
+          ]
+        },
+        \\"publish\\": true,
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
+        \\"runtime\\": \\"python3.8\\",
+        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
+        \\"timeout\\": 5
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-lambda_code-bucket_177F316E\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-test-lambda\\",
+        \\"force_destroy\\": true
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
+        \\"block_public_acls\\": true,
+        \\"block_public_policy\\": true,
+        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1377,6 +1481,11 @@ exports[`renders a lambda with log retention 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1457,6 +1566,14 @@ exports[`renders a lambda with log retention 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1515,6 +1632,11 @@ exports[`renders a lambda with s3 bucket 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1595,6 +1717,14 @@ exports[`renders a lambda with s3 bucket 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1653,6 +1783,11 @@ exports[`renders a lambda with timeout 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1733,6 +1868,14 @@ exports[`renders a lambda with timeout 1`] = `
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
       }
     }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
+      }
+    }
   }
 }"
 `;
@@ -1804,6 +1947,11 @@ exports[`renders a lambda with vpc config 1`] = `
         \\"version\\": \\"2012-10-17\\"
       }
     }
+  },
+  \\"provider\\": {
+    \\"archive\\": [
+      {}
+    ]
   },
   \\"resource\\": {
     \\"aws_cloudwatch_log_group\\": {
@@ -1892,6 +2040,14 @@ exports[`renders a lambda with vpc config 1`] = `
         \\"block_public_acls\\": true,
         \\"block_public_policy\\": true,
         \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"archive\\": {
+        \\"source\\": \\"hashicorp/archive\\",
+        \\"version\\": \\"~> 2.2\\"
       }
     }
   }


### PR DESCRIPTION
## Goal
Remove default provider initialization requirement for consumers of this library.

- Add null and local providers to the ECS service construct
- Add archive provider to the versioned lambda construct

**BREAKING CHANGE**: Remove null, local, and archive providers from consuming applications.