### PR TITLE
chore: expose preventDestroy for event rule

### DIFF
--- a/src/base/ApplicationEventBridgeRule.ts
+++ b/src/base/ApplicationEventBridgeRule.ts
@@ -28,7 +28,7 @@ export interface ApplicationEventBridgeRuleProps {
   scheduleExpression?: string;
   targets?: Target[];
   tags?: { [key: string]: string };
-  preventDestroy? : boolean;
+  preventDestroy?: boolean;
 }
 
 export class ApplicationEventBridgeRule extends Resource {
@@ -60,7 +60,7 @@ export class ApplicationEventBridgeRule extends Resource {
         scheduleExpression,
         eventBusName: eventBus,
         lifecycle: {
-          preventDestroy: this.config.preventDestroy
+          preventDestroy: this.config.preventDestroy,
         },
         tags: this.config.tags,
       }

--- a/src/base/ApplicationEventBridgeRule.ts
+++ b/src/base/ApplicationEventBridgeRule.ts
@@ -28,6 +28,7 @@ export interface ApplicationEventBridgeRuleProps {
   scheduleExpression?: string;
   targets?: Target[];
   tags?: { [key: string]: string };
+  preventDestroy? : boolean;
 }
 
 export class ApplicationEventBridgeRule extends Resource {
@@ -58,6 +59,9 @@ export class ApplicationEventBridgeRule extends Resource {
         eventPattern: eventPattern ? JSON.stringify(eventPattern) : undefined,
         scheduleExpression,
         eventBusName: eventBus,
+        lifecycle: {
+          preventDestroy: this.config.preventDestroy
+        },
         tags: this.config.tags,
       }
     );

--- a/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
@@ -8,6 +8,8 @@ exports[`AplicationEventBridgeRule renders an event bridge with description 1`] 
         \\"description\\": \\"Test description\\",
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\"
       }
     }
@@ -22,6 +24,8 @@ exports[`AplicationEventBridgeRule renders an event bridge with event bus name 1
       \\"test-event-bridge-rule_DA4F2E87\\": {
         \\"event_bus_name\\": \\"test-bus\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\"
       }
     }
@@ -36,6 +40,8 @@ exports[`AplicationEventBridgeRule renders an event bridge with pre-existing sqs
       \\"test-event-bridge-rule_DA4F2E87\\": {
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\"
       }
     },
@@ -64,6 +70,8 @@ exports[`AplicationEventBridgeRule renders an event bridge with scheduleExpressi
     \\"aws_cloudwatch_event_rule\\": {
       \\"test-event-bridge-rule_DA4F2E87\\": {
         \\"event_bus_name\\": \\"default\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\",
         \\"schedule_expression\\": \\"rate(1 minute)\\"
       }
@@ -79,6 +87,8 @@ exports[`AplicationEventBridgeRule renders an event bridge with sqs target 1`] =
       \\"test-event-bridge-rule_DA4F2E87\\": {
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\"
       }
     },
@@ -112,6 +122,8 @@ exports[`AplicationEventBridgeRule renders an event bridge with tags 1`] = `
       \\"test-event-bridge-rule_DA4F2E87\\": {
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\",
         \\"tags\\": {
           \\"for\\": \\"test\\",
@@ -130,6 +142,8 @@ exports[`AplicationEventBridgeRule renders an event bridge without a target 1`] 
       \\"test-event-bridge-rule_DA4F2E87\\": {
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"Test-EventBridge-Rule\\"
       }
     }

--- a/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
+++ b/src/pocket/PocketEventBridgeRuleWithMultipleTargets.spec.ts
@@ -103,4 +103,42 @@ describe('PocketEventBridgeRuleWithMultipleTargets', () => {
     });
     expect(synthed).toMatchSnapshot();
   });
+
+  test('renders an event bridge rule with prevent destroy flag', () => {
+    const synthed = Testing.synthScope((stack) => {
+      const testConfig: PocketEventBridgeProps = {
+        eventRule: {
+          name: 'test-event-bridge-rule-multiple-targets',
+          eventPattern: {
+            source: ['aws.states'],
+            'detail-type': ['Step Functions Execution Status Change'],
+          },
+          preventDestroy: true,
+        },
+        targets: [
+          {
+            targetId: 'test-lambda-id',
+            arn: 'lambda.arn',
+          },
+          {
+            targetId: 'test-sqs-id',
+            arn: 'testSqs.arn',
+          },
+        ],
+      };
+
+      new PocketEventBridgeRuleWithMultipleTargets(
+        stack,
+        'test-event-bridge-for-multiple-targets-1',
+        {
+          ...testConfig,
+          eventRule: {
+            ...testConfig.eventRule,
+            description: 'Test description',
+          },
+        }
+      );
+    });
+    expect(synthed).toMatchSnapshot();
+  });
 });

--- a/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
@@ -61,6 +61,8 @@ exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and mu
         \\"description\\": \\"Test description\\",
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
       }
     },
@@ -187,6 +189,44 @@ exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and pr
         \\"description\\": \\"Test description\\",
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
+        \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
+      }
+    },
+    \\"aws_cloudwatch_event_target\\": {
+      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F\\": {
+        \\"arn\\": \\"lambda.arn\\",
+        \\"dead_letter_config\\": {
+        },
+        \\"event_bus_name\\": \\"default\\",
+        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
+        \\"target_id\\": \\"test-lambda-id\\"
+      },
+      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF\\": {
+        \\"arn\\": \\"testSqs.arn\\",
+        \\"dead_letter_config\\": {
+        },
+        \\"event_bus_name\\": \\"default\\",
+        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
+        \\"target_id\\": \\"test-sqs-id\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge rule with prevent destroy flag 1`] = `
+"{
+  \\"resource\\": {
+    \\"aws_cloudwatch_event_rule\\": {
+      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\": {
+        \\"description\\": \\"Test description\\",
+        \\"event_bus_name\\": \\"default\\",
+        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+          \\"prevent_destroy\\": true
+        },
         \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
       }
     },

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -60,6 +60,8 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
       \\"test-event-bridge-lambda_event-bridge-rule_529FF7C2\\": {
         \\"event_bus_name\\": \\"test-bus\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"test-event-bridge-lambda-Rule\\"
       }
     },
@@ -235,6 +237,8 @@ exports[`renders an event bridge and lambda target with rule description 1`] = `
         \\"description\\": \\"Test description\\",
         \\"event_bus_name\\": \\"default\\",
         \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
+        \\"lifecycle\\": {
+        },
         \\"name\\": \\"test-event-bridge-lambda-Rule\\"
       }
     },


### PR DESCRIPTION
# Goal
expose preventDestroy for event rule

Aws doesnt check if the event-rule has target before it gets deleted.
so we are exposing the `preventDestroy` under lifecycle to help the consuming repo config them