### PR TITLE
Fix(application ecs service): expose ECR repos and task definition

### DIFF
--- a/src/base/ApplicationECSService.spec.ts
+++ b/src/base/ApplicationECSService.spec.ts
@@ -270,4 +270,31 @@ describe('ApplicationECSService', () => {
     });
     expect(synthed).toMatchSnapshot();
   });
+
+  it('exposes ECR repos and task definition as public fields', () => {
+    BASE_CONFIG.containerConfigs = [
+      {
+        portMappings: [
+          {
+            containerPort: 3002,
+            hostPort: 3001,
+          },
+        ],
+        name: 'lebowski',
+      },
+    ];
+
+    Testing.synthScope((stack) => {
+      const applicationECSService = new ApplicationECSService(
+        stack,
+        'testECSService',
+        BASE_CONFIG
+      );
+
+      expect(applicationECSService.ecrRepos.length).toEqual(1);
+      expect(
+        applicationECSService.taskDefinition.terraformResourceType
+      ).toEqual('aws_ecs_task_definition');
+    });
+  });
 });

--- a/src/base/ApplicationECSService.ts
+++ b/src/base/ApplicationECSService.ts
@@ -64,6 +64,8 @@ export class ApplicationECSService extends Resource {
   public readonly ecsSecurityGroup: vpc.SecurityGroup;
   public readonly mainTargetGroup?: ApplicationTargetGroup;
   public readonly codeDeployApp?: ApplicationECSAlbCodeDeploy;
+  public readonly ecrRepos: ecr.EcrRepository[];
+  public readonly taskDefinition: ecs.EcsTaskDefinition;
   private readonly config: ApplicationECSServiceProps;
 
   constructor(
@@ -81,6 +83,8 @@ export class ApplicationECSService extends Resource {
 
     this.ecsSecurityGroup = this.setupECSSecurityGroups();
     const { taskDef, ecrRepos } = this.setupECSTaskDefinition();
+    this.taskDefinition = taskDef;
+    this.ecrRepos = ecrRepos;
 
     //Setup an array of resources that the ecs service will need to depend on
     const ecsServiceDependsOn: TerraformResource[] = [...ecrRepos];


### PR DESCRIPTION
# Goal
Expose the ECR repositories that may be created by the `ApplicationECSService`. The immediate need is that the DataFlows repo needs to reference this ECR repo. (See [FFRECSV2-217](https://getpocket.atlassian.net/browse/FFRECSV2-217) for more details.)

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/FFRECSV2-217

## Implementation Decisions
- I couldn't see how to unpack `this.setupECSTaskDefinition()` directly unto class fields, so I used a simple assignment.