### PR TITLE
feat: expose sqsQueueResource on PocketSQSWithLambdaTarget

### DIFF
--- a/src/pocket/PocketSQSWithLambdaTarget.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.ts
@@ -39,7 +39,7 @@ export interface PocketSQSProps {
  * Extends the base pocket versioned lambda class to add a sqs based trigger on top of the lambda
  */
 export class PocketSQSWithLambdaTarget extends PocketVersionedLambda {
-  private readonly sqsQueueResource: sqs.SqsQueue | sqs.DataAwsSqsQueue;
+  public readonly sqsQueueResource: sqs.SqsQueue | sqs.DataAwsSqsQueue;
 
   constructor(
     scope: Construct,


### PR DESCRIPTION
# Goal

Make `sqsQueueResource` a public property so that the underlying data (e.g. `arn`) can be accessed for additional permissions/integrations.
