### PR TITLE
fix(api gateway lambda integration): Fix redeployment trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "jest": "^27.3.1",
         "prettier": "^2.4.1",
         "semantic-release": "^18.0.0",
+        "sinon": "^12.0.1",
         "ts-jest": "^27.0.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.2",
@@ -1956,13 +1957,30 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
-      "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "node_modules/@skorfmann/ink-confirm-input": {
       "version": "3.0.0",
@@ -8708,6 +8726,12 @@
         "node": "*"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -8871,6 +8895,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -9301,6 +9331,43 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -14056,6 +14123,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/sinon": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
+      "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^8.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -17041,13 +17135,30 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
-      "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@skorfmann/ink-confirm-input": {
       "version": "3.0.0",
@@ -22101,6 +22212,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -22241,6 +22358,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -22574,6 +22697,45 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "no-case": {
       "version": "3.0.4",
@@ -25924,6 +26086,28 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "sinon": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
+      "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^8.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "jest": "^27.3.1",
     "prettier": "^2.4.1",
     "semantic-release": "^18.0.0",
+    "sinon": "^12.0.1",
     "ts-jest": "^27.0.7",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.2",

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,16 +1,10 @@
 import { Construct } from 'constructs';
 import { App, TerraformStack } from 'cdktf';
 import { AwsProvider } from '@cdktf/provider-aws';
+import { PocketALBApplication } from './pocket/PocketALBApplication';
+import { ApplicationECSContainerDefinitionProps } from './base/ApplicationECSContainerDefinition';
 import { LocalProvider } from '@cdktf/provider-local';
 import { NullProvider } from '@cdktf/provider-null';
-import {
-  ApiGatewayLambdaRoute,
-  PocketApiGateway,
-  PocketApiGatewayProps,
-} from './pocket/PocketApiGatewayLambdaIntegration';
-import { LAMBDA_RUNTIMES } from './base/ApplicationVersionedLambda';
-import { PocketVPC } from './pocket/PocketVPC';
-import { ArchiveProvider } from '@cdktf/provider-archive';
 
 class Example extends TerraformStack {
   constructor(scope: Construct, name: string) {
@@ -21,61 +15,45 @@ class Example extends TerraformStack {
     });
     new LocalProvider(this, 'local', {});
     new NullProvider(this, 'null', {});
-    new ArchiveProvider(this, 'archive');
 
-    const vpc = new PocketVPC(this, 'kelvin-pocket-vpv');
-
-    const fxaEventsRoute: ApiGatewayLambdaRoute = {
-      path: 'events',
-      method: 'POST',
-      eventHandler: {
-        name: `Kelvin-ApiGateway-FxA-Events`,
-        lambda: {
-          runtime: LAMBDA_RUNTIMES.NODEJS14,
-          handler: 'index.handler',
-          timeout: 120,
-          environment: {
-            SENTRY_DSN: 'sentry',
-            GIT_SHA: 'asdasdasd',
-            ENVIRONMENT: 'development',
-          },
-          // vpcConfig: {
-          //  // securityGroupIds: vpc.defaultSecurityGroups.ids,
-          //   subnetIds: vpc.privateSubnetIds,
-          // },
-          codeDeploy: {
-            region: vpc.region,
-            accountId: vpc.accountId,
-          },
-          alarms: {
-            // TODO: set better alarm values
-            /*
-            errors: {
-              evaluationPeriods: 3,
-              period: 3600, // 1 hour
-              threshold: 20,
-              actions: config.isDev
-                ? []
-                : [pagerDuty!.snsNonCriticalAlarmTopic.arn],
-            },
-            */
-          },
+    const containerConfigBlue: ApplicationECSContainerDefinitionProps = {
+      name: 'blueContainer',
+      containerImage: 'bitnami/node-example:0.0.1',
+      portMappings: [
+        {
+          hostPort: 3000,
+          containerPort: 3000,
         },
-        tags: { name: 'Kelvin', environment: 'Dev' },
-      },
-    };
-    const pocketApiGatewayProps: PocketApiGatewayProps = {
-      name: `Kelvin-API-Gateway`,
-      stage: 'dev',
-      routes: [fxaEventsRoute],
-      tags: { name: 'Kelvin' },
+      ],
+      envVars: [
+        {
+          name: 'foo',
+          value: 'bar',
+        },
+      ],
     };
 
-    new PocketApiGateway(
-      this,
-      'fxa-events-apigateway-lambda',
-      pocketApiGatewayProps
-    );
+    new PocketALBApplication(this, 'example', {
+      exposedContainer: {
+        name: 'blueContainer',
+        port: 3000,
+        healthCheckPath: '/',
+      },
+      codeDeploy: {
+        useCodeDeploy: true,
+      },
+      cdn: false, // maybe make this false if you're testing an actual terraform apply - cdn's take a loooong time to spin up
+      alb6CharacterPrefix: 'ACMECO',
+      internal: false,
+      domain: 'acme.getpocket.dev',
+      prefix: 'ACME-Dev', // Prefix is a combo of the `Name-Environment`
+      containerConfigs: [containerConfigBlue],
+      ecsIamConfig: {
+        prefix: 'ACME-Dev',
+        taskExecutionRolePolicyStatements: [],
+        taskRolePolicyStatements: [],
+      },
+    });
   }
 }
 

--- a/src/pocket/PocketApiGatewayLambdaIntegration.spec.ts
+++ b/src/pocket/PocketApiGatewayLambdaIntegration.spec.ts
@@ -1,4 +1,5 @@
 import { Testing } from 'cdktf';
+import sinon from 'sinon';
 import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda';
 import {
   PocketApiGateway,
@@ -23,11 +24,25 @@ const config: PocketApiGatewayProps = {
   ],
 };
 
-test('renders an api gateway with a lambda integration', () => {
-  const synthed = Testing.synthScope((stack) => {
-    new PocketApiGateway(stack, 'test-api-lambda', {
-      ...config,
+describe('PocketApiGatewayLambdaIntegration', () => {
+  let clock;
+  const now = 1637693316456;
+
+  beforeAll(() => {
+    clock = sinon.useFakeTimers({
+      now: now,
+      shouldAdvanceTime: false,
     });
   });
-  expect(synthed).toMatchSnapshot();
+
+  afterAll(() => clock.restore());
+
+  it('renders an api gateway with a lambda integration', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new PocketApiGateway(stack, 'test-api-lambda', {
+        ...config,
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
 });

--- a/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders an api gateway with a lambda integration 1`] = `
+exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda integration 1`] = `
 "{
   \\"data\\": {
     \\"archive_file\\": {
@@ -66,7 +66,8 @@ exports[`renders an api gateway with a lambda integration 1`] = `
         ],
         \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\",
         \\"triggers\\": {
-          \\"redeployment\\": \\"\${sha1(jsonencode({resources = [aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8.id, aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.id, aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id, aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.id], name = \\\\\\"test-api-lambda\\\\\\", stage = \\\\\\"test\\\\\\", routes = [[object Object]]}))}\\"
+          \\"deployedAt\\": \\"1637693316456\\",
+          \\"redeployment\\": \\"\${sha1(jsonencode({resources = [aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8.id, aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.id, aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id, aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.id]}))}\\"
         }
       }
     },


### PR DESCRIPTION
## Goal

- JSON encode the `PocketApiGatewayProps` to trigger redeployment of the API Gateway resource
- Add tags to the API Gateway REST API resource

## Implementation decisions
- redeployment triggers are provided by the service consuming the API gateway construct. if no trigger is provided, then we use the current time as the trigger. this way, what's being set as a trigger becomes the responsibility of the consuming service

ticket:[ infra-188 ](https://getpocket.atlassian.net/browse/INFRA-188)

