### PR TITLE
fix(eventBridgeRule): expose scheduleExpression through Pocket- contructs

### DIFF
--- a/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
+++ b/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
@@ -33,7 +33,7 @@ describe('PocketEventBridgeRuleWithMultipleTargets', () => {
       const testConfig: PocketEventBridgeProps = {
         eventRule: {
           name: 'test-event-bridge-rule-multiple-targets',
-          pattern: {
+          eventPattern: {
             source: ['aws.states'],
             'detail-type': ['Step Functions Execution Status Change'],
           },
@@ -72,7 +72,7 @@ describe('PocketEventBridgeRuleWithMultipleTargets', () => {
       const testConfig: PocketEventBridgeProps = {
         eventRule: {
           name: 'test-event-bridge-rule-multiple-targets',
-          pattern: {
+          eventPattern: {
             source: ['aws.states'],
             'detail-type': ['Step Functions Execution Status Change'],
           },

--- a/src/pocket/PocketEventBridgeRuleWithMultipleTargets.ts
+++ b/src/pocket/PocketEventBridgeRuleWithMultipleTargets.ts
@@ -2,6 +2,7 @@ import { Resource, TerraformResource } from 'cdktf';
 import { Construct } from 'constructs';
 import {
   ApplicationEventBridgeRule,
+  ApplicationEventBridgeRuleProps,
   Target,
 } from '../base/ApplicationEventBridgeRule';
 
@@ -15,12 +16,7 @@ export type PocketEventBridgeTargets = {
 };
 
 export interface PocketEventBridgeProps {
-  eventRule: {
-    name: string;
-    description?: string;
-    eventBusName?: string;
-    pattern: { [key: string]: any };
-  };
+  eventRule: Omit<ApplicationEventBridgeRuleProps, 'targets' | 'tags'>;
   targets?: PocketEventBridgeTargets[];
   tags?: { [key: string]: string };
 }
@@ -71,10 +67,7 @@ export class PocketEventBridgeRuleWithMultipleTargets extends Resource {
     });
 
     return new ApplicationEventBridgeRule(this, 'event-bridge-rule', {
-      name: this.config.eventRule.name,
-      description: eventRuleConfig.description,
-      eventBusName: eventRuleConfig.eventBusName,
-      eventPattern: eventRuleConfig.pattern,
+      ...eventRuleConfig,
       targets: targets,
       tags: this.config.tags,
     });

--- a/src/pocket/PocketEventBridgeWithLambdaTarget.spec.ts
+++ b/src/pocket/PocketEventBridgeWithLambdaTarget.spec.ts
@@ -8,7 +8,7 @@ import { LAMBDA_RUNTIMES } from '../base/ApplicationVersionedLambda';
 const config: PocketEventBridgeWithLambdaTargetProps = {
   name: 'test-event-bridge-lambda',
   eventRule: {
-    pattern: {
+    eventPattern: {
       source: ['aws.states'],
       'detail-type': ['Step Functions Execution Status Change'],
     },

--- a/src/pocket/PocketEventBridgeWithLambdaTarget.ts
+++ b/src/pocket/PocketEventBridgeWithLambdaTarget.ts
@@ -1,6 +1,7 @@
 import { Construct } from 'constructs';
 import {
   ApplicationEventBridgeRule,
+  ApplicationEventBridgeRuleProps,
   Target,
 } from '../base/ApplicationEventBridgeRule';
 import { ApplicationVersionedLambda } from '../base/ApplicationVersionedLambda';
@@ -12,11 +13,7 @@ import {
 
 export interface PocketEventBridgeWithLambdaTargetProps
   extends PocketVersionedLambdaProps {
-  eventRule: {
-    description?: string;
-    eventBusName?: string;
-    pattern: { [key: string]: any };
-  };
+  eventRule: Omit<ApplicationEventBridgeRuleProps, 'name' | 'targets' | 'tags'>;
 }
 
 /**
@@ -78,10 +75,8 @@ export class PocketEventBridgeWithLambdaTarget extends PocketVersionedLambda {
     );
 
     return new ApplicationEventBridgeRule(this, 'event-bridge-rule', {
+      ...eventRuleConfig,
       name: this.config.name,
-      description: eventRuleConfig.description,
-      eventBusName: eventRuleConfig.eventBusName,
-      eventPattern: eventRuleConfig.pattern,
       targets: targets,
       tags: this.config.tags,
     });


### PR DESCRIPTION
## Goal

Expose `scheduleExpression` which was added to `ApplicationEventBridgeRule` through the `Pocket-` constructs, by including the underlying interface for `ApplicationEventBridgeRuleProperties`


## Implementation decisions

* Use the underlying property interface for `ApplicationEventBridgeRule` and allow `Pocket-` class to override portions
