### PR TITLE
feat(dynamodb streams): expose enum of stream types & add error checking

### DIFF
--- a/src/base/ApplicationDynamoDBTable.spec.ts
+++ b/src/base/ApplicationDynamoDBTable.spec.ts
@@ -4,6 +4,7 @@ import {
   ApplicationDynamoDBTable,
   ApplicationDynamoDBProps,
   ApplicationDynamoDBTableCapacityMode,
+  ApplicationDynamoDBTableStreamViewType,
 } from './ApplicationDynamoDBTable';
 
 describe('ApplicationDynamoDBTable', () => {
@@ -187,5 +188,52 @@ describe('ApplicationDynamoDBTable', () => {
       new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', BASE_CONFIG);
     });
     expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders a dynamodb table with streams enabled', () => {
+    const config: ApplicationDynamoDBProps = {
+      ...BASE_CONFIG,
+      tableConfig: {
+        streamEnabled: true,
+        streamViewType:
+          ApplicationDynamoDBTableStreamViewType.NEW_AND_OLD_IMAGES,
+      },
+    };
+
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', config);
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('fails to render a dynamodb table with streams enabled if stream view type is not specified', () => {
+    const config: ApplicationDynamoDBProps = {
+      ...BASE_CONFIG,
+      tableConfig: {
+        streamEnabled: true,
+      },
+    };
+
+    expect(() => {
+      Testing.synthScope((stack) => {
+        new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', config);
+      });
+    }).toThrow('you must specify a stream view type if streams are enabled');
+  });
+
+  it('fails to render a dynamodb table with streams enabled if stream view type is invalid', () => {
+    const config: ApplicationDynamoDBProps = {
+      ...BASE_CONFIG,
+      tableConfig: {
+        streamEnabled: true,
+        streamViewType: 'PURPLE_MONKEY_DISHWASHER',
+      },
+    };
+
+    expect(() => {
+      Testing.synthScope((stack) => {
+        new ApplicationDynamoDBTable(stack, 'testDynamoDBTable', config);
+      });
+    }).toThrow('you must specify a valid stream view type');
   });
 });

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ApplicationDynamoDBTable renders a dynamodb table with streams enabled 1`] = `
+"{
+  \\"resource\\": {
+    \\"aws_dynamodb_table\\": {
+      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
+        \\"billing_mode\\": \\"PROVISIONED\\",
+        \\"lifecycle\\": {
+          \\"ignore_changes\\": [
+            \\"read_capacity\\",
+            \\"write_capacity\\"
+          ],
+          \\"prevent_destroy\\": true
+        },
+        \\"name\\": \\"abides-\\",
+        \\"stream_enabled\\": true,
+        \\"stream_view_type\\": \\"NEW_AND_OLD_IMAGES\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`ApplicationDynamoDBTable renders dynamo db table global secondary indexes 1`] = `
 "{
   \\"data\\": {


### PR DESCRIPTION
# Goal

expose enum of stream types & add error checking when enabling streams.

## Reference

Tickets:
* https://getpocket.atlassian.net/browse/BACK-1625