### PR TITLE
feat: DLQ as an optional parameter to ApplicationSqsSnsTopicSubscriptionProps

### DIFF
--- a/src/base/ApplicationSqsSnsTopicSubscription.spec.ts
+++ b/src/base/ApplicationSqsSnsTopicSubscription.spec.ts
@@ -11,6 +11,17 @@ describe('ApplicationSqsSnsTopicSubscription', () => {
     }),
   });
 
+  const getConfigWithDlq = (stack) => ({
+    name: 'test-sns-subscription',
+    snsTopicArn: 'arn:aws:sns:TopicName',
+    sqsQueue: new sqs.SqsQueue(stack, 'sqs', {
+      name: 'test-sqs',
+    }),
+    snsDlq: new sqs.SqsQueue(stack, 'dlq', {
+      name: 'test-sqs-dlq',
+    }),
+  });
+
   it('renders an SQS SNS subscription without tags', () => {
     const synthed = Testing.synthScope((stack) => {
       new ApplicationSqsSnsTopicSubscription(
@@ -26,6 +37,16 @@ describe('ApplicationSqsSnsTopicSubscription', () => {
     const synthed = Testing.synthScope((stack) => {
       new ApplicationSqsSnsTopicSubscription(stack, 'sqs-sns-subscription', {
         ...getConfig(stack),
+        tags: { hello: 'there' },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders an SQS SNS subscription witg dlq passed', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationSqsSnsTopicSubscription(stack, 'sqs-sns-subscription', {
+        ...getConfigWithDlq(stack),
         tags: { hello: 'there' },
       });
     });

--- a/src/base/ApplicationSqsSnsTopicSubscription.ts
+++ b/src/base/ApplicationSqsSnsTopicSubscription.ts
@@ -7,6 +7,7 @@ export interface ApplicationSqsSnsTopicSubscriptionProps {
   name: string;
   snsTopicArn: string;
   sqsQueue: sqs.SqsQueue | sqs.DataAwsSqsQueue;
+  snsDlq?: sqs.SqsQueue;
   tags?: { [key: string]: string };
   dependsOn?: TerraformResource[];
 }
@@ -24,7 +25,7 @@ export class ApplicationSqsSnsTopicSubscription extends Resource {
   ) {
     super(scope, name);
 
-    const snsTopicDlq = this.createSqsSubscriptionDlq();
+    const snsTopicDlq = this.config.snsDlq ?? this.createSqsSubscriptionDlq();
     this.snsTopicSubscription = this.createSnsTopicSubscription(snsTopicDlq);
     this.createPoliciesForSnsToSQS(snsTopicDlq);
   }

--- a/src/base/__snapshots__/ApplicationSqsSnsTopicSubscription.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationSqsSnsTopicSubscription.spec.ts.snap
@@ -1,5 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription witg dlq passed 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_iam_policy_document\\": {
+      \\"sqs-sns-subscription_sns-dlq-policy-document_46022E28\\": {
+        \\"depends_on\\": [
+          \\"aws_sqs_queue.dlq\\"
+        ],
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sqs:SendMessage\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"ArnEquals\\",
+                \\"values\\": [
+                  \\"arn:aws:sns:TopicName\\"
+                ],
+                \\"variable\\": \\"aws:SourceArn\\"
+              }
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"sns.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ],
+            \\"resources\\": [
+              \\"\${aws_sqs_queue.dlq.arn}\\"
+            ]
+          }
+        ]
+      },
+      \\"sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA\\": {
+        \\"depends_on\\": [
+          \\"aws_sqs_queue.sqs\\"
+        ],
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"sqs:SendMessage\\"
+            ],
+            \\"condition\\": [
+              {
+                \\"test\\": \\"ArnEquals\\",
+                \\"values\\": [
+                  \\"arn:aws:sns:TopicName\\"
+                ],
+                \\"variable\\": \\"aws:SourceArn\\"
+              }
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"sns.amazonaws.com\\"
+                ],
+                \\"type\\": \\"Service\\"
+              }
+            ],
+            \\"resources\\": [
+              \\"\${aws_sqs_queue.sqs.arn}\\"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_sns_topic_subscription\\": {
+      \\"sqs-sns-subscription_5757EDDD\\": {
+        \\"depends_on\\": [
+          \\"aws_sqs_queue.dlq\\"
+        ],
+        \\"endpoint\\": \\"\${aws_sqs_queue.sqs.arn}\\",
+        \\"protocol\\": \\"sqs\\",
+        \\"redrive_policy\\": \\"{\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.dlq.arn}\\\\\\"}\\",
+        \\"topic_arn\\": \\"arn:aws:sns:TopicName\\"
+      }
+    },
+    \\"aws_sqs_queue\\": {
+      \\"dlq\\": {
+        \\"name\\": \\"test-sqs-dlq\\"
+      },
+      \\"sqs\\": {
+        \\"name\\": \\"test-sqs\\"
+      }
+    },
+    \\"aws_sqs_queue_policy\\": {
+      \\"sqs-sns-subscription_sns-dlq-policy_736EBF83\\": {
+        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}\\",
+        \\"queue_url\\": \\"\${aws_sqs_queue.dlq.url}\\"
+      },
+      \\"sqs-sns-subscription_sns-sqs-policy_ADC74422\\": {
+        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}\\",
+        \\"queue_url\\": \\"\${aws_sqs_queue.sqs.url}\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with tags 1`] = `
 "{
   \\"data\\": {


### PR DESCRIPTION
## goal
- passing DLQ as an optional parameter to ApplicationSqsSnsTopicSubscriptionProps

## why?
- to create DLQ outside this construct and pass them in. then in the consuming application, can set the inline access policy for both the sqs and corresponding dlq for sns subscriptions

### implementation decision
- if dlq is passed, use it as dlq for sns
- if dlq is not passed, create one. 
