### PR TITLE
fix(newrelic): Update sum to slideBy

### DIFF
--- a/src/pocket/PocketSynthetics.ts
+++ b/src/pocket/PocketSynthetics.ts
@@ -13,10 +13,13 @@ export interface PocketSyntheticProps {
   nrqlConfig?: {
     query?: string;
     evaluationOffset?: number;
-    valueFunction?: string;
     violationTimeLimitSeconds?: number;
     closeViolationsOnExpiration?: boolean;
     expirationDuration?: number;
+    slideBy: number;
+    aggregationWindow: number;
+    aggregationMethod: string;
+    aggregationDelay: string;
     critical?: {
       operator?: string;
       threshold?: number;
@@ -64,8 +67,10 @@ export class PocketSyntheticCheck extends Resource {
 
     const defaultNrqlConfig = {
       query: `SELECT count(result) from SyntheticCheck where result = 'FAILED' and monitorName = '${pocketMonitor.name}'`,
-      evaluationOffset: 3,
-      valueFunction: 'sum',
+      aggregationMethod: 'cadence',
+      aggregationWindow: 3000,
+      aggregationDelay: '180',
+      slideBy: 60,
       violationTimeLimitSeconds: 2592000,
       closeViolationsOnExpiration: true,
       expirationDuration: 600,
@@ -87,11 +92,13 @@ export class PocketSyntheticCheck extends Resource {
       policyId: this.config.policyId,
       fillValue: 0,
       fillOption: 'static',
+      aggregationWindow: this.config.nrqlConfig.aggregationWindow,
+      aggregationMethod: this.config.nrqlConfig.aggregationMethod,
+      aggregationDelay: this.config.nrqlConfig.aggregationDelay,
+      slideBy: this.config.nrqlConfig.slideBy,
       nrql: {
         query: this.config.nrqlConfig.query,
-        evaluationOffset: this.config.nrqlConfig.evaluationOffset,
       },
-      valueFunction: this.config.nrqlConfig.valueFunction,
       violationTimeLimitSeconds:
         this.config.nrqlConfig.violationTimeLimitSeconds,
       closeViolationsOnExpiration:

--- a/src/pocket/__snapshots__/PocketSynthetics.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSynthetics.spec.ts.snap
@@ -5,6 +5,9 @@ exports[`allows passing different values for nrql config 1`] = `
   \\"resource\\": {
     \\"newrelic_nrql_alert_condition\\": {
       \\"test-synthetic_alert-condition_4C991B53\\": {
+        \\"aggregation_delay\\": \\"180\\",
+        \\"aggregation_method\\": \\"cadence\\",
+        \\"aggregation_window\\": 3000,
         \\"close_violations_on_expiration\\": true,
         \\"critical\\": {
           \\"operator\\": \\"above\\",
@@ -17,11 +20,10 @@ exports[`allows passing different values for nrql config 1`] = `
         \\"fill_value\\": 0,
         \\"name\\": \\"test-synthetic-nrql\\",
         \\"nrql\\": {
-          \\"evaluation_offset\\": 3,
           \\"query\\": \\"SELECT * FROM MY-COOL-TABLE\\"
         },
         \\"policy_id\\": 1707149,
-        \\"value_function\\": \\"sum\\",
+        \\"slide_by\\": 60,
         \\"violation_time_limit_seconds\\": 2592000
       }
     },
@@ -49,6 +51,9 @@ exports[`renders a Pocket New Relic synthetic check 1`] = `
   \\"resource\\": {
     \\"newrelic_nrql_alert_condition\\": {
       \\"test-synthetic_alert-condition_4C991B53\\": {
+        \\"aggregation_delay\\": \\"180\\",
+        \\"aggregation_method\\": \\"cadence\\",
+        \\"aggregation_window\\": 3000,
         \\"close_violations_on_expiration\\": true,
         \\"critical\\": {
           \\"operator\\": \\"above\\",
@@ -61,11 +66,10 @@ exports[`renders a Pocket New Relic synthetic check 1`] = `
         \\"fill_value\\": 0,
         \\"name\\": \\"test-synthetic-nrql\\",
         \\"nrql\\": {
-          \\"evaluation_offset\\": 3,
           \\"query\\": \\"SELECT count(result) from SyntheticCheck where result = 'FAILED' and monitorName = '\${newrelic_synthetics_monitor.test-synthetic_test-synthetic-synthetics-monitor_914DC880.name}'\\"
         },
         \\"policy_id\\": 1707149,
-        \\"value_function\\": \\"sum\\",
+        \\"slide_by\\": 60,
         \\"violation_time_limit_seconds\\": 2592000
       }
     },


### PR DESCRIPTION
# Goal

`sum` went away on June 30th 2022. Updating to use `slideBy` instead. I _think_ this matches the current configuration.

@bassrock mentioned not seeing the conversion code in the UI. That is because they automatically converted it for us.

https://discuss.newrelic.com/t/converting-sum-of-thresholds-to-use-sliding-windows-aggregation/175084
