### PR TITLE
fix(lambda): add NodeJS 16 support

### DIFF
--- a/src/base/ApplicationVersionedLambda.ts
+++ b/src/base/ApplicationVersionedLambda.ts
@@ -10,6 +10,7 @@ export enum LAMBDA_RUNTIMES {
   PYTHON38 = 'python3.8',
   NODEJS12 = 'nodejs12.x',
   NODEJS14 = 'nodejs14.x',
+  NODEJS16 = 'nodejs16.x',
 }
 
 export interface ApplicationVersionedLambdaProps {


### PR DESCRIPTION
## Goal

Allow the use of NodeJS 16 runtime for lambda
Reference: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
