### PR TITLE
fix(types): Export the PocketApiGatewayLambdaIntegration class and types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // this is the entry point for the npm package
 // anything we want consumable (module, type, class, etc) should be exported here
+export * from './pocket/PocketApiGatewayLambdaIntegration';
 export * from './pocket/PocketALBApplication';
 export * from './pocket/PocketECSCodePipeline';
 export * from './pocket/PocketEventBridgeWithLambdaTarget';


### PR DESCRIPTION
## Goal

Export the typescript class and types for PocketApiGatewayLambdaIntegration
