### PR TITLE
fix: remove validation as its done during terraform apply 

### DIFF
--- a/src/base/ApplicationSQSQueue.spec.ts
+++ b/src/base/ApplicationSQSQueue.spec.ts
@@ -58,7 +58,7 @@ describe('ApplicationSQSQueue', () => {
     testFieldValidation({ visibilityTimeoutSeconds: 43201 });
 
     testFieldValidation({ messageRetentionSeconds: 59 });
-    testFieldValidation({ messageRetentionSeconds: 43201 });
+    testFieldValidation({ messageRetentionSeconds: 1209601 });
 
     testFieldValidation({ maxMessageSize: 234 });
     testFieldValidation({ maxMessageSize: 262145 });

--- a/src/base/ApplicationSQSQueue.ts
+++ b/src/base/ApplicationSQSQueue.ts
@@ -51,7 +51,7 @@ const validations: {
   },
   messageRetentionSeconds: {
     min: 60,
-    max: 43200,
+    max: 1209600,
   },
   maxMessageSize: {
     min: 1024,


### PR DESCRIPTION
## Goal

- set max retention time to 1209600 as per documentation 

doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue#message_retention_seconds

build failure - https://us-east-1.console.aws.amazon.com/codesuite/codebuild/996905175585/projects/AccountDataDeleter-PRs-Prod/build/AccountDataDeleter-PRs-Prod%3A9718c345-2bc8-487b-9762-11d483b306dd?region=us-east-1