### PR TITLE
feat(ApplicationECSContainerDefinition) Allow passing entrypoint

### DIFF
--- a/src/base/ApplicationECSContainerDefinition.spec.ts
+++ b/src/base/ApplicationECSContainerDefinition.spec.ts
@@ -133,5 +133,13 @@ describe('ApplicationECSContainerDefinition', () => {
           `"sourceVolume":"/[{}].txt"}`
       );
     });
+
+    it('passes entryPoint', () => {
+      config.entryPoint = ['/bin/bash'];
+
+      const result = buildDefinitionJSON(config);
+
+      expect(result).to.contain(`"entryPoint":["/bin/bash"]`);
+    });
   });
 });

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -48,6 +48,7 @@ export interface ApplicationECSContainerDefinitionProps {
   healthCheck?: HealthcheckVariable;
   mountPoints?: MountPoint[];
   dependsOn?: DependsOn[];
+  entryPoint?: string[];
 }
 
 export function buildDefinitionJSON(
@@ -70,7 +71,7 @@ export function buildDefinitionJSON(
         'awslogs-stream-prefix': 'ecs',
       },
     },
-    entryPoint: null,
+    entryPoint: config.entryPoint ?? null,
     portMappings: config.portMappings ?? [],
     linuxParameters: null,
     cpu: config.cpu ?? 0,


### PR DESCRIPTION
# Goal
The pocket/parser repo uses this for creating it's container definition. I need to pass in entrypoint so that I can create the kinesis-agent config. 

Tickets:
* https://mozilla-hub.atlassian.net/browse/SE-2958
