### PR TITLE
[INFRA-638] Make Lambda CodeDeploy notifications configurable

### DIFF
--- a/src/base/ApplicationLambdaCodeDeploy.spec.ts
+++ b/src/base/ApplicationLambdaCodeDeploy.spec.ts
@@ -38,4 +38,45 @@ describe('ApplicationLambdaCodeDeploy', () => {
     });
     expect(synthed).toMatchSnapshot();
   });
+
+  it('renders a lambda code deploy app with default notifications', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLambdaCodeDeploy(stack, 'test-lambda-code-deploy', {
+        ...config,
+        deploySnsTopicArn: 'test:deploy-topic:arn',
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders a lambda code deploy app with started and succeeded notifications only', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLambdaCodeDeploy(stack, 'test-lambda-code-deploy', {
+        ...config,
+        deploySnsTopicArn: 'test:deploy-topic:arn',
+        notifications: {
+          //have to explicitly set notifyOnFailed to false since it'll be set to true as default
+          notifyOnFailed: false,
+          notifyOnStarted: true,
+          notifyOnSucceeded: true,
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders a lambda code deploy app with all notifications enabled', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLambdaCodeDeploy(stack, 'test-lambda-code-deploy', {
+        ...config,
+        deploySnsTopicArn: 'test:deploy-topic:arn',
+        notifications: {
+          //not setting the notifyOnFailed since it will be enabled by default if not provided
+          notifyOnStarted: true,
+          notifyOnSucceeded: true,
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
 });

--- a/src/base/ApplicationLambdaCodeDeploy.ts
+++ b/src/base/ApplicationLambdaCodeDeploy.ts
@@ -8,6 +8,20 @@ export interface ApplicationVersionedLambdaCodeDeployProps {
   detailType?: 'BASIC' | 'FULL';
   region: string;
   accountId: string;
+  notifications?: {
+    /**
+     * Option to send CodeDeploy notifications on Started event, defaults to true.
+     */
+    notifyOnStarted?: boolean;
+    /**
+     * Option to send CodeDeploy notifications on Succeeded event, defaults to true.
+     */
+    notifyOnSucceeded?: boolean;
+    /**
+     * Option to send CodeDeploy notifications on Failed event, defaults to true.
+     */
+    notifyOnFailed?: boolean;
+  };
 }
 
 export class ApplicationLambdaCodeDeploy extends Resource {
@@ -100,9 +114,27 @@ export class ApplicationLambdaCodeDeploy extends Resource {
   private setupCodeDeployNotifications(
     codeDeployApp: codedeploy.CodedeployApp
   ) {
+    const eventTypeIds = [];
+
+    // the OR condition here sets the notification for failed deploys which is a default when no notification preferences are provided
+    if (
+      this.config.notifications?.notifyOnFailed ||
+      this.config.notifications?.notifyOnFailed === undefined
+    ) {
+      eventTypeIds.push('codedeploy-application-deployment-failed');
+    }
+
+    if (this.config.notifications?.notifyOnSucceeded) {
+      eventTypeIds.push('codedeploy-application-deployment-succeeded');
+    }
+
+    if (this.config.notifications?.notifyOnStarted) {
+      eventTypeIds.push('codedeploy-application-deployment-started');
+    }
+
     new codestar.CodestarnotificationsNotificationRule(this, 'notifications', {
       detailType: this.config.detailType ?? 'BASIC',
-      eventTypeIds: ['codedeploy-application-deployment-failed'],
+      eventTypeIds: eventTypeIds,
       name: codeDeployApp.name,
       resource: `arn:aws:codedeploy:${this.config.region}:${this.config.accountId}:application:${codeDeployApp.name}`,
       target: [

--- a/src/base/__snapshots__/ApplicationLambdaCodeDeploy.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLambdaCodeDeploy.spec.ts.snap
@@ -242,3 +242,264 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
   }
 }"
 `;
+
+exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with default notifications 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codedeploy.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_codedeploy_app\\": {
+      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
+        \\"compute_platform\\": \\"Lambda\\",
+        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+      }
+    },
+    \\"aws_codedeploy_deployment_group\\": {
+      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
+        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"auto_rollback_configuration\\": {
+          \\"enabled\\": true,
+          \\"events\\": [
+            \\"DEPLOYMENT_FAILURE\\"
+          ]
+        },
+        \\"depends_on\\": [
+          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        ],
+        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
+        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"deployment_style\\": {
+          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
+          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        },
+        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+      }
+    },
+    \\"aws_codestarnotifications_notification_rule\\": {
+      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
+        \\"detail_type\\": \\"BASIC\\",
+        \\"event_type_ids\\": [
+          \\"codedeploy-application-deployment-failed\\"
+        ],
+        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"target\\": [
+          {
+            \\"address\\": \\"test:deploy-topic:arn\\"
+          }
+        ]
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
+        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+        ],
+        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with started and succeeded notifications only 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codedeploy.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_codedeploy_app\\": {
+      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
+        \\"compute_platform\\": \\"Lambda\\",
+        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+      }
+    },
+    \\"aws_codedeploy_deployment_group\\": {
+      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
+        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"auto_rollback_configuration\\": {
+          \\"enabled\\": true,
+          \\"events\\": [
+            \\"DEPLOYMENT_FAILURE\\"
+          ]
+        },
+        \\"depends_on\\": [
+          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        ],
+        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
+        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"deployment_style\\": {
+          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
+          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        },
+        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+      }
+    },
+    \\"aws_codestarnotifications_notification_rule\\": {
+      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
+        \\"detail_type\\": \\"BASIC\\",
+        \\"event_type_ids\\": [
+          \\"codedeploy-application-deployment-succeeded\\",
+          \\"codedeploy-application-deployment-started\\"
+        ],
+        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"target\\": [
+          {
+            \\"address\\": \\"test:deploy-topic:arn\\"
+          }
+        ]
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
+        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+        ],
+        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with all notifications enabled 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codedeploy.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_codedeploy_app\\": {
+      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
+        \\"compute_platform\\": \\"Lambda\\",
+        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+      }
+    },
+    \\"aws_codedeploy_deployment_group\\": {
+      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
+        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"auto_rollback_configuration\\": {
+          \\"enabled\\": true,
+          \\"events\\": [
+            \\"DEPLOYMENT_FAILURE\\"
+          ]
+        },
+        \\"depends_on\\": [
+          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        ],
+        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
+        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"deployment_style\\": {
+          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
+          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        },
+        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+      }
+    },
+    \\"aws_codestarnotifications_notification_rule\\": {
+      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
+        \\"detail_type\\": \\"BASIC\\",
+        \\"event_type_ids\\": [
+          \\"codedeploy-application-deployment-failed\\",
+          \\"codedeploy-application-deployment-succeeded\\",
+          \\"codedeploy-application-deployment-started\\"
+        ],
+        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
+        \\"target\\": [
+          {
+            \\"address\\": \\"test:deploy-topic:arn\\"
+          }
+        ]
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
+        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+        ],
+        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+      }
+    }
+  }
+}"
+`;

--- a/src/pocket/PocketVersionedLambda.spec.ts
+++ b/src/pocket/PocketVersionedLambda.spec.ts
@@ -148,6 +148,29 @@ test('renders a lambda with code deploy', () => {
   expect(synthed).toMatchSnapshot();
 });
 
+test('renders a lambda with code deploy with all deploy notifications turned on', () => {
+  const synthed = Testing.synthScope((stack) => {
+    new PocketVersionedLambda(stack, 'test-lambda', {
+      ...config,
+      lambda: {
+        ...config.lambda,
+        codeDeploy: {
+          deploySnsTopicArn: 'arn:test',
+          detailType: 'FULL',
+          region: 'us-east-1',
+          accountId: 'test-account',
+          notifications: {
+            // omitting notifyOnFailed since it's set to true by default if not provided
+            notifyOnStarted: true,
+            notifyOnSucceeded: true,
+          },
+        },
+      },
+    });
+  });
+  expect(synthed).toMatchSnapshot();
+});
+
 test('renders a lambda with alarms', () => {
   const synthed = Testing.synthScope((stack) => {
     new PocketVersionedLambda(stack, 'test-lambda', {

--- a/src/pocket/PocketVersionedLambda.ts
+++ b/src/pocket/PocketVersionedLambda.ts
@@ -44,6 +44,11 @@ export interface PocketVersionedLambdaProps {
       detailType?: 'BASIC' | 'FULL';
       region: string;
       accountId: string;
+      notifications?: {
+        notifyOnStarted?: boolean;
+        notifyOnSucceeded?: boolean;
+        notifyOnFailed?: boolean;
+      };
     };
     alarms?: {
       invocations?: PocketVersionedLambdaDefaultAlarmProps;
@@ -173,6 +178,7 @@ export class PocketVersionedLambda extends Resource {
       detailType: lambdaConfig.codeDeploy.detailType,
       region: lambdaConfig.codeDeploy.region,
       accountId: lambdaConfig.codeDeploy.accountId,
+      notifications: lambdaConfig.codeDeploy.notifications,
     });
   }
 

--- a/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -922,6 +922,220 @@ exports[`renders a lambda with code deploy 1`] = `
 }"
 `;
 
+exports[`renders a lambda with code deploy with all deploy notifications turned on 1`] = `
+"{
+  \\"data\\": {
+    \\"archive_file\\": {
+      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
+        \\"output_path\\": \\"index.py.zip\\",
+        \\"source\\": [
+          {
+            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
+            \\"filename\\": \\"index.py\\"
+          }
+        ],
+        \\"type\\": \\"zip\\"
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"test-lambda_assume-policy-document_D538087D\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"lambda.amazonaws.com\\",
+                  \\"edgelambda.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      },
+      \\"test-lambda_execution-policy-document_D94D17B4\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"logs:CreateLogGroup\\",
+              \\"logs:CreateLogStream\\",
+              \\"logs:PutLogEvents\\",
+              \\"logs:DescribeLogStreams\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"resources\\": [
+              \\"arn:aws:logs:*:*:*\\"
+            ]
+          }
+        ],
+        \\"version\\": \\"2012-10-17\\"
+      },
+      \\"test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sts:AssumeRole\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"codedeploy.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_cloudwatch_log_group\\": {
+      \\"test-lambda_log-group_ACC182B5\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"retention_in_days\\": 14
+      }
+    },
+    \\"aws_codedeploy_app\\": {
+      \\"test-lambda_lambda-code-deploy_code-deploy-app_7C98647C\\": {
+        \\"compute_platform\\": \\"Lambda\\",
+        \\"name\\": \\"test-lambda-Lambda\\"
+      }
+    },
+    \\"aws_codedeploy_deployment_group\\": {
+      \\"test-lambda_lambda-code-deploy_code-deployment-group_07908CD9\\": {
+        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
+        \\"auto_rollback_configuration\\": {
+          \\"enabled\\": true,
+          \\"events\\": [
+            \\"DEPLOYMENT_FAILURE\\"
+          ]
+        },
+        \\"depends_on\\": [
+          \\"aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C\\"
+        ],
+        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
+        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
+        \\"deployment_style\\": {
+          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
+          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        },
+        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.arn}\\"
+      }
+    },
+    \\"aws_codestarnotifications_notification_rule\\": {
+      \\"test-lambda_lambda-code-deploy_notifications_E3D09B45\\": {
+        \\"detail_type\\": \\"FULL\\",
+        \\"event_type_ids\\": [
+          \\"codedeploy-application-deployment-failed\\",
+          \\"codedeploy-application-deployment-succeeded\\",
+          \\"codedeploy-application-deployment-started\\"
+        ],
+        \\"name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
+        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:test-account:application:\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
+        \\"target\\": [
+          {
+            \\"address\\": \\"arn:test\\"
+          }
+        ]
+      }
+    },
+    \\"aws_iam_policy\\": {
+      \\"test-lambda_execution-policy_19C785A8\\": {
+        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+      }
+    },
+    \\"aws_iam_role\\": {
+      \\"test-lambda_execution-role_9D4EE856\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
+        \\"name\\": \\"test-lambda-ExecutionRole\\"
+      },
+      \\"test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC\\": {
+        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39.json}\\",
+        \\"name\\": \\"test-lambda-CodeDeployRole\\"
+      }
+    },
+    \\"aws_iam_role_policy_attachment\\": {
+      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
+          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+        ],
+        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+      },
+      \\"test-lambda_lambda-code-deploy_code-deploy-policy-attachment_0805E344\\": {
+        \\"depends_on\\": [
+          \\"aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC\\"
+        ],
+        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
+        \\"role\\": \\"\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.name}\\"
+      }
+    },
+    \\"aws_lambda_alias\\": {
+      \\"test-lambda_alias_CCFDFCE9\\": {
+        \\"depends_on\\": [
+          \\"aws_lambda_function.test-lambda_8915D118\\"
+        ],
+        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
+        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"function_version\\"
+          ]
+        },
+        \\"name\\": \\"DEPLOYED\\"
+      }
+    },
+    \\"aws_lambda_function\\": {
+      \\"test-lambda_8915D118\\": {
+        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
+        \\"function_name\\": \\"test-lambda-Function\\",
+        \\"handler\\": \\"index.handler\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"filename\\",
+            \\"source_code_hash\\",
+            \\"publish\\"
+          ]
+        },
+        \\"memory_size\\": 128,
+        \\"publish\\": true,
+        \\"reserved_concurrent_executions\\": -1,
+        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
+        \\"runtime\\": \\"python3.8\\",
+        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
+        \\"timeout\\": 5
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"test-lambda_code-bucket_177F316E\\": {
+        \\"acl\\": \\"private\\",
+        \\"bucket\\": \\"pocket-test-lambda\\",
+        \\"force_destroy\\": true
+      }
+    },
+    \\"aws_s3_bucket_public_access_block\\": {
+      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
+        \\"block_public_acls\\": true,
+        \\"block_public_policy\\": true,
+        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`renders a lambda with concurrencyLimit 1`] = `
 "{
   \\"data\\": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,8 @@
   "extends": "@pocket-tools/tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "src"
   },
-  "exclude": [
-    "node_modules/",
-    "dist/"
-  ],
-  "include": [
-    "src/**/*.ts", 
-    "src/config"
-  ],
+  "exclude": ["node_modules/", "dist/"],
+  "include": ["src/**/*.ts", "src/config"]
 }


### PR DESCRIPTION
# Goal

Make the Lambda CodeDeploy notifications configurable to prevent noise in the **#log-backend-deploys** channel

Tickets:
* [INFRA-638]

Similar to this PR: https://github.com/Pocket/terraform-modules/pull/911