### PR TITLE
feat(PocketECSCodePipeline): add parameter for custom artifact bucket name [FFRECSV2-218]

### DIFF
--- a/src/pocket/PocketECSCodePipeline.spec.ts
+++ b/src/pocket/PocketECSCodePipeline.spec.ts
@@ -64,6 +64,16 @@ test('renders a Pocket ECS Codepipeline template with the provided CodeDeploy de
   expect(synthed).toMatchSnapshot();
 });
 
+test('renders a Pocket ECS Codepipeline template with the provided artifact bucket prefix', () => {
+  const synthed = Testing.synthScope((stack) => {
+    new PocketECSCodePipeline(stack, 'test-codepipeline', {
+      ...config,
+      artifactBucketPrefix: 'my-codepipeline',
+    });
+  });
+  expect(synthed).toMatchSnapshot();
+});
+
 test('renders a Pocket ECS Codepipeline template with the provided appspec path', () => {
   const synthed = Testing.synthScope((stack) => {
     new PocketECSCodePipeline(stack, 'test-codepipeline', {

--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -5,6 +5,7 @@ import crypto from 'crypto';
 
 export interface PocketECSCodePipelineProps {
   prefix: string;
+  artifactBucketPrefix?: string;
   source: {
     repository: string;
     branchName: string;
@@ -69,6 +70,9 @@ export class PocketECSCodePipeline extends Resource {
   private getCodeBuildProjectName = () =>
     this.config.codeBuildProjectName ?? this.config.prefix;
 
+  private getArtifactBucketPrefix = () =>
+    this.config.artifactBucketPrefix ?? 'pocket-codepipeline';
+
   private getCodeDeployApplicationName = () =>
     this.config.codeDeploy?.applicationName ?? `${this.config.prefix}-ECS`;
 
@@ -125,7 +129,7 @@ export class PocketECSCodePipeline extends Resource {
       .digest('hex');
 
     return new s3.S3Bucket(this, 'codepipeline-bucket', {
-      bucket: `pocket-codepipeline-${prefixHash}`,
+      bucket: `${this.getArtifactBucketPrefix()}-${prefixHash}`,
       acl: 'private',
       forceDestroy: true,
       tags: this.config.tags,

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -1347,6 +1347,224 @@ exports[`renders a Pocket ECS Codepipeline template with the provided appspec pa
 }"
 `;
 
+exports[`renders a Pocket ECS Codepipeline template with the provided artifact bucket prefix 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codepipeline.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      },
+      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"codestar-connections:UseConnection\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:codestart-connection:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codebuild:BatchGetBuilds\\",
+              \\"codebuild:StartBuild\\",
+              \\"codebuild:BatchGetBuildBatches\\",
+              \\"codebuild:StartBuildBatch\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"codedeploy:CreateDeployment\\",
+              \\"codedeploy:GetApplication\\",
+              \\"codedeploy:GetApplicationRevision\\",
+              \\"codedeploy:GetDeployment\\",
+              \\"codedeploy:RegisterApplicationRevision\\",
+              \\"codedeploy:GetDeploymentConfig\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
+              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"s3:GetObject\\",
+              \\"s3:GetObjectVersion\\",
+              \\"s3:GetBucketVersioning\\",
+              \\"s3:PutObjectAcl\\",
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
+              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"iam:PassRole\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"StringEqualsIfExists\\",
+                \\"values\\": [
+                  \\"ecs-tasks.amazonaws.com\\"
+                ],
+                \\"variable\\": \\"iam:PassedToService\\"
+              }
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          },
+          {
+            \\"actions\\": [
+              \\"ecs:RegisterTaskDefinition\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"*\\"
+            ]
+          }
+        ]
+      }
+    },
+    \\"aws_kms_alias\\": {
+      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
+        \\"name\\": \\"alias/aws/s3\\"
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_codepipeline\\": {
+      \\"test-codepipeline_367BF1E2\\": {
+        \\"artifact_store\\": [
+          {
+            \\"encryption_key\\": {
+              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
+              \\"type\\": \\"KMS\\"
+            },
+            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
+            \\"type\\": \\"S3\\"
+          }
+        ],
+        \\"name\\": \\"Test-Env-CodePipeline\\",
+        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
+        \\"stage\\": [
+          {
+            \\"action\\": [
+              {
+                \\"category\\": \\"Source\\",
+                \\"configuration\\": {
+                  \\"BranchName\\": \\"test\\",
+                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
+                  \\"DetectChanges\\": \\"false\\",
+                  \\"FullRepositoryId\\": \\"string\\"
+                },
+                \\"name\\": \\"GitHub_Checkout\\",
+                \\"namespace\\": \\"SourceVariables\\",
+                \\"output_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeStarSourceConnection\\",
+                \\"version\\": \\"1\\"
+              }
+            ],
+            \\"name\\": \\"Source\\"
+          },
+          {
+            \\"action\\": [
+              {
+                \\"category\\": \\"Build\\",
+                \\"configuration\\": {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
+                  \\"ProjectName\\": \\"Test-Env\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"SourceOutput\\"
+                ],
+                \\"name\\": \\"Deploy_CDK\\",
+                \\"output_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeBuild\\",
+                \\"run_order\\": 1,
+                \\"version\\": \\"1\\"
+              },
+              {
+                \\"category\\": \\"Deploy\\",
+                \\"configuration\\": {
+                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
+                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
+                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
+                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
+                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                },
+                \\"input_artifacts\\": [
+                  \\"CodeBuildOutput\\"
+                ],
+                \\"name\\": \\"Deploy_ECS\\",
+                \\"owner\\": \\"AWS\\",
+                \\"provider\\": \\"CodeDeployToECS\\",
+                \\"run_order\\": 2,
+                \\"version\\": \\"1\\"
+              }
+            ],
+            \\"name\\": \\"Deploy\\"
+          }
+        ]
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
+        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+      }
+    },
+    \\"aws_iam_role_policy\\": {
+      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
+        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
+        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"my-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
+        \\"force_destroy\\": true
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders a Pocket ECS Codepipeline template with the provided code build project name 1`] = `
 "{
   \\"data\\": {


### PR DESCRIPTION
# Goal
Allow `PocketECSCodePipeline` to be deployed outside of Pocket's AWS account. This currently fails because the artifact bucket is not unique. I ran into this because I'm writing steps on how others can deploy [Pocket/data-flows](https://github.com/Pocket/data-flows).

## Reference

Tickets:
* [Link to JIRA tickets](https://getpocket.atlassian.net/browse/FFRECSV2-218)

## Implementation Decisions
- Should we have an organization parameter somewhere, that would allow us to configure the `pocket` string globally?