### PR TITLE
feat(pocket-ecs-codepipeline): Make codepipeline steps extendable

### DIFF
--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -92,9 +92,27 @@ test('renders a Pocket ECS Codepipeline template with a custom step', () => {
   const synthed = Testing.synthScope((stack) => {
     new PocketECSCodePipeline(stack, 'test-codepipeline', {
       ...config,
+      preDeployStages: [
+        {
+          name: 'Custom_PreDeploy_Stage',
+          action: [
+            {
+              name: 'MyBuild',
+              category: 'Deploy',
+              owner: 'AWS',
+              provider: 'CodeBuild',
+              version: '1',
+              configuration: {
+                projectName: 'Test-Env-MyBuild',
+              },
+              runOrder: 1,
+            },
+          ],
+        },
+      ],
       postDeployStages: [
         {
-          name: 'Custom_Stage',
+          name: 'Custom_PostDeploy_Stage',
           action: [
             {
               name: 'Custom_Action',

--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -3,6 +3,7 @@ import {
   PocketECSCodePipeline,
   PocketECSCodePipelineProps,
 } from './PocketECSCodePipeline';
+import { codepipeline } from '@cdktf/provider-aws';
 
 const config: PocketECSCodePipelineProps = {
   prefix: 'Test-Env',
@@ -84,6 +85,43 @@ test('renders a Pocket ECS Codepipeline template with the provided taskdef path'
         taskDefPath: 'testtaskdef.json',
       },
     });
+  });
+  expect(synthed).toMatchSnapshot();
+});
+
+test('renders a Pocket ECS Codepipeline template with a custom step', () => {
+  class CustomECSCodePipeline extends PocketECSCodePipeline {
+    protected getDeployStage = (): codepipeline.CodepipelineStage => {
+      const deployStage = super.getDeployStage();
+      const maxRunOrder = Math.max(
+        ...deployStage.action.map((action) => action.runOrder),
+        1 // default runOrder if deployStage is empty.
+      );
+
+      // Add a custom action to the stage with a higher runOrder, to run it at the end.
+      deployStage.action.push(this.getCustomDeployAction(maxRunOrder + 1));
+
+      return deployStage;
+    };
+
+    protected getCustomDeployAction = (
+      runOrder: number
+    ): codepipeline.CodepipelineStageAction => ({
+      name: 'Deploy_Prefect_Cloud',
+      category: 'Deploy',
+      owner: 'AWS',
+      provider: 'StepFunctions',
+      version: '1',
+      configuration: {
+        stateMachineArn: 'myStateMachineArn123',
+        ExecutionNamePrefix: 'CodePipelineDeploy',
+      },
+      runOrder: runOrder,
+    });
+  }
+
+  const synthed = Testing.synthScope((stack) => {
+    new CustomECSCodePipeline(stack, 'test-codepipeline', config);
   });
   expect(synthed).toMatchSnapshot();
 });

--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -3,7 +3,6 @@ import {
   PocketECSCodePipeline,
   PocketECSCodePipelineProps,
 } from './PocketECSCodePipeline';
-import { codepipeline } from '@cdktf/provider-aws';
 
 const config: PocketECSCodePipelineProps = {
   prefix: 'Test-Env',
@@ -90,38 +89,27 @@ test('renders a Pocket ECS Codepipeline template with the provided taskdef path'
 });
 
 test('renders a Pocket ECS Codepipeline template with a custom step', () => {
-  class CustomECSCodePipeline extends PocketECSCodePipeline {
-    protected getDeployStage = (): codepipeline.CodepipelineStage => {
-      const deployStage = super.getDeployStage();
-      const maxRunOrder = Math.max(
-        ...deployStage.action.map((action) => action.runOrder),
-        1 // default runOrder if deployStage is empty.
-      );
-
-      // Add a custom action to the stage with a higher runOrder, to run it at the end.
-      deployStage.action.push(this.getCustomDeployAction(maxRunOrder + 1));
-
-      return deployStage;
-    };
-
-    protected getCustomDeployAction = (
-      runOrder: number
-    ): codepipeline.CodepipelineStageAction => ({
-      name: 'Deploy_Prefect_Cloud',
-      category: 'Deploy',
-      owner: 'AWS',
-      provider: 'StepFunctions',
-      version: '1',
-      configuration: {
-        stateMachineArn: 'myStateMachineArn123',
-        ExecutionNamePrefix: 'CodePipelineDeploy',
-      },
-      runOrder: runOrder,
-    });
-  }
-
   const synthed = Testing.synthScope((stack) => {
-    new CustomECSCodePipeline(stack, 'test-codepipeline', config);
+    new PocketECSCodePipeline(stack, 'test-codepipeline', {
+      ...config,
+      postDeployStage: {
+        name: 'Custom_Stage',
+        action: [
+          {
+            name: 'Custom_Action',
+            category: 'Deploy',
+            owner: 'AWS',
+            provider: 'StepFunctions',
+            version: '1',
+            configuration: {
+              stateMachineArn: 'myStateMachineArn123',
+              ExecutionNamePrefix: 'CodePipelineDeploy',
+            },
+            runOrder: 1,
+          },
+        ],
+      },
+    });
   });
   expect(synthed).toMatchSnapshot();
 });

--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -88,7 +88,7 @@ test('renders a Pocket ECS Codepipeline template with the provided taskdef path'
   expect(synthed).toMatchSnapshot();
 });
 
-test('renders a Pocket ECS Codepipeline template with a custom step', () => {
+test('renders a Pocket ECS Codepipeline template with custom steps', () => {
   const synthed = Testing.synthScope((stack) => {
     new PocketECSCodePipeline(stack, 'test-codepipeline', {
       ...config,

--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -92,23 +92,25 @@ test('renders a Pocket ECS Codepipeline template with a custom step', () => {
   const synthed = Testing.synthScope((stack) => {
     new PocketECSCodePipeline(stack, 'test-codepipeline', {
       ...config,
-      postDeployStage: {
-        name: 'Custom_Stage',
-        action: [
-          {
-            name: 'Custom_Action',
-            category: 'Deploy',
-            owner: 'AWS',
-            provider: 'StepFunctions',
-            version: '1',
-            configuration: {
-              stateMachineArn: 'myStateMachineArn123',
-              ExecutionNamePrefix: 'CodePipelineDeploy',
+      postDeployStages: [
+        {
+          name: 'Custom_Stage',
+          action: [
+            {
+              name: 'Custom_Action',
+              category: 'Deploy',
+              owner: 'AWS',
+              provider: 'StepFunctions',
+              version: '1',
+              configuration: {
+                stateMachineArn: 'myStateMachineArn123',
+                ExecutionNamePrefix: 'CodePipelineDeploy',
+              },
+              runOrder: 1,
             },
-            runOrder: 1,
-          },
-        ],
-      },
+          ],
+        },
+      ],
     });
   });
   expect(synthed).toMatchSnapshot();

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -174,7 +174,7 @@ export class PocketECSCodePipeline extends Resource {
                 'codebuild:StartBuildBatch',
               ],
               resources: [
-                `arn:aws:codebuild:*:*:project/${this.codeBuildProjectName}`,
+                `arn:aws:codebuild:*:*:project/${this.codeBuildProjectName}*`,
               ],
             },
             {

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -50,8 +50,8 @@ export class PocketECSCodePipeline extends Resource {
     this.appSpecTemplatePath = this.getAppSpecTemplatePath();
 
     this.s3KmsAlias = this.createS3KmsAlias();
-    this.pipelineRole = this.createPipelineRole();
     this.pipelineArtifactBucket = this.createArtifactBucket();
+    this.pipelineRole = this.createPipelineRole();
     this.codePipeline = this.createCodePipeline();
   }
 
@@ -254,7 +254,7 @@ export class PocketECSCodePipeline extends Resource {
   });
 
   protected getDeployCdkAction = () => ({
-    name: 'Deploy_CDK',
+    name: 'CodeBuild',
     category: 'Build',
     owner: 'AWS',
     provider: 'CodeBuild',

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -254,7 +254,7 @@ export class PocketECSCodePipeline extends Resource {
   });
 
   protected getDeployCdkAction = () => ({
-    name: 'CodeBuild',
+    name: 'Deploy_CDK',
     category: 'Build',
     owner: 'AWS',
     provider: 'CodeBuild',

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -227,6 +227,10 @@ export class PocketECSCodePipeline extends Resource {
     },
   ];
 
+  /**
+   * Get the source code from GitHub.
+   * @protected
+   */
   protected getSourceStage = () => ({
     name: 'Source',
     action: [
@@ -248,12 +252,22 @@ export class PocketECSCodePipeline extends Resource {
     ],
   });
 
-  protected getDeployStage = () => ({
+  /**
+   * Get a stage that deploys the infrastructure and ECS service.
+   * @protected
+   */
+  protected getDeployStage = (): codepipeline.CodepipelineStage => ({
     name: 'Deploy',
-    action: [this.getDeployCdkAction(), this.getDeployEcsAction()],
+    action: [this.getDeployCdkAction(1), this.getDeployEcsAction(2)],
   });
 
-  protected getDeployCdkAction = () => ({
+  /**
+   * Get the CDK for Terraform deployment step that runs `terraform apply`.
+   * @protected
+   */
+  protected getDeployCdkAction = (
+    runOrder: number
+  ): codepipeline.CodepipelineStageAction => ({
     name: 'Deploy_CDK',
     category: 'Build',
     owner: 'AWS',
@@ -268,10 +282,16 @@ export class PocketECSCodePipeline extends Resource {
         value: '#{SourceVariables.BranchName}',
       })}]`,
     },
-    runOrder: 1,
+    runOrder: runOrder,
   });
 
-  protected getDeployEcsAction = () => ({
+  /**
+   * Get the ECS CodeDeploy step that does a blue/green deployment.
+   * @protected
+   */
+  protected getDeployEcsAction = (
+    runOrder: number
+  ): codepipeline.CodepipelineStageAction => ({
     name: 'Deploy_ECS',
     category: 'Deploy',
     owner: 'AWS',
@@ -286,6 +306,6 @@ export class PocketECSCodePipeline extends Resource {
       AppSpecTemplateArtifact: 'CodeBuildOutput',
       AppSpecTemplatePath: this.appSpecTemplatePath,
     },
-    runOrder: 2,
+    runOrder: runOrder,
   });
 }

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -1,6 +1,6 @@
-import {Resource} from 'cdktf';
-import {Construct} from 'constructs';
-import {codepipeline, iam, kms, s3} from '@cdktf/provider-aws';
+import { Resource } from 'cdktf';
+import { Construct } from 'constructs';
+import { codepipeline, iam, kms, s3 } from '@cdktf/provider-aws';
 import crypto from 'crypto';
 
 export interface PocketECSCodePipelineProps {
@@ -44,7 +44,8 @@ export class PocketECSCodePipeline extends Resource {
 
     this.codeBuildProjectName = this.getCodeBuildProjectName();
     this.codeDeployApplicationName = this.getCodeDeployApplicationName();
-    this.codeDeployDeploymentGroupName = this.getCodeDeployDeploymentGroupName();
+    this.codeDeployDeploymentGroupName =
+      this.getCodeDeployDeploymentGroupName();
     this.taskDefinitionTemplatePath = this.getTaskDefinitionTemplatePath();
     this.appSpecTemplatePath = this.getAppSpecTemplatePath();
 
@@ -60,12 +61,10 @@ export class PocketECSCodePipeline extends Resource {
     this.config.codeBuildProjectName ?? this.config.prefix;
 
   protected getCodeDeployApplicationName = () =>
-    this.config.codeDeploy?.applicationName ??
-    `${this.config.prefix}-ECS`;
+    this.config.codeDeploy?.applicationName ?? `${this.config.prefix}-ECS`;
 
   protected getCodeDeployDeploymentGroupName = () =>
-    this.config.codeDeploy?.deploymentGroupName ??
-    `${this.config.prefix}-ECS`;
+    this.config.codeDeploy?.deploymentGroupName ?? `${this.config.prefix}-ECS`;
 
   protected getTaskDefinitionTemplatePath = () =>
     this.config.codeDeploy?.taskDefPath ??
@@ -76,13 +75,9 @@ export class PocketECSCodePipeline extends Resource {
     PocketECSCodePipeline.DEFAULT_APPSPEC_PATH;
 
   protected createS3KmsAlias() {
-    return new kms.DataAwsKmsAlias(
-      this,
-      'kms_s3_alias',
-      {
-        name: 'alias/aws/s3',
-      }
-    );
+    return new kms.DataAwsKmsAlias(this, 'kms_s3_alias', {
+      name: 'alias/aws/s3',
+    });
   }
 
   /**
@@ -255,10 +250,7 @@ export class PocketECSCodePipeline extends Resource {
 
   protected getDeployStage = () => ({
     name: 'Deploy',
-    action: [
-      this.getDeployCdkAction(),
-      this.getDeployEcsAction(),
-    ],
+    action: [this.getDeployCdkAction(), this.getDeployEcsAction()],
   });
 
   protected getDeployCdkAction = () => ({

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -17,7 +17,13 @@ export interface PocketECSCodePipelineProps {
     appSpecPath?: string;
     taskDefPath?: string;
   };
-  // Optional stages to run after the deploy stage.
+  /** Optional stages to run before the deploy stage.
+   * For CodeBuild actions, ensure that the project name starts with `prefix`.
+   */
+  preDeployStages?: codepipeline.CodepipelineStage[];
+  /** Optional stages to run after the deploy stage.
+   * For CodeBuild actions, ensure that the project name starts with `prefix`.
+   */
   postDeployStages?: codepipeline.CodepipelineStage[];
   tags?: { [key: string]: string };
 }
@@ -83,6 +89,7 @@ export class PocketECSCodePipeline extends Resource {
    */
   private getStages = () => [
     this.getSourceStage(),
+    ...(this.config.preDeployStages ? this.config.preDeployStages : []),
     this.getDeployStage(),
     ...(this.config.postDeployStages ? this.config.postDeployStages : []),
   ];
@@ -174,6 +181,9 @@ export class PocketECSCodePipeline extends Resource {
                 'codebuild:StartBuildBatch',
               ],
               resources: [
+                // The * allows CodeBuild in `preDeployStages` and
+                // `postDeployStages` to start, if the project name starts with
+                // `this.config.prefix`.
                 `arn:aws:codebuild:*:*:project/${this.codeBuildProjectName}*`,
               ],
             },

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -1,6 +1,6 @@
-import { Resource } from 'cdktf';
-import { Construct } from 'constructs';
-import { codepipeline, iam, kms, s3 } from '@cdktf/provider-aws';
+import {Resource} from 'cdktf';
+import {Construct} from 'constructs';
+import {codepipeline, iam, kms, s3} from '@cdktf/provider-aws';
 import crypto from 'crypto';
 
 export interface PocketECSCodePipelineProps {
@@ -41,6 +41,7 @@ export class PocketECSCodePipeline extends Resource {
     protected config: PocketECSCodePipelineProps
   ) {
     super(scope, name);
+
     this.codeBuildProjectName = this.getCodeBuildProjectName();
     this.codeDeployApplicationName = this.getCodeDeployApplicationName();
     this.codeDeployDeploymentGroupName = this.getCodeDeployDeploymentGroupName();
@@ -54,14 +55,34 @@ export class PocketECSCodePipeline extends Resource {
   }
 
   protected getPipelineName = () => `${this.config.prefix}-CodePipeline`;
-  protected getCodeBuildProjectName = () => this.config.codeBuildProjectName ?? this.config.prefix;
-  protected getCodeDeployApplicationName = () => this.config.codeDeploy?.applicationName ?? `${this.config.prefix}-ECS`;
-  protected getCodeDeployDeploymentGroupName = () => this.config.codeDeploy?.deploymentGroupName ?? `${this.config.prefix}-ECS`;
-  protected getTaskDefinitionTemplatePath = () => this.config.codeDeploy?.taskDefPath ?? PocketECSCodePipeline.DEFAULT_TASKDEF_PATH;
-  protected getAppSpecTemplatePath = () => this.config.codeDeploy?.appSpecPath ?? PocketECSCodePipeline.DEFAULT_APPSPEC_PATH;
+
+  protected getCodeBuildProjectName = () =>
+    this.config.codeBuildProjectName ?? this.config.prefix;
+
+  protected getCodeDeployApplicationName = () =>
+    this.config.codeDeploy?.applicationName ??
+    `${this.config.prefix}-ECS`;
+
+  protected getCodeDeployDeploymentGroupName = () =>
+    this.config.codeDeploy?.deploymentGroupName ??
+    `${this.config.prefix}-ECS`;
+
+  protected getTaskDefinitionTemplatePath = () =>
+    this.config.codeDeploy?.taskDefPath ??
+    PocketECSCodePipeline.DEFAULT_TASKDEF_PATH;
+
+  protected getAppSpecTemplatePath = () =>
+    this.config.codeDeploy?.appSpecPath ??
+    PocketECSCodePipeline.DEFAULT_APPSPEC_PATH;
 
   protected createS3KmsAlias() {
-    return new kms.DataAwsKmsAlias(this, 'kms_s3_alias', {name: 'alias/aws/s3'});
+    return new kms.DataAwsKmsAlias(
+      this,
+      'kms_s3_alias',
+      {
+        name: 'alias/aws/s3',
+      }
+    );
   }
 
   /**
@@ -73,10 +94,7 @@ export class PocketECSCodePipeline extends Resource {
       name: this.getPipelineName(),
       roleArn: this.pipelineRole.arn,
       artifactStore: this.getArtifactStore(),
-      stage: [
-        this.getSourceStage(),
-        this.getDeployStage(),
-      ],
+      stage: [this.getSourceStage(), this.getDeployStage()],
       tags: this.config.tags,
     });
   }
@@ -206,13 +224,13 @@ export class PocketECSCodePipeline extends Resource {
     return role;
   }
 
-  protected getArtifactStore = () => ([
+  protected getArtifactStore = () => [
     {
       location: this.pipelineArtifactBucket.bucket,
       type: 'S3',
-      encryptionKey: {id: this.s3KmsAlias.arn, type: 'KMS'},
+      encryptionKey: { id: this.s3KmsAlias.arn, type: 'KMS' },
     },
-  ]);
+  ];
 
   protected getSourceStage = () => ({
     name: 'Source',

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -42,7 +42,7 @@ exports[`renders a Pocket ECS Codepipeline template 1`] = `
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {
@@ -260,7 +260,7 @@ exports[`renders a Pocket ECS Codepipeline template with a custom step 1`] = `
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {
@@ -370,6 +370,22 @@ exports[`renders a Pocket ECS Codepipeline template with a custom step 1`] = `
           {
             \\"action\\": [
               {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"projectName\\": \\"Test-Env-MyBuild\\"
+                },
+                \\"name\\": \\"MyBuild\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              }
+            ],
+            \\"name\\": \\"Custom_PreDeploy_Stage\\"
+          },
+          {
+            \\"action\\": [
+              {
                 \\"category\\": \\"Build\\",
                 \\"configuration\\": {
                   \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
@@ -424,7 +440,7 @@ exports[`renders a Pocket ECS Codepipeline template with a custom step 1`] = `
                 \\"version\\": \\"1\\"
               }
             ],
-            \\"name\\": \\"Custom_Stage\\"
+            \\"name\\": \\"Custom_PostDeploy_Stage\\"
           }
         ]
       }
@@ -495,7 +511,7 @@ exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {
@@ -719,7 +735,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {
@@ -937,7 +953,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {
@@ -1155,7 +1171,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided appspec pa
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {
@@ -1373,7 +1389,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided code build
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/TestBuildName\\"
+              \\"arn:aws:codebuild:*:*:project/TestBuildName*\\"
             ]
           },
           {
@@ -1591,7 +1607,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided taskdef pa
             ],
             \\"effect\\": \\"Allow\\",
             \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
             ]
           },
           {

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -218,7 +218,7 @@ exports[`renders a Pocket ECS Codepipeline template 1`] = `
 }"
 `;
 
-exports[`renders a Pocket ECS Codepipeline template with a custom step 1`] = `
+exports[`renders a Pocket ECS Codepipeline template with custom steps 1`] = `
 "{
   \\"data\\": {
     \\"aws_iam_policy_document\\": {

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -408,6 +408,23 @@ exports[`renders a Pocket ECS Codepipeline template with a custom step 1`] = `
               }
             ],
             \\"name\\": \\"Deploy\\"
+          },
+          {
+            \\"action\\": [
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ExecutionNamePrefix\\": \\"CodePipelineDeploy\\",
+                  \\"stateMachineArn\\": \\"myStateMachineArn123\\"
+                },
+                \\"name\\": \\"Custom_Action\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"StepFunctions\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              }
+            ],
+            \\"name\\": \\"Custom_Stage\\"
           }
         ]
       }

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -218,6 +218,224 @@ exports[`renders a Pocket ECS Codepipeline template 1`] = `
 }"
 `;
 
+exports[`renders a Pocket ECS Codepipeline template with a custom step 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ]
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\"
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"artifact_store\\": [
+          {
+            \\"encryption_key\\": {
+              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+              \\"type\\": \\"KMS\\"
+            },
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\"
+          }
+        ],
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"stage\\": [
+          {
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"BranchName\\": \\"test\\",
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"DetectChanges\\": \\"false\\",
+                  \\"FullRepositoryId\\": \\"string\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ],
+            \\"name\\": \\"Source\\"
+          },
+          {
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
+                  \\"ProjectName\\": \\"Test-Env\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"Deploy_CDK\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ],
+            \\"name\\": \\"Deploy\\"
+          }
+        ]
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
 "{
   \\"data\\": {

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -160,7 +160,7 @@ exports[`renders a Pocket ECS Codepipeline template 1`] = `
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],
@@ -378,7 +378,7 @@ exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],
@@ -602,7 +602,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],
@@ -820,7 +820,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],
@@ -1038,7 +1038,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided appspec pa
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],
@@ -1256,7 +1256,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided code build
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],
@@ -1474,7 +1474,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided taskdef pa
                 \\"input_artifacts\\": [
                   \\"SourceOutput\\"
                 ],
-                \\"name\\": \\"CodeBuild\\",
+                \\"name\\": \\"Deploy_CDK\\",
                 \\"output_artifacts\\": [
                   \\"CodeBuildOutput\\"
                 ],


### PR DESCRIPTION
# Goal
Allow CodePipeline steps to be added to `PocketECSCodePipeline`.

Our immediate use-case is that we want to add a deployment step that registers Prefect flows. The new test case illustrates how we might do this.

Changes:
- Add `preDeployStages` and `postDeployStages` properties to respectively run stages before and after the deployment.
- Change CodePipeline permissions to execute CodeBuild project if name starts with `prefix`, instead of requiring an exact match. This makes it easy to add custom CodeBuild actions.
- Extracted parts of `createCodePipeline` into smaller methods.

## Reference

Related PR:
* https://github.com/Pocket/data-flows/pull/12

## Implementation Decisions
- Originally we made methods in this class `protected` to allow the CodePipeline stages to be customized. This allows for a lot of customization. After review we decided to keep methods private and pass in a custom stage through the constructor instead.