### PR TITLE
feat(peer): removing peer depedencies in favor of direct usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,18 +43,7 @@
         "ts-node": "10.8.1"
       },
       "engines": {
-        "node": ">=10.12"
-      },
-      "peerDependencies": {
-        "@cdktf/provider-archive": "0.5.27",
-        "@cdktf/provider-aws": "8.0.12",
-        "@cdktf/provider-local": "0.5.26",
-        "@cdktf/provider-newrelic": "0.5.142",
-        "@cdktf/provider-null": "0.7.27",
-        "@cdktf/provider-pagerduty": "0.5.27",
-        "cdktf": "0.11.2",
-        "cdktf-cli": "0.11.2",
-        "constructs": "10.1.42"
+        "node": ">=14"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -83,18 +83,7 @@
     ]
   },
   "engines": {
-    "node": ">=10.12"
-  },
-  "peerDependencies": {
-    "@cdktf/provider-archive": "0.5.27",
-    "@cdktf/provider-aws": "8.0.12",
-    "@cdktf/provider-local": "0.5.26",
-    "@cdktf/provider-newrelic": "0.5.142",
-    "@cdktf/provider-null": "0.7.27",
-    "@cdktf/provider-pagerduty": "0.5.27",
-    "cdktf": "0.11.2",
-    "cdktf-cli": "0.11.2",
-    "constructs": "10.1.42"
+    "node": ">=14"
   },
   "dependencies": {
     "@cdktf/provider-archive": "0.5.27",


### PR DESCRIPTION
# Goal

Remove the usage of peer dependencies and require direct usage of explicit versions in our repos.


This will cause these exact versions to always be installed in our repositories. Based on our usage at @pocket I have not seen a use of us using a different version in downstream repos.