### PR TITLE
feat(Allow configuring Alarm Description)

### DIFF
--- a/src/pocket/PocketALBApplication.spec.ts
+++ b/src/pocket/PocketALBApplication.spec.ts
@@ -341,4 +341,21 @@ describe('PocketALBApplication', () => {
     });
     expect(synthed).toMatchSnapshot();
   });
+
+  it('renders an Pocket App with custom Alarm Description', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new PocketALBApplication(stack, 'testPocketApp', {
+        ...BASE_CONFIG,
+        alarms: {
+          http5xxErrorPercentage: {
+            alarmDescription: 'Uh oh. something bad happened.',
+          },
+          httpLatency: {
+            alarmDescription: 'Uh oh. This is very slow.',
+          },
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
 });

--- a/src/pocket/PocketALBApplication.ts
+++ b/src/pocket/PocketALBApplication.ts
@@ -20,6 +20,7 @@ export interface PocketALBApplicationAlarmProps {
   evaluationPeriods?: number;
   datapointsToAlarm?: number;
   actions?: string[];
+  alarmDescription?: string;
 }
 
 export interface PocketALBApplicationProps {
@@ -843,7 +844,9 @@ export class PocketALBApplication extends Resource {
       alarmActions: alarmsConfig?.http5xxErrorPercentage?.actions ?? [],
       okActions: alarmsConfig?.http5xxErrorPercentage?.actions ?? [],
       tags: this.config.tags,
-      alarmDescription: 'Percentage of 5xx responses exceeds threshold',
+      alarmDescription:
+        alarmsConfig?.http5xxErrorPercentage?.alarmDescription ??
+        'Percentage of 5xx responses exceeds threshold',
     };
     const latencyAlarm: CloudWatch.CloudwatchMetricAlarmConfig = {
       alarmName: 'Alarm-HTTPResponseTime',
@@ -858,7 +861,9 @@ export class PocketALBApplication extends Resource {
       statistic: 'Average',
       comparisonOperator: 'GreaterThanThreshold',
       threshold: alarmsConfig?.httpLatency?.threshold ?? 300,
-      alarmDescription: 'Average HTTP response time exceeds threshold',
+      alarmDescription:
+        alarmsConfig?.httpLatency?.alarmDescription ??
+        'Average HTTP response time exceeds threshold',
       insufficientDataActions: [],
       alarmActions: alarmsConfig?.httpLatency?.actions ?? [],
       okActions: alarmsConfig?.httpLatency?.actions ?? [],

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -1453,6 +1453,662 @@ exports[`PocketALBApplication renders an Pocket App with code deploy and creates
 }"
 `;
 
+exports[`PocketALBApplication renders an Pocket App with custom Alarm Description 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_caller_identity\\": {
+      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {}
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs.application-autoscaling.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      },
+      \\"testPocketApp_autoscaling_role_policy_4E03A5E2\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"cloudwatch:PutMetricAlarm\\",
+              \\"cloudwatch:DescribeAlarms\\",
+              \\"cloudwatch:DeleteAlarms\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:cloudwatch:*:*:alarm:/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:DescribeServices\\",
+              \\"ecs:UpdateService\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:ecs:*:*:service/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}*\\"
+            ]
+          }
+        ]
+      },
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
+        \\"name\\": \\"alias/aws/secretsmanager\\"
+      }
+    },
+    \\"aws_region\\": {
+      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {}
+    },
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
+        \\"name\\": \\"bowling.gov\\"
+      }
+    },
+    \\"aws_security_groups\\": {
+      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"group-name\\",
+            \\"values\\": [
+              \\"default\\"
+            ]
+          },
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            ]
+          }
+        ]
+      }
+    },
+    \\"aws_ssm_parameter\\": {
+      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
+        \\"name\\": \\"/Shared/PrivateSubnets\\"
+      },
+      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
+        \\"name\\": \\"/Shared/PublicSubnets\\"
+      },
+      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
+        \\"name\\": \\"/Shared/Vpc\\"
+      }
+    },
+    \\"aws_subnet_ids\\": {
+      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
+          }
+        ],
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+      },
+      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"subnet-id\\",
+            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
+          }
+        ],
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+      }
+    },
+    \\"aws_vpc\\": {
+      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
+        \\"filter\\": [
+          {
+            \\"name\\": \\"vpc-id\\",
+            \\"values\\": [
+              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_acm_certificate\\": {
+      \\"testPocketApp_alb_certificate_417C14FF\\": {
+        \\"domain_name\\": \\"testing.bowling.gov\\",
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"validation_method\\": \\"DNS\\"
+      }
+    },
+    \\"aws_acm_certificate_validation\\": {
+      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"depends_on\\": [
+          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"validation_record_fqdns\\": [
+          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        ]
+      }
+    },
+    \\"aws_alb\\": {
+      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+        ],
+        \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+      }
+    },
+    \\"aws_alb_listener\\": {
+      \\"testPocketApp_listener_http_A9E227C2\\": {
+        \\"default_action\\": [
+          {
+            \\"redirect\\": {
+              \\"port\\": \\"443\\",
+              \\"protocol\\": \\"HTTPS\\",
+              \\"status_code\\": \\"HTTP_301\\"
+            },
+            \\"type\\": \\"redirect\\"
+          }
+        ],
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\"
+      },
+      \\"testPocketApp_listener_https_7F49DE83\\": {
+        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
+        \\"default_action\\": [
+          {
+            \\"fixed_response\\": {
+              \\"content_type\\": \\"text/plain\\",
+              \\"message_body\\": \\"\\",
+              \\"status_code\\": \\"503\\"
+            },
+            \\"type\\": \\"fixed-response\\"
+          }
+        ],
+        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
+        \\"port\\": 443,
+        \\"protocol\\": \\"HTTPS\\",
+        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+      }
+    },
+    \\"aws_alb_listener_rule\\": {
+      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
+        \\"action\\": [
+          {
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
+            \\"type\\": \\"forward\\"
+          }
+        ],
+        \\"condition\\": [
+          {
+            \\"path_pattern\\": {
+              \\"values\\": [
+                \\"*\\"
+              ]
+            }
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"action\\"
+          ]
+        },
+        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
+        \\"priority\\": 1
+      }
+    },
+    \\"aws_alb_target_group\\": {
+      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
+        \\"deregistration_delay\\": \\"120\\",
+        \\"health_check\\": {
+          \\"healthy_threshold\\": 5,
+          \\"interval\\": 15,
+          \\"path\\": \\"/test\\",
+          \\"protocol\\": \\"HTTP\\",
+          \\"unhealthy_threshold\\": 3
+        },
+        \\"name_prefix\\": \\"TSTAPP\\",
+        \\"port\\": 80,
+        \\"protocol\\": \\"HTTP\\",
+        \\"tags\\": {
+          \\"type\\": \\"blue\\"
+        },
+        \\"target_type\\": \\"ip\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+      }
+    },
+    \\"aws_appautoscaling_policy\\": {
+      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"name\\": \\"testapp-ScaleInPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": {
+          \\"adjustment_type\\": \\"ChangeInCapacity\\",
+          \\"cooldown\\": 60,
+          \\"metric_aggregation_type\\": \\"Average\\",
+          \\"step_adjustment\\": [
+            {
+              \\"metric_interval_upper_bound\\": \\"0\\",
+              \\"scaling_adjustment\\": -1
+            }
+          ]
+        }
+      },
+      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
+        \\"depends_on\\": [
+          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+        ],
+        \\"name\\": \\"testapp-ScaleOutPolicy\\",
+        \\"policy_type\\": \\"StepScaling\\",
+        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
+        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
+        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
+        \\"step_scaling_policy_configuration\\": {
+          \\"adjustment_type\\": \\"ChangeInCapacity\\",
+          \\"cooldown\\": 60,
+          \\"metric_aggregation_type\\": \\"Average\\",
+          \\"step_adjustment\\": [
+            {
+              \\"metric_interval_lower_bound\\": \\"0\\",
+              \\"scaling_adjustment\\": 2
+            }
+          ]
+        }
+      }
+    },
+    \\"aws_appautoscaling_target\\": {
+      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
+        \\"max_capacity\\": 2,
+        \\"min_capacity\\": 1,
+        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
+        \\"role_arn\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.arn}\\",
+        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
+        \\"service_namespace\\": \\"ecs\\"
+      }
+    },
+    \\"aws_cloudwatch_dashboard\\": {
+      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
+        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
+        \\"dashboard_name\\": \\"testapp-ALBDashboard\\"
+      }
+    },
+    \\"aws_cloudwatch_metric_alarm\\": {
+      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Uh oh. This is very slow.\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"datapoints_to_alarm\\": 1,
+        \\"dimensions\\": {
+          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        },
+        \\"evaluation_periods\\": 1,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_name\\": \\"TargetResponseTime\\",
+        \\"namespace\\": \\"AWS/ApplicationELB\\",
+        \\"ok_actions\\": [],
+        \\"period\\": 300,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 300
+      },
+      \\"testPocketApp_alarm-httptarget5xxerrorrate_39F471E9\\": {
+        \\"alarm_actions\\": [],
+        \\"alarm_description\\": \\"Uh oh. something bad happened.\\",
+        \\"alarm_name\\": \\"testapp-Alarm-HTTPTarget5xxErrorRate\\",
+        \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
+        \\"datapoints_to_alarm\\": 5,
+        \\"evaluation_periods\\": 5,
+        \\"insufficient_data_actions\\": [],
+        \\"metric_query\\": [
+          {
+            \\"id\\": \\"requests\\",
+            \\"metric\\": {
+              \\"dimensions\\": {
+                \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+              },
+              \\"metric_name\\": \\"RequestCount\\",
+              \\"namespace\\": \\"AWS/ApplicationELB\\",
+              \\"period\\": 60,
+              \\"stat\\": \\"Sum\\",
+              \\"unit\\": \\"Count\\"
+            }
+          },
+          {
+            \\"id\\": \\"errors\\",
+            \\"metric\\": {
+              \\"dimensions\\": {
+                \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+              },
+              \\"metric_name\\": \\"HTTPCode_Target_5XX_Count\\",
+              \\"namespace\\": \\"AWS/ApplicationELB\\",
+              \\"period\\": 60,
+              \\"stat\\": \\"Sum\\",
+              \\"unit\\": \\"Count\\"
+            }
+          },
+          {
+            \\"expression\\": \\"errors/requests*100\\",
+            \\"id\\": \\"expression\\",
+            \\"label\\": \\"HTTP 5xx Error Rate\\",
+            \\"return_data\\": true
+          }
+        ],
+        \\"ok_actions\\": [],
+        \\"threshold\\": 5
+      },
+      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
+        \\"alarm_name\\": \\"testapp Service Low CPU\\",
+        \\"comparison_operator\\": \\"LessThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 30,
+        \\"treat_missing_data\\": \\"notBreaching\\"
+      },
+      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
+        \\"alarm_actions\\": [
+          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+        ],
+        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
+        \\"alarm_name\\": \\"testapp Service High CPU\\",
+        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
+        \\"dimensions\\": {
+          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
+          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        },
+        \\"evaluation_periods\\": 2,
+        \\"metric_name\\": \\"CPUUtilization\\",
+        \\"namespace\\": \\"AWS/ECS\\",
+        \\"period\\": 60,
+        \\"statistic\\": \\"Average\\",
+        \\"threshold\\": 45,
+        \\"treat_missing_data\\": \\"notBreaching\\"
+      }
+    },
+    \\"aws_ecs_cluster\\": {
+      \\"testPocketApp_ecs_cluster_C3960066\\": {
+        \\"name\\": \\"testapp\\",
+        \\"setting\\": [
+          {
+            \\"name\\": \\"containerInsights\\",
+            \\"value\\": \\"enabled\\"
+          }
+        ]
+      }
+    },
+    \\"aws_ecs_service\\": {
+      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
+        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
+        \\"depends_on\\": [
+          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
+          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+        ],
+        \\"deployment_controller\\": {
+          \\"type\\": \\"ECS\\"
+        },
+        \\"deployment_maximum_percent\\": 200,
+        \\"deployment_minimum_healthy_percent\\": 100,
+        \\"desired_count\\": 2,
+        \\"launch_type\\": \\"FARGATE\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"desired_count\\",
+            \\"load_balancer\\"
+          ]
+        },
+        \\"load_balancer\\": [
+          {
+            \\"container_name\\": \\"main_container\\",
+            \\"container_port\\": 8675309,
+            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+          }
+        ],
+        \\"name\\": \\"testapp\\",
+        \\"network_configuration\\": {
+          \\"security_groups\\": [
+            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+          ],
+          \\"subnets\\": \\"\${data.aws_subnet_ids.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+        },
+        \\"propagate_tags\\": \\"SERVICE\\",
+        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+      }
+    },
+    \\"aws_ecs_task_definition\\": {
+      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
+        \\"container_definitions\\": \\"[]\\",
+        \\"cpu\\": \\"512\\",
+        \\"depends_on\\": [],
+        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
+        \\"family\\": \\"testapp\\",
+        \\"memory\\": \\"2048\\",
+        \\"network_mode\\": \\"awsvpc\\",
+        \\"requires_compatibilities\\": [
+          \\"FARGATE\\"
+        ],
+        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
+        \\"volume\\": []
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"testPocketApp_autoscaling_autoscaling_role_2A822527\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_autoscaling_assume_9DAB9CD7.json}\\",
+        \\"name\\": \\"testapp-AutoScalingRole\\"
+      },
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskExecutionRole\\"
+      },
+      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
+        \\"name\\": \\"testapp-TaskRole\\"
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"testPocketApp_autoscaling_autoscaling_role_policy_2C958C29\\": {
+        \\"name\\": \\"testapp-AutoScalingPolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_autoscaling_role_policy_4E03A5E2.json}\\",
+        \\"role\\": \\"\${aws_iam_role.testPocketApp_autoscaling_autoscaling_role_2A822527.id}\\"
+      }
+    },
+    \\"aws_route53_record\\": {
+      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
+        \\"depends_on\\": [
+          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+        ],
+        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_name}\\",
+        \\"records\\": [
+          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_value}\\"
+        ],
+        \\"ttl\\": 60,
+        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options)[0].resource_record_type}\\",
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+      },
+      \\"testPocketApp_alb_record_7B56ED33\\": {
+        \\"alias\\": [
+          {
+            \\"evaluate_target_health\\": true,
+            \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
+            \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"weighted_routing_policy[0].weight\\"
+          ]
+        },
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"set_identifier\\": \\"1\\",
+        \\"type\\": \\"A\\",
+        \\"weighted_routing_policy\\": [
+          {
+            \\"weight\\": 1
+          }
+        ],
+        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+      },
+      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
+        \\"name\\": \\"testing.bowling.gov\\",
+        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
+        \\"ttl\\": 86400,
+        \\"type\\": \\"NS\\",
+        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      }
+    },
+    \\"aws_route53_zone\\": {
+      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
+        \\"name\\": \\"testing.bowling.gov\\"
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        },
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+      },
+      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
+        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": [],
+            \\"prefix_list_ids\\": [],
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": [
+              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 8675309
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
+        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+      }
+    },
+    \\"null_resource\\": {
+      \\"testPocketApp_ecs_service_8F213571\\": {}
+    }
+  }
+}"
+`;
+
 exports[`PocketALBApplication renders an Pocket App with logs and dashboard in a specified region 1`] = `
 "{
   \\"data\\": {


### PR DESCRIPTION
# Goal

As part of my ongoing PagerDuty work I would like to modify our default alarms to allow changing the description. The intention here is to add a link in the description to a runbook or troubleshooting for the alarm.

For example for a `5xx` error on the `Parser` I'd imagine linking to a runbook in our Confluence that has some common troubleshooting steps for what to do when you get that alert for `5xx`.

# To Do:
- [ ] Verify that the description gets passed through to PagerDuty and on to your alarm. Maybe someone can forward me an email / notification from PagerDuty from Cloudwatch to look at.

# Tickets:
* [ JIRA](https://mozilla-hub.atlassian.net/browse/SE-2875)
