### PR TITLE
fix(application sqs queue): expose dead letter queue

### DIFF
--- a/src/base/ApplicationSQSQueue.ts
+++ b/src/base/ApplicationSQSQueue.ts
@@ -72,6 +72,7 @@ const validations: {
  */
 export class ApplicationSQSQueue extends Resource {
   public readonly sqsQueue: sqs.SqsQueue;
+  public deadLetterQueue: sqs.SqsQueue | undefined;
 
   constructor(
     scope: Construct,
@@ -118,10 +119,10 @@ export class ApplicationSQSQueue extends Resource {
     };
 
     if (config.maxReceiveCount && config.maxReceiveCount > 0) {
-      const deadLetterQueue = this.createDeadLetterSQSQueue(config);
+      this.deadLetterQueue = this.createDeadLetterSQSQueue(config);
       sqsConfig.redrivePolicy = JSON.stringify({
         maxReceiveCount: config.maxReceiveCount,
-        deadLetterTargetArn: deadLetterQueue.arn,
+        deadLetterTargetArn: this.deadLetterQueue.arn,
       });
     }
 

--- a/src/pocket/PocketSQSWithLambdaTarget.ts
+++ b/src/pocket/PocketSQSWithLambdaTarget.ts
@@ -40,6 +40,7 @@ export interface PocketSQSProps {
  */
 export class PocketSQSWithLambdaTarget extends PocketVersionedLambda {
   public readonly sqsQueueResource: sqs.SqsQueue | sqs.DataAwsSqsQueue;
+  public readonly applicationSqsQueue: ApplicationSQSQueue;
 
   constructor(
     scope: Construct,
@@ -54,11 +55,13 @@ export class PocketSQSWithLambdaTarget extends PocketVersionedLambda {
         ...config.configFromPreexistingSqsQueue,
       });
     } else {
-      this.sqsQueueResource = this.createSqsQueue({
+      this.applicationSqsQueue = this.createSqsQueue({
         ...config.sqsQueue,
         name: `${config.name}-Queue`,
         tags: config.tags,
       });
+
+      this.sqsQueueResource = this.applicationSqsQueue.sqsQueue;
     }
 
     this.createSQSExecutionPolicyOnLambda(
@@ -75,9 +78,8 @@ export class PocketSQSWithLambdaTarget extends PocketVersionedLambda {
    */
   private createSqsQueue(
     sqsQueueConfig: ApplicationSQSQueueProps
-  ): sqs.SqsQueue {
-    return new ApplicationSQSQueue(this, 'lambda_sqs_queue', sqsQueueConfig)
-      .sqsQueue;
+  ): ApplicationSQSQueue {
+    return new ApplicationSQSQueue(this, 'lambda_sqs_queue', sqsQueueConfig);
   }
 
   /**


### PR DESCRIPTION
## Goal

Expose the dead letter queue that may be created on the `ApplicationSQSQueue` construct.
Expose the `ApplicationSQSQueue` construct created as part of the `PocketSQSWithLambdaTarget` construct