### PR TITLE
fix(api-gateway): add lifecycle property to api gateway

### DIFF
--- a/src/pocket/PocketApiGatewayLambdaIntegration.ts
+++ b/src/pocket/PocketApiGatewayLambdaIntegration.ts
@@ -84,6 +84,7 @@ export class PocketApiGateway extends Resource {
           ),
           ...triggers,
         },
+        lifecycle: { createBeforeDestroy: true },
         dependsOn: routeDependencies,
       }
     );

--- a/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -64,6 +64,9 @@ exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda 
           \\"aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1\\",
           \\"aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8\\"
         ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
         \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\",
         \\"triggers\\": {
           \\"deployedAt\\": \\"1637693316456\\",


### PR DESCRIPTION
# Goal

add lifecycle property to api gateway

otherwise  code build throws an error: 
`Error: error deleting API Gateway Deployment (ixfyda): BadRequestException: Active stages pointing to this deployment must be moved or deleted`

fix from this github issue: https://github.com/hashicorp/terraform/issues/10674

Tickets:
infra-188

