### PR TITLE
fix(EventBridgeRule): make terraform resource optional

### DIFF
--- a/src/base/ApplicationEventBridgeRule.spec.ts
+++ b/src/base/ApplicationEventBridgeRule.spec.ts
@@ -41,6 +41,25 @@ describe('AplicationEventBridgeRule', () => {
     expect(synthed).toMatchSnapshot();
   });
 
+  it('renders an event bridge with pre-existing sqs target', () => {
+    const synthed = Testing.synthScope((stack) => {
+      const appSqs = new sqs.SqsQueue(stack, 'test-queue', {
+        name: 'Test-SQS-Queue',
+      });
+
+      new ApplicationEventBridgeRule(stack, 'test-event-bridge-rule', {
+        ...config,
+        targets: [
+          {
+            arn: appSqs.arn,
+            targetId: 'sqs',
+          },
+        ],
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
   it('renders an event bridge with description', () => {
     const synthed = Testing.synthScope((stack) => {
       new ApplicationEventBridgeRule(stack, 'test-event-bridge-rule', {

--- a/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
@@ -29,6 +29,35 @@ exports[`AplicationEventBridgeRule renders an event bridge with event bus name 1
 }"
 `;
 
+exports[`AplicationEventBridgeRule renders an event bridge with pre-existing sqs target 1`] = `
+"{
+  \\"resource\\": {
+    \\"aws_cloudwatch_event_rule\\": {
+      \\"test-event-bridge-rule_DA4F2E87\\": {
+        \\"event_bus_name\\": \\"default\\",
+        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"name\\": \\"Test-EventBridge-Rule\\"
+      }
+    },
+    \\"aws_cloudwatch_event_target\\": {
+      \\"test-event-bridge-rule_event-bridge-target-sqs_E09C359A\\": {
+        \\"arn\\": \\"\${aws_sqs_queue.test-queue.arn}\\",
+        \\"dead_letter_config\\": {
+        },
+        \\"event_bus_name\\": \\"default\\",
+        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87.name}\\",
+        \\"target_id\\": \\"sqs\\"
+      }
+    },
+    \\"aws_sqs_queue\\": {
+      \\"test-queue\\": {
+        \\"name\\": \\"Test-SQS-Queue\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`AplicationEventBridgeRule renders an event bridge with sqs target 1`] = `
 "{
   \\"resource\\": {

--- a/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
+++ b/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
@@ -10,55 +10,97 @@ import {
 import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda';
 import { sqs } from '@cdktf/provider-aws';
 
-test('renders an event bridge and multiple target', () => {
-  const synthed = Testing.synthScope((stack) => {
-    const lambdaConfig: PocketVersionedLambdaProps = {
-      name: 'test-lambda',
-      lambda: {
-        runtime: LAMBDA_RUNTIMES.PYTHON38,
-        handler: 'index.handler',
-      },
-    };
-    const testLambda = new PocketVersionedLambda(
-      stack,
-      'test-lambda',
-      lambdaConfig
-    );
+describe('PocketEventBridgeRuleWithMultipleTargets', () => {
+  test('renders an event bridge and multiple targets', () => {
+    const synthed = Testing.synthScope((stack) => {
+      const lambdaConfig: PocketVersionedLambdaProps = {
+        name: 'test-lambda',
+        lambda: {
+          runtime: LAMBDA_RUNTIMES.PYTHON38,
+          handler: 'index.handler',
+        },
+      };
+      const testLambda = new PocketVersionedLambda(
+        stack,
+        'test-lambda',
+        lambdaConfig
+      );
 
-    const testSqs = new sqs.SqsQueue(stack, 'test-queue', {
-      name: 'Test-SQS-Queue',
+      const testSqs = new sqs.SqsQueue(stack, 'test-queue', {
+        name: 'Test-SQS-Queue',
+      });
+
+      const testConfig: PocketEventBridgeProps = {
+        eventRule: {
+          name: 'test-event-bridge-rule-multiple-targets',
+          pattern: {
+            source: ['aws.states'],
+            'detail-type': ['Step Functions Execution Status Change'],
+          },
+        },
+        targets: [
+          {
+            targetId: 'test-lambda-id',
+            arn: 'lambda.arn',
+            terraformResource: testLambda.lambda.versionedLambda,
+          },
+          {
+            targetId: 'test-sqs-id',
+            arn: testSqs.arn,
+            terraformResource: testSqs,
+          },
+        ],
+      };
+
+      new PocketEventBridgeRuleWithMultipleTargets(
+        stack,
+        'test-event-bridge-for-multiple-targets-1',
+        {
+          ...testConfig,
+          eventRule: {
+            ...testConfig.eventRule,
+            description: 'Test description',
+          },
+        }
+      );
     });
-
-    const testConfig: PocketEventBridgeProps = {
-      eventRule: {
-        name: 'test-event-bridge-rule-multiple-targets',
-        pattern: {
-          source: ['aws.states'],
-          'detail-type': ['Step Functions Execution Status Change'],
-        },
-      },
-      targets: [
-        {
-          targetId: 'test-lambda-id',
-          arn: 'lambda.arn',
-          terraformResource: testLambda.lambda.versionedLambda,
-        },
-        {
-          targetId: 'test-sqs-id',
-          arn: testSqs.arn,
-          terraformResource: testSqs,
-        },
-      ],
-    };
-
-    new PocketEventBridgeRuleWithMultipleTargets(
-      stack,
-      'test-event-bridge-for-multiple-targets-1',
-      {
-        ...testConfig,
-        eventRule: { ...testConfig.eventRule, description: 'Test description' },
-      }
-    );
+    expect(synthed).toMatchSnapshot();
   });
-  expect(synthed).toMatchSnapshot();
+
+  test('renders an event bridge and pre-existing targets', () => {
+    const synthed = Testing.synthScope((stack) => {
+      const testConfig: PocketEventBridgeProps = {
+        eventRule: {
+          name: 'test-event-bridge-rule-multiple-targets',
+          pattern: {
+            source: ['aws.states'],
+            'detail-type': ['Step Functions Execution Status Change'],
+          },
+        },
+        targets: [
+          {
+            targetId: 'test-lambda-id',
+            arn: 'lambda.arn',
+          },
+          {
+            targetId: 'test-sqs-id',
+            arn: 'testSqs.arn',
+          },
+        ],
+      };
+
+      new PocketEventBridgeRuleWithMultipleTargets(
+        stack,
+        'test-event-bridge-for-multiple-targets-1',
+        {
+          ...testConfig,
+          eventRule: {
+            ...testConfig.eventRule,
+            description: 'Test description',
+          },
+        }
+      );
+    });
+    expect(synthed).toMatchSnapshot();
+  });
 });

--- a/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders an event bridge and multiple target 1`] = `
+exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and multiple targets 1`] = `
 "{
   \\"data\\": {
     \\"archive_file\\": {
@@ -173,6 +173,39 @@ exports[`renders an event bridge and multiple target 1`] = `
     \\"aws_sqs_queue\\": {
       \\"test-queue\\": {
         \\"name\\": \\"Test-SQS-Queue\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and pre-existing targets 1`] = `
+"{
+  \\"resource\\": {
+    \\"aws_cloudwatch_event_rule\\": {
+      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\": {
+        \\"description\\": \\"Test description\\",
+        \\"event_bus_name\\": \\"default\\",
+        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
+      }
+    },
+    \\"aws_cloudwatch_event_target\\": {
+      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F\\": {
+        \\"arn\\": \\"lambda.arn\\",
+        \\"dead_letter_config\\": {
+        },
+        \\"event_bus_name\\": \\"default\\",
+        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
+        \\"target_id\\": \\"test-lambda-id\\"
+      },
+      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF\\": {
+        \\"arn\\": \\"testSqs.arn\\",
+        \\"dead_letter_config\\": {
+        },
+        \\"event_bus_name\\": \\"default\\",
+        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
+        \\"target_id\\": \\"test-sqs-id\\"
       }
     }
   }


### PR DESCRIPTION
# Goal

make passing in a dependent terraform resource optional when creating event bridge rule targets. this change is to satisfy the use case when an event bridge rule target already exists.

## Reference

Documentation here:
* https://getpocket.atlassian.net/browse/BACK-1539