### PR TITLE
feat(lambda): expose reservedConcurrencyLimit and memorySize (in MB) to lambda props

### DIFF
--- a/src/base/ApplicationVersionedLambda.ts
+++ b/src/base/ApplicationVersionedLambda.ts
@@ -18,7 +18,7 @@ export interface ApplicationVersionedLambdaProps {
   runtime: LAMBDA_RUNTIMES;
   handler: string;
   timeout?: number;
-  reservedConcurrencyLimit? : number;
+  reservedConcurrencyLimit?: number;
   memorySizeInMb?: number;
   environment?: { [key: string]: string };
   vpcConfig?: lambdafunction.LambdaFunctionVpcConfig;
@@ -77,7 +77,8 @@ export class ApplicationVersionedLambda extends Resource {
       sourceCodeHash: defaultLambda.outputBase64Sha256,
       role: this.lambdaExecutionRole.arn,
       memorySize: this.config.memorySizeInMb ?? DEFAULT_MEMORY_SIZE,
-      reservedConcurrentExecutions: this.config.reservedConcurrencyLimit ?? DEFAULT_CONCURRENCY_LIMIT,
+      reservedConcurrentExecutions:
+        this.config.reservedConcurrencyLimit ?? DEFAULT_CONCURRENCY_LIMIT,
       vpcConfig: this.config.vpcConfig,
       publish: true,
       lifecycle: {

--- a/src/base/ApplicationVersionedLambda.ts
+++ b/src/base/ApplicationVersionedLambda.ts
@@ -18,6 +18,8 @@ export interface ApplicationVersionedLambdaProps {
   runtime: LAMBDA_RUNTIMES;
   handler: string;
   timeout?: number;
+  reservedConcurrencyLimit? : number;
+  memorySizeInMb?: number;
   environment?: { [key: string]: string };
   vpcConfig?: lambdafunction.LambdaFunctionVpcConfig;
   executionPolicyStatements?: iam.DataAwsIamPolicyDocumentStatement[];
@@ -29,6 +31,9 @@ export interface ApplicationVersionedLambdaProps {
 
 const DEFAULT_TIMEOUT = 5;
 const DEFAULT_RETENTION = 14;
+//https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#reserved_concurrent_executions
+const DEFAULT_CONCURRENCY_LIMIT = -1; //unreserved concurrency
+const DEFAULT_MEMORY_SIZE = 128;
 
 export class ApplicationVersionedLambda extends Resource {
   public readonly versionedLambda: lambdafunction.LambdaAlias;
@@ -71,6 +76,8 @@ export class ApplicationVersionedLambda extends Resource {
       timeout: this.config.timeout ?? DEFAULT_TIMEOUT,
       sourceCodeHash: defaultLambda.outputBase64Sha256,
       role: this.lambdaExecutionRole.arn,
+      memorySize: this.config.memorySizeInMb ?? DEFAULT_MEMORY_SIZE,
+      reservedConcurrentExecutions: this.config.reservedConcurrencyLimit ?? DEFAULT_CONCURRENCY_LIMIT,
       vpcConfig: this.config.vpcConfig,
       publish: true,
       lifecycle: {

--- a/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
@@ -113,7 +113,9 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"nodejs14.x\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -251,7 +253,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -389,7 +393,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with description 
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -533,7 +539,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with environment 
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -680,7 +688,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with execution po
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -818,7 +828,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with log retentio
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -957,7 +969,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with publish igno
             \\"publish\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -1095,7 +1109,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -1233,7 +1249,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -1379,7 +1397,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] 
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
@@ -1530,7 +1550,9 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with vpc 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",

--- a/src/pocket/PocketVersionedLambda.spec.ts
+++ b/src/pocket/PocketVersionedLambda.spec.ts
@@ -199,33 +199,32 @@ test('it can treat missing data as breaching', () => {
     });
   });
   expect(synthed).toMatchSnapshot();
+});
 
-
-  test('renders a lambda with concurrencyLimit', () => {
-    const synthed = Testing.synthScope((stack) => {
-      new PocketVersionedLambda(stack, 'test-lambda', {
-        ...config,
-        lambda: {
-          ...config.lambda,
-          reservedConcurrencyLimit: 10,
-        },
-      });
+test('renders a lambda with concurrencyLimit', () => {
+  const synthed = Testing.synthScope((stack) => {
+    new PocketVersionedLambda(stack, 'test-lambda', {
+      ...config,
+      lambda: {
+        ...config.lambda,
+        reservedConcurrencyLimit: 10,
+      },
     });
-    expect(synthed).toMatchSnapshot();
   });
+  expect(synthed).toMatchSnapshot();
+});
 
-  test('renders a lambda with memorySizeInMb', () => {
-    const synthed = Testing.synthScope((stack) => {
-      new PocketVersionedLambda(stack, 'test-lambda', {
-        ...config,
-        lambda: {
-          ...config.lambda,
-          memorySizeInMb: 512,
-        },
-      });
+test('renders a lambda with memorySizeInMb', () => {
+  const synthed = Testing.synthScope((stack) => {
+    new PocketVersionedLambda(stack, 'test-lambda', {
+      ...config,
+      lambda: {
+        ...config.lambda,
+        memorySizeInMb: 512,
+      },
     });
-    expect(synthed).toMatchSnapshot();
   });
+  expect(synthed).toMatchSnapshot();
 });
 
 const testAlarmValidation = (alarmType: string) => {

--- a/src/pocket/PocketVersionedLambda.spec.ts
+++ b/src/pocket/PocketVersionedLambda.spec.ts
@@ -199,6 +199,33 @@ test('it can treat missing data as breaching', () => {
     });
   });
   expect(synthed).toMatchSnapshot();
+
+
+  test('renders a lambda with concurrencyLimit', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new PocketVersionedLambda(stack, 'test-lambda', {
+        ...config,
+        lambda: {
+          ...config.lambda,
+          reservedConcurrencyLimit: 10,
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  test('renders a lambda with memorySizeInMb', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new PocketVersionedLambda(stack, 'test-lambda', {
+        ...config,
+        lambda: {
+          ...config.lambda,
+          memorySizeInMb: 512,
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
 });
 
 const testAlarmValidation = (alarmType: string) => {

--- a/src/pocket/PocketVersionedLambda.ts
+++ b/src/pocket/PocketVersionedLambda.ts
@@ -32,8 +32,8 @@ export interface PocketVersionedLambdaProps {
     runtime: LAMBDA_RUNTIMES;
     handler: string;
     timeout?: number;
-    reservedConcurrencyLimit?: number,
-    memorySizeInMb?: number,
+    reservedConcurrencyLimit?: number;
+    memorySizeInMb?: number;
     environment?: { [key: string]: string };
     vpcConfig?: lambdafunction.LambdaFunctionVpcConfig;
     executionPolicyStatements?: iam.DataAwsIamPolicyDocumentStatement[];
@@ -194,7 +194,7 @@ export class PocketVersionedLambda extends Resource {
       tags: this.config.tags,
       usesCodeDeploy: !!lambdaConfig.codeDeploy,
       memorySizeInMb: lambdaConfig.memorySizeInMb,
-      reservedConcurrencyLimit: lambdaConfig.reservedConcurrencyLimit
+      reservedConcurrencyLimit: lambdaConfig.reservedConcurrencyLimit,
     });
   }
 }

--- a/src/pocket/PocketVersionedLambda.ts
+++ b/src/pocket/PocketVersionedLambda.ts
@@ -32,6 +32,8 @@ export interface PocketVersionedLambdaProps {
     runtime: LAMBDA_RUNTIMES;
     handler: string;
     timeout?: number;
+    reservedConcurrencyLimit?: number,
+    memorySizeInMb?: number,
     environment?: { [key: string]: string };
     vpcConfig?: lambdafunction.LambdaFunctionVpcConfig;
     executionPolicyStatements?: iam.DataAwsIamPolicyDocumentStatement[];
@@ -191,6 +193,8 @@ export class PocketVersionedLambda extends Resource {
         lambdaConfig.s3Bucket ?? `pocket-${this.config.name.toLowerCase()}`,
       tags: this.config.tags,
       usesCodeDeploy: !!lambdaConfig.codeDeploy,
+      memorySizeInMb: lambdaConfig.memorySizeInMb,
+      reservedConcurrencyLimit: lambdaConfig.reservedConcurrencyLimit
     });
   }
 }

--- a/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -211,7 +211,9 @@ exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda 
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136.output_base64sha256}\\",

--- a/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
@@ -147,7 +147,9 @@ exports[`renders an event bridge and multiple target 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -134,7 +134,9 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}\\",
@@ -307,7 +309,9 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}\\",

--- a/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
@@ -156,7 +156,9 @@ exports[`renders a lambda triggered by an existing sqs queue 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",
@@ -332,7 +334,9 @@ exports[`renders a plain sqs queue and lambda target 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",
@@ -514,7 +518,9 @@ exports[`renders a plain sqs queue with a deadletter and lambda target 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",

--- a/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -922,6 +922,146 @@ exports[`renders a lambda with code deploy 1`] = `
 }"
 `;
 
+exports[`renders a lambda with concurrencyLimit 1`] = `
+"{
+  \\"data\\": {
+    \\"archive_file\\": {
+      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
+        \\"output_path\\": \\"index.py.zip\\",
+        \\"source\\": [
+          {
+            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
+            \\"filename\\": \\"index.py\\"
+          }
+        ],
+        \\"type\\": \\"zip\\"
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda_assume-policy-document_D538087D\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"lambda.amazonaws.com\\",
+                  \\"edgelambda.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      },
+      \\"test-lambda_execution-policy-document_D94D17B4\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"logs:CreateLogGroup\\",
+              \\"logs:CreateLogStream\\",
+              \\"logs:PutLogEvents\\",
+              \\"logs:DescribeLogStreams\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:logs:*:*:*\\"
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_cloudwatch_log_group\\": {
+      \\"test-lambda_log-group_ACC182B5\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"retention_in_days\\": 14
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"test-lambda_execution-policy_19C785A8\\": {
+        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda_execution-role_9D4EE856\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
+        \\"name\\": \\"test-lambda-ExecutionRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
+          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+        ],
+        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+      }
+    },
+    \\"aws_lambda_alias\\": {
+      \\"test-lambda_alias_CCFDFCE9\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"function_version\\"
+          ]
+        },
+        \\"name\\": \\"DEPLOYED\\"
+      }
+    },
+    \\"aws_lambda_function\\": {
+      \\"test-lambda_8915D118\\": {
+        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
+        \\"function_name\\": \\"test-lambda-Function\\",
+        \\"handler\\": \\"index.handler\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"filename\\",
+            \\"source_code_hash\\"
+          ]
+        },
+        \\"memory_size\\": 128,
+        \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": 10,
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
+        \\"runtime\\": \\"python3.8\\",
+        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
+        \\"timeout\\": 5
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-lambda_code-bucket_177F316E\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-test-lambda\\",
+        \\"force_destroy\\": true
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
+        \\"block_public_acls\\": true,
+        \\"block_public_policy\\": true,
+        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders a lambda with environment variables 1`] = `
 "{
   \\"data\\": {
@@ -1471,6 +1611,146 @@ exports[`renders a lambda with log retention 1`] = `
           ]
         },
         \\"memory_size\\": 128,
+        \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
+        \\"runtime\\": \\"python3.8\\",
+        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
+        \\"timeout\\": 5
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-lambda_code-bucket_177F316E\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-test-lambda\\",
+        \\"force_destroy\\": true
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
+        \\"block_public_acls\\": true,
+        \\"block_public_policy\\": true,
+        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`renders a lambda with memorySizeInMb 1`] = `
+"{
+  \\"data\\": {
+    \\"archive_file\\": {
+      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
+        \\"output_path\\": \\"index.py.zip\\",
+        \\"source\\": [
+          {
+            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
+            \\"filename\\": \\"index.py\\"
+          }
+        ],
+        \\"type\\": \\"zip\\"
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda_assume-policy-document_D538087D\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"lambda.amazonaws.com\\",
+                  \\"edgelambda.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      },
+      \\"test-lambda_execution-policy-document_D94D17B4\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"logs:CreateLogGroup\\",
+              \\"logs:CreateLogStream\\",
+              \\"logs:PutLogEvents\\",
+              \\"logs:DescribeLogStreams\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:logs:*:*:*\\"
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_cloudwatch_log_group\\": {
+      \\"test-lambda_log-group_ACC182B5\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"retention_in_days\\": 14
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"test-lambda_execution-policy_19C785A8\\": {
+        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda_execution-role_9D4EE856\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
+        \\"name\\": \\"test-lambda-ExecutionRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
+          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+        ],
+        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+      }
+    },
+    \\"aws_lambda_alias\\": {
+      \\"test-lambda_alias_CCFDFCE9\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"function_version\\"
+          ]
+        },
+        \\"name\\": \\"DEPLOYED\\"
+      }
+    },
+    \\"aws_lambda_function\\": {
+      \\"test-lambda_8915D118\\": {
+        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
+        \\"function_name\\": \\"test-lambda-Function\\",
+        \\"handler\\": \\"index.handler\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"filename\\",
+            \\"source_code_hash\\"
+          ]
+        },
+        \\"memory_size\\": 512,
         \\"publish\\": true,
         \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",

--- a/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -138,7 +138,9 @@ exports[`it can treat missing data as breaching 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -276,7 +278,9 @@ exports[`renders a lambda target 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -414,7 +418,9 @@ exports[`renders a lambda target with tags 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -677,7 +683,9 @@ exports[`renders a lambda with alarms 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -887,7 +895,9 @@ exports[`renders a lambda with code deploy 1`] = `
             \\"publish\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1031,7 +1041,9 @@ exports[`renders a lambda with environment variables 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1178,7 +1190,9 @@ exports[`renders a lambda with execution policy 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1316,7 +1330,9 @@ exports[`renders a lambda with lambda description 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1454,7 +1470,9 @@ exports[`renders a lambda with log retention 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1592,7 +1610,9 @@ exports[`renders a lambda with s3 bucket 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1730,7 +1750,9 @@ exports[`renders a lambda with timeout 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
@@ -1881,7 +1903,9 @@ exports[`renders a lambda with vpc config 1`] = `
             \\"source_code_hash\\"
           ]
         },
+        \\"memory_size\\": 128,
         \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
         \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
         \\"runtime\\": \\"python3.8\\",
         \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",


### PR DESCRIPTION
# Goal
- to expose reservedConcurrencyLimit and memorySize (in MB) to lambda props, so that it can be set by the consumping application.


### Implementation details
- set to terraform defaults if the concurrency limit or memory size is not set by the consuming application. 
- when not set, reserved concurrency defaults to `-1` (denotes unreserved concurrency)
- when not set, memory size default is 128MB.

terraform documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#reserved_concurrent_executions

Ticket:[ BACK-1417](https://getpocket.atlassian.net/browse/BACK-1417)
