### PR TITLE
feat(event-bus): add event bus application construct

### DIFF
--- a/src/base/ApplicationEventBridgeRule.ts
+++ b/src/base/ApplicationEventBridgeRule.ts
@@ -35,7 +35,7 @@ export class ApplicationEventBridgeRule extends Resource {
     if (this.config.targets?.length > 5) {
       throw new Error('AWS allows only up to 5 targets per event bridge rule');
     }
-
+    const eventBus = this.config.eventBusName ?? 'default';
     const rule = new eventbridge.CloudwatchEventRule(
       this,
       'event-bridge-rule',
@@ -43,7 +43,7 @@ export class ApplicationEventBridgeRule extends Resource {
         name: `${this.config.name}-Rule`,
         description: this.config.description,
         eventPattern: JSON.stringify(this.config.eventPattern),
-        eventBusName: this.config.eventBusName ?? 'default',
+        eventBusName: eventBus,
         tags: this.config.tags,
       }
     );
@@ -59,6 +59,7 @@ export class ApplicationEventBridgeRule extends Resource {
             arn: t.arn,
             deadLetterConfig: t.deadLetterArn ? { arn: t.deadLetterArn } : {},
             dependsOn: [t.dependsOn, rule],
+            eventBusName: eventBus,
           }
         );
       });

--- a/src/base/ApplicationEventBus.spec.ts
+++ b/src/base/ApplicationEventBus.spec.ts
@@ -1,12 +1,15 @@
 import { Testing } from 'cdktf';
-import { ApplicationEventBus, ApplicationEventBusProps } from './ApplicationEventBus';
+import {
+  ApplicationEventBus,
+  ApplicationEventBusProps,
+} from './ApplicationEventBus';
 
 describe('ApplicationEventBus', () => {
-  it('renders an event bus with name and target',() => {
-    let props : ApplicationEventBusProps = {
+  it('renders an event bus with name and target', () => {
+    const props: ApplicationEventBusProps = {
       name: 'test-event-bus',
-      tags: {'service': 'test-service'}
-    }
+      tags: { service: 'test-service' },
+    };
     const synthed = Testing.synthScope((stack) => {
       new ApplicationEventBus(stack, 'test-event-bus', props);
     });

--- a/src/base/ApplicationEventBus.spec.ts
+++ b/src/base/ApplicationEventBus.spec.ts
@@ -1,0 +1,15 @@
+import { Testing } from 'cdktf';
+import { ApplicationEventBus, ApplicationEventBusProps } from './ApplicationEventBus';
+
+describe('ApplicationEventBus', () => {
+  it('renders an event bus with name and target',() => {
+    let props : ApplicationEventBusProps = {
+      name: 'test-event-bus',
+      tags: {'service': 'test-service'}
+    }
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationEventBus(stack, 'test-event-bus', props);
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+});

--- a/src/base/ApplicationEventBus.ts
+++ b/src/base/ApplicationEventBus.ts
@@ -1,0 +1,33 @@
+import { Resource } from 'cdktf';
+import { eventbridge } from '@cdktf/provider-aws';
+import { Construct } from 'constructs';
+
+export interface ApplicationEventBusProps {
+  name: string,
+  tags?: { [key: string]: string };
+}
+
+export class ApplicationEventBus extends Resource {
+  public readonly bus: eventbridge.CloudwatchEventBus;
+
+  constructor(
+    scope: Construct,
+    name: string,
+    private config: ApplicationEventBusProps
+  ) {
+    super(scope, name);
+
+    this.bus = this.createCloudwatchEventRule();
+  }
+
+  private createCloudwatchEventRule() : eventbridge.CloudwatchEventBus{
+    return new eventbridge.CloudwatchEventBus(
+      this,
+      `event-bus-${this.config.name}`,
+      {
+        name: this.config.name,
+        tags: this.config.tags
+      }
+    );
+  }
+}

--- a/src/base/ApplicationEventBus.ts
+++ b/src/base/ApplicationEventBus.ts
@@ -3,7 +3,7 @@ import { eventbridge } from '@cdktf/provider-aws';
 import { Construct } from 'constructs';
 
 export interface ApplicationEventBusProps {
-  name: string,
+  name: string;
   tags?: { [key: string]: string };
 }
 
@@ -17,16 +17,16 @@ export class ApplicationEventBus extends Resource {
   ) {
     super(scope, name);
 
-    this.bus = this.createCloudwatchEventRule();
+    this.bus = this.createCloudWatchEventBus();
   }
 
-  private createCloudwatchEventRule() : eventbridge.CloudwatchEventBus{
+  private createCloudWatchEventBus(): eventbridge.CloudwatchEventBus {
     return new eventbridge.CloudwatchEventBus(
       this,
       `event-bus-${this.config.name}`,
       {
         name: this.config.name,
-        tags: this.config.tags
+        tags: this.config.tags,
       }
     );
   }

--- a/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
@@ -48,6 +48,7 @@ exports[`AplicationEventBridgeRule renders an event bridge with sqs target 1`] =
           \\"aws_sqs_queue.test-queue\\",
           \\"aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87\\"
         ],
+        \\"event_bus_name\\": \\"default\\",
         \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87.name}\\",
         \\"target_id\\": \\"sqs\\"
       }

--- a/src/base/__snapshots__/ApplicationEventBus.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationEventBus.spec.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationEventBus renders an event bus with name and target 1`] = `
+"{
+  \\"resource\\": {
+    \\"aws_cloudwatch_event_bus\\": {
+      \\"test-event-bus_event-bus-test-event-bus_3B38546A\\": {
+        \\"name\\": \\"test-event-bus\\",
+        \\"tags\\": {
+          \\"service\\": \\"test-service\\"
+        }
+      }
+    }
+  }
+}"
+`;

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,59 +1,96 @@
 import { Construct } from 'constructs';
-import { App, TerraformStack } from 'cdktf';
-import { AwsProvider } from '@cdktf/provider-aws';
+import { App, TerraformResource, TerraformStack } from 'cdktf';
+import { AwsProvider, lambdafunction, sqs } from '@cdktf/provider-aws';
 import { PocketALBApplication } from './pocket/PocketALBApplication';
 import { ApplicationECSContainerDefinitionProps } from './base/ApplicationECSContainerDefinition';
 import { LocalProvider } from '@cdktf/provider-local';
 import { NullProvider } from '@cdktf/provider-null';
+import { ArchiveProvider } from '@cdktf/provider-archive';
+import { PocketVPC } from './pocket/PocketVPC';
+import { PocketEventBridgeWithLambdaTarget } from './pocket/PocketEventBridgeWithLambdaTarget';
+import { LAMBDA_RUNTIMES } from './base/ApplicationVersionedLambda';
+import { PocketVersionedLambda, PocketVersionedLambdaProps } from './pocket/PocketVersionedLambda';
+import {
+  PocketEventBridgeProps,
+  PocketEventBridgeRuleWithMultipleTargets,
+  PocketEventBridgeTargets
+} from './pocket/PocketEventBridgeRuleWithMultipleTargets';
+import { ApplicationEventBus } from './base/ApplicationEventBus';
 
 class Example extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
 
     new AwsProvider(this, 'aws', {
-      region: 'us-east-1',
+      region: 'us-east-1'
     });
     new LocalProvider(this, 'local', {});
     new NullProvider(this, 'null', {});
+    new ArchiveProvider(this, 'archive');
 
-    const containerConfigBlue: ApplicationECSContainerDefinitionProps = {
-      name: 'blueContainer',
-      containerImage: 'bitnami/node-example:0.0.1',
-      portMappings: [
-        {
-          hostPort: 3000,
-          containerPort: 3000,
-        },
-      ],
-      envVars: [
-        {
-          name: 'foo',
-          value: 'bar',
-        },
-      ],
+    const vpc = new PocketVPC(this, 'pocket-shared-vpc');
+
+    const lambdaConfig: PocketVersionedLambdaProps = {
+      name: 'test-datasync-lambda',
+      lambda: {
+        runtime: LAMBDA_RUNTIMES.PYTHON38,
+        handler: 'index.handler'
+      }
+    };
+    const targetLambda = new PocketVersionedLambda(
+      this,
+      'datasync-target-lambda',
+      lambdaConfig
+    );
+
+    const targetLambdaDLQ = new sqs.SqsQueue(this, 'datasync-target-lambda-dlq', {
+      name: 'datasync-target-lambda-dlq'
+    });
+
+
+    let eventBridgeTarget: PocketEventBridgeTargets = {
+      targetId: 'datasync-lambda-id',
+      arn: targetLambda.lambda.versionedLambda.arn,
+      terraformResource: targetLambda.lambda.versionedLambda,
+      deadLetterArn: targetLambdaDLQ.arn
     };
 
-    new PocketALBApplication(this, 'example', {
-      exposedContainer: {
-        name: 'blueContainer',
-        port: 3000,
-        healthCheckPath: '/',
-      },
-      codeDeploy: {
-        useCodeDeploy: true,
-      },
-      cdn: false, // maybe make this false if you're testing an actual terraform apply - cdn's take a loooong time to spin up
-      alb6CharacterPrefix: 'ACMECO',
-      internal: false,
-      domain: 'acme.getpocket.dev',
-      prefix: 'ACME-Dev', // Prefix is a combo of the `Name-Environment`
-      containerConfigs: [containerConfigBlue],
-      ecsIamConfig: {
-        prefix: 'ACME-Dev',
-        taskExecutionRolePolicyStatements: [],
-        taskRolePolicyStatements: [],
-      },
+    let dataSyncEventBus = new ApplicationEventBus(this, 'test-datasync-event-bus', {
+      name: 'test-datasync-event-bus'
     });
+
+    const datasyncConfig: PocketEventBridgeProps = {
+      eventRule: {
+        name: 'test-event-bridge-rule-multiple-targets',
+        pattern: {
+          source: ['curation-migration-datasync-2'],
+          'detail-type': ['add-scheduled-item', 'update-scheduled-item']
+        },
+        eventBusName: dataSyncEventBus.bus.name
+      },
+      targets: [
+        { ...eventBridgeTarget }
+      ]
+    };
+
+    let eventBridgeRuleObj = new PocketEventBridgeRuleWithMultipleTargets(
+      this,
+      'datasync-event-bridge-with-multiple-targets',
+      datasyncConfig
+    );
+
+    let eventBridgeRule =  eventBridgeRuleObj.getEventBridge();
+
+    new lambdafunction.LambdaPermission(this, 'test-datasync-lambda-Function-permission', {
+      action: 'lambda:InvokeFunction',
+      functionName: targetLambda.lambda.versionedLambda.functionName,
+      qualifier: targetLambda.lambda.versionedLambda.name,
+      principal: 'events.amazonaws.com',
+      sourceArn: eventBridgeRule.rule.arn,
+      dependsOn: [targetLambda.lambda.versionedLambda, eventBridgeRule.rule],
+    });
+
+    //to test dlq: setup lambda iam permission to publish to dlq.
   }
 }
 

--- a/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
@@ -73,6 +73,7 @@ exports[`renders an event bridge and multiple target 1`] = `
           \\"aws_lambda_alias.test-lambda_alias_CCFDFCE9\\",
           \\"aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\"
         ],
+        \\"event_bus_name\\": \\"default\\",
         \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
         \\"target_id\\": \\"test-lambda-id\\"
       },
@@ -84,6 +85,7 @@ exports[`renders an event bridge and multiple target 1`] = `
           \\"aws_sqs_queue.test-queue\\",
           \\"aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\"
         ],
+        \\"event_bus_name\\": \\"default\\",
         \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
         \\"target_id\\": \\"test-sqs-id\\"
       }

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -72,6 +72,7 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
           \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
           \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
         ],
+        \\"event_bus_name\\": \\"test-bus\\",
         \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}\\",
         \\"target_id\\": \\"lambda\\"
       }
@@ -244,6 +245,7 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
           \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
           \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
         ],
+        \\"event_bus_name\\": \\"default\\",
         \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}\\",
         \\"target_id\\": \\"lambda\\"
       }


### PR DESCRIPTION
## Goal
- to create custom event bus for event-rules and their targets.

### Implementation details/feedback-on:
- created `ApplicationEventBus` for rolling out custom event bus
- if the `eventBus` is given in the event-rule props, then it is assigned to both event-rule and all its targets.
- if the custom event bus name is not given in the event-rule props, then the `default` event bus is assumed.
- we don't roll-out eventBus as a part of `PocketEventBridgeRuleWithMultipleTargets` construct. if the consuming application requires it, then it can create one and attach them to the pocket construct. 

### Todo
- [x] we are getting this error: 
```
Error: Creating EventBridge Target failed: ResourceNotFoundException: 
Rule test-event-bridge-rule-multiple-targets-Rule does not exist on EventBus default.
```
- fixed by assigning event bus name to the targets as well. 

### Dev deployment: 

[custom event bus]( https://us-east-1.console.aws.amazon.com/events/home?region=us-east-1#/eventbuses/sendevents?eventBus=test-event-bus)
sample event rule: 
```
{
  "version": "0",
  "id": "caa9fa98-246b-5495-9c36-e417e51c5aa6",
  "detail-type": "add-item",
  "source": "test-custom-bus-events",
  "account": "410318598490",
  "time": "2022-04-21T18:00:28Z",
  "region": "us-east-1",
  "resources": [],
  "detail": {
    "hello": "world"
  }
}
```

[cloudwatch logs for capturing event at the lambda target](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Ftest-lambda-Function/log-events/2022$252F04$252F21$252F$255B1$255Df92d0cbafaac480fb827d07265542e9f)

Ticket: https://getpocket.atlassian.net/browse/INFRA-434