### PR TITLE
fix: missing efs policy action

### DIFF
--- a/src/base/ApplicationECSService.ts
+++ b/src/base/ApplicationECSService.ts
@@ -536,6 +536,7 @@ export class ApplicationECSService extends Resource {
           Action: [
             'elasticfilesystem:ClientMount',
             'elasticfilesystem:ClientWrite',
+            'elasticfilesystem:ClientRootAccess',
           ],
           Condition: {
             Bool: {

--- a/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -115,7 +115,7 @@ exports[`ApplicationECSService attaches persistent (efs) storage to a ECS task 1
           \\"time_sleep.testECSService_waitTwoMinutes_F8D60FA5\\"
         ],
         \\"file_system_id\\": \\"someId\\",
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Id\\\\\\":\\\\\\"abides-dev\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Sid\\\\\\":\\\\\\"abides-dev\\\\\\",\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"AWS\\\\\\":\\\\\\"*\\\\\\"},\\\\\\"Resource\\\\\\":\\\\\\"fakeArn\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"elasticfilesystem:ClientMount\\\\\\",\\\\\\"elasticfilesystem:ClientWrite\\\\\\"],\\\\\\"Condition\\\\\\":{\\\\\\"Bool\\\\\\":{\\\\\\"elasticfilesystem:AccessedViaMountTarget\\\\\\":\\\\\\"true\\\\\\"}}}]}\\"
+        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Id\\\\\\":\\\\\\"abides-dev\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Sid\\\\\\":\\\\\\"abides-dev\\\\\\",\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"AWS\\\\\\":\\\\\\"*\\\\\\"},\\\\\\"Resource\\\\\\":\\\\\\"fakeArn\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"elasticfilesystem:ClientMount\\\\\\",\\\\\\"elasticfilesystem:ClientWrite\\\\\\",\\\\\\"elasticfilesystem:ClientRootAccess\\\\\\"],\\\\\\"Condition\\\\\\":{\\\\\\"Bool\\\\\\":{\\\\\\"elasticfilesystem:AccessedViaMountTarget\\\\\\":\\\\\\"true\\\\\\"}}}]}\\"
       }
     },
     \\"aws_efs_mount_target\\": {

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -471,7 +471,7 @@ exports[`PocketALBApplication renders a Pocket App with attached persistent stor
           \\"time_sleep.testPocketApp_ecs_service_waitTwoMinutes_E07A2D17\\"
         ],
         \\"file_system_id\\": \\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}\\",
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Id\\\\\\":\\\\\\"testapp\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Sid\\\\\\":\\\\\\"testapp\\\\\\",\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"AWS\\\\\\":\\\\\\"*\\\\\\"},\\\\\\"Resource\\\\\\":\\\\\\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.arn}\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"elasticfilesystem:ClientMount\\\\\\",\\\\\\"elasticfilesystem:ClientWrite\\\\\\"],\\\\\\"Condition\\\\\\":{\\\\\\"Bool\\\\\\":{\\\\\\"elasticfilesystem:AccessedViaMountTarget\\\\\\":\\\\\\"true\\\\\\"}}}]}\\"
+        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Id\\\\\\":\\\\\\"testapp\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Sid\\\\\\":\\\\\\"testapp\\\\\\",\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"AWS\\\\\\":\\\\\\"*\\\\\\"},\\\\\\"Resource\\\\\\":\\\\\\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.arn}\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"elasticfilesystem:ClientMount\\\\\\",\\\\\\"elasticfilesystem:ClientWrite\\\\\\",\\\\\\"elasticfilesystem:ClientRootAccess\\\\\\"],\\\\\\"Condition\\\\\\":{\\\\\\"Bool\\\\\\":{\\\\\\"elasticfilesystem:AccessedViaMountTarget\\\\\\":\\\\\\"true\\\\\\"}}}]}\\"
       }
     },
     \\"aws_efs_mount_target\\": {


### PR DESCRIPTION
# Goal

Add missing policy action required for ECS tasks running as root writing to EFS filesystems

Tickets:
* https://mozilla-hub.atlassian.net/browse/POC-189