### PR TITLE
feat(accessLogs): adding in access log to s3 support for ALBs

### DIFF
--- a/src/base/ApplicationLoadBalancer.spec.ts
+++ b/src/base/ApplicationLoadBalancer.spec.ts
@@ -29,4 +29,104 @@ describe('ApplicationLoadBalancer', () => {
     });
     expect(synthed).toMatchSnapshot();
   });
+
+  it('renders an ALB with logs with a new bucket', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLoadBalancer(stack, 'testALB', {
+        prefix: 'test-',
+        alb6CharacterPrefix: 'TEST',
+        vpcId: '123',
+        subnetIds: ['a', 'b'],
+        tags: {
+          name: 'thedude',
+          hobby: 'bowling',
+        },
+        accessLogs: {
+          bucket: 'logging-bucket',
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders an ALB with logs with a new bucket and prefix', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLoadBalancer(stack, 'testALB', {
+        prefix: 'test-',
+        alb6CharacterPrefix: 'TEST',
+        vpcId: '123',
+        subnetIds: ['a', 'b'],
+        tags: {
+          name: 'thedude',
+          hobby: 'bowling',
+        },
+        accessLogs: {
+          bucket: 'logging-bucket',
+          prefix: 'logs/ahoy/cool/service',
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders an ALB with logs with an existing bucket', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLoadBalancer(stack, 'testALB', {
+        prefix: 'test-',
+        alb6CharacterPrefix: 'TEST',
+        vpcId: '123',
+        subnetIds: ['a', 'b'],
+        tags: {
+          name: 'thedude',
+          hobby: 'bowling',
+        },
+        accessLogs: {
+          existingBucket: 'logging-bucket',
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('renders an ALB with logs with an existing bucket and prefix', () => {
+    const synthed = Testing.synthScope((stack) => {
+      new ApplicationLoadBalancer(stack, 'testALB', {
+        prefix: 'test-',
+        alb6CharacterPrefix: 'TEST',
+        vpcId: '123',
+        subnetIds: ['a', 'b'],
+        tags: {
+          name: 'thedude',
+          hobby: 'bowling',
+        },
+        accessLogs: {
+          existingBucket: 'logging-bucket',
+          prefix: 'logs/ahoy/cool/service',
+        },
+      });
+    });
+    expect(synthed).toMatchSnapshot();
+  });
+
+  it('errors when no bucket provided', () => {
+    expect(() => {
+      Testing.synthScope((stack) => {
+        new ApplicationLoadBalancer(stack, 'testALB', {
+          prefix: 'test-',
+          alb6CharacterPrefix: 'TEST',
+          vpcId: '123',
+          subnetIds: ['a', 'b'],
+          tags: {
+            name: 'thedude',
+            hobby: 'bowling',
+          },
+          accessLogs: {
+            prefix: 'logs/ahoy/cool/service',
+          },
+        });
+      });
+    }).toThrow(
+      'If you are configuring access logs you need to define either an existing bucket or a new one to store the logs'
+    );
+  });
 });

--- a/src/base/ApplicationLoadBalancer.ts
+++ b/src/base/ApplicationLoadBalancer.ts
@@ -90,9 +90,15 @@ export class ApplicationLoadBalancer extends Resource {
       const accountId = new datasources.DataAwsCallerIdentity(this, 'caller')
         .accountId;
 
-      const accessLogsPrefix = `server-logs/${config.prefix.toLowerCase()}/internal-alb/AWSLogs/${accountId}/elasticloadbalancing/`;
-      const prefix =
-        config.accessLogs.prefix !== undefined ? accessLogsPrefix : '';
+      let prefix =
+        config.accessLogs.prefix === undefined
+          ? `server-logs/${config.prefix.toLowerCase()}/internal-alb/AWSLogs/${accountId}/elasticloadbalancing/`
+          : config.accessLogs.prefix;
+
+      if (prefix.charAt(prefix.length - 1) !== '/') {
+        //prefix must end in a slash
+        prefix = `${prefix}/`;
+      }
 
       const bucket = this.getOrCreateBucket({
         bucket: config.accessLogs.bucket,

--- a/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
@@ -1,5 +1,467 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_caller_identity\\": {
+      \\"testALB_caller_823E8516\\": {
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"testALB_iam-log-bucket-policy-document_C7E41154\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"arn:aws:iam::\${data.aws_caller_identity.testALB_caller_823E8516.account_id}:root\\"
+                ],
+                \\"type\\": \\"AWS\\"
+              }
+            ],
+            \\"resources\\": [
+              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/*\\"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_alb\\": {
+      \\"testALB_alb_F6B33218\\": {
+        \\"access_logs\\": {
+          \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
+          \\"enabled\\": true,
+          \\"prefix\\": \\"\\"
+        },
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TEST\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        ],
+        \\"subnets\\": [
+          \\"a\\",
+          \\"b\\"
+        ],
+        \\"tags\\": {
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"testALB_log-bucket_E9787BB1\\": {
+        \\"bucket\\": \\"logging-bucket\\"
+      }
+    },
+    \\"aws_s3_bucket_policy\\": {
+      \\"testALB_log-bucket-policy_EB762FB5\\": {
+        \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}\\"
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testALB_alb_security_group_57C45F23\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [
+            ],
+            \\"prefix_list_ids\\": [
+            ],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"test--HTTP/S Security Group\\",
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        },
+        \\"vpc_id\\": \\"123\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and prefix 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_caller_identity\\": {
+      \\"testALB_caller_823E8516\\": {
+      }
+    },
+    \\"aws_iam_policy_document\\": {
+      \\"testALB_iam-log-bucket-policy-document_C7E41154\\": {
+        \\"statement\\": [
+          {
+            \\"actions\\": [
+              \\"s3:PutObject\\"
+            ],
+            \\"effect\\": \\"Allow\\",
+            \\"principals\\": [
+              {
+                \\"identifiers\\": [
+                  \\"arn:aws:iam::\${data.aws_caller_identity.testALB_caller_823E8516.account_id}:root\\"
+                ],
+                \\"type\\": \\"AWS\\"
+              }
+            ],
+            \\"resources\\": [
+              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/*\\"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_alb\\": {
+      \\"testALB_alb_F6B33218\\": {
+        \\"access_logs\\": {
+          \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
+          \\"enabled\\": true,
+          \\"prefix\\": \\"server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/\\"
+        },
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TEST\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        ],
+        \\"subnets\\": [
+          \\"a\\",
+          \\"b\\"
+        ],
+        \\"tags\\": {
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        }
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"testALB_log-bucket_E9787BB1\\": {
+        \\"bucket\\": \\"logging-bucket\\"
+      }
+    },
+    \\"aws_s3_bucket_policy\\": {
+      \\"testALB_log-bucket-policy_EB762FB5\\": {
+        \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
+        \\"policy\\": \\"\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}\\"
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testALB_alb_security_group_57C45F23\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [
+            ],
+            \\"prefix_list_ids\\": [
+            ],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"test--HTTP/S Security Group\\",
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        },
+        \\"vpc_id\\": \\"123\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucket 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_caller_identity\\": {
+      \\"testALB_caller_823E8516\\": {
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"testALB_log-bucket_E9787BB1\\": {
+        \\"bucket\\": \\"logging-bucket\\"
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_alb\\": {
+      \\"testALB_alb_F6B33218\\": {
+        \\"access_logs\\": {
+          \\"bucket\\": \\"\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
+          \\"enabled\\": true,
+          \\"prefix\\": \\"\\"
+        },
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TEST\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        ],
+        \\"subnets\\": [
+          \\"a\\",
+          \\"b\\"
+        ],
+        \\"tags\\": {
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testALB_alb_security_group_57C45F23\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [
+            ],
+            \\"prefix_list_ids\\": [
+            ],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"test--HTTP/S Security Group\\",
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        },
+        \\"vpc_id\\": \\"123\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucket and prefix 1`] = `
+"{
+  \\"data\\": {
+    \\"aws_caller_identity\\": {
+      \\"testALB_caller_823E8516\\": {
+      }
+    },
+    \\"aws_s3_bucket\\": {
+      \\"testALB_log-bucket_E9787BB1\\": {
+        \\"bucket\\": \\"logging-bucket\\"
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"aws_alb\\": {
+      \\"testALB_alb_F6B33218\\": {
+        \\"access_logs\\": {
+          \\"bucket\\": \\"\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
+          \\"enabled\\": true,
+          \\"prefix\\": \\"server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/\\"
+        },
+        \\"internal\\": false,
+        \\"name_prefix\\": \\"TEST\\",
+        \\"security_groups\\": [
+          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        ],
+        \\"subnets\\": [
+          \\"a\\",
+          \\"b\\"
+        ],
+        \\"tags\\": {
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        }
+      }
+    },
+    \\"aws_security_group\\": {
+      \\"testALB_alb_security_group_57C45F23\\": {
+        \\"description\\": \\"External security group  (Managed by Terraform)\\",
+        \\"egress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": \\"required\\",
+            \\"from_port\\": 0,
+            \\"ipv6_cidr_blocks\\": [
+            ],
+            \\"prefix_list_ids\\": [
+            ],
+            \\"protocol\\": \\"-1\\",
+            \\"security_groups\\": [
+            ],
+            \\"self\\": null,
+            \\"to_port\\": 0
+          }
+        ],
+        \\"ingress\\": [
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 443,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 443
+          },
+          {
+            \\"cidr_blocks\\": [
+              \\"0.0.0.0/0\\"
+            ],
+            \\"description\\": null,
+            \\"from_port\\": 80,
+            \\"ipv6_cidr_blocks\\": null,
+            \\"prefix_list_ids\\": null,
+            \\"protocol\\": \\"TCP\\",
+            \\"security_groups\\": null,
+            \\"self\\": null,
+            \\"to_port\\": 80
+          }
+        ],
+        \\"lifecycle\\": {
+          \\"create_before_destroy\\": true
+        },
+        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
+        \\"tags\\": {
+          \\"Name\\": \\"test--HTTP/S Security Group\\",
+          \\"hobby\\": \\"bowling\\",
+          \\"name\\": \\"thedude\\"
+        },
+        \\"vpc_id\\": \\"123\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`ApplicationLoadBalancer renders an ALB with tags 1`] = `
 "{
   \\"resource\\": {

--- a/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
               }
             ],
             \\"resources\\": [
-              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/*\\"
+              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/*\\"
             ]
           }
         ]
@@ -37,7 +37,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
         \\"access_logs\\": {
           \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
           \\"enabled\\": true,
-          \\"prefix\\": \\"\\"
+          \\"prefix\\": \\"server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/\\"
         },
         \\"internal\\": false,
         \\"name_prefix\\": \\"TEST\\",
@@ -154,7 +154,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
               }
             ],
             \\"resources\\": [
-              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/*\\"
+              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/logs/ahoy/cool/service/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/*\\"
             ]
           }
         ]
@@ -167,7 +167,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
         \\"access_logs\\": {
           \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
           \\"enabled\\": true,
-          \\"prefix\\": \\"server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/\\"
+          \\"prefix\\": \\"logs/ahoy/cool/service/\\"
         },
         \\"internal\\": false,
         \\"name_prefix\\": \\"TEST\\",
@@ -279,7 +279,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
         \\"access_logs\\": {
           \\"bucket\\": \\"\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
           \\"enabled\\": true,
-          \\"prefix\\": \\"\\"
+          \\"prefix\\": \\"server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/\\"
         },
         \\"internal\\": false,
         \\"name_prefix\\": \\"TEST\\",
@@ -380,7 +380,7 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
         \\"access_logs\\": {
           \\"bucket\\": \\"\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
           \\"enabled\\": true,
-          \\"prefix\\": \\"server-logs/test-/internal-alb/AWSLogs/\${data.aws_caller_identity.testALB_caller_823E8516.account_id}/elasticloadbalancing/\\"
+          \\"prefix\\": \\"logs/ahoy/cool/service/\\"
         },
         \\"internal\\": false,
         \\"name_prefix\\": \\"TEST\\",

--- a/src/pocket/PocketALBApplication.ts
+++ b/src/pocket/PocketALBApplication.ts
@@ -65,6 +65,31 @@ export interface PocketALBApplicationProps {
    * Optional config to create a CDN. By default no CDN is created.
    */
   cdn?: boolean;
+
+  /**
+   * Optional config to dump alb logs to a bucket.
+
+   */
+  accessLogs?: {
+    /**
+     * Existing bucket to dump alb logs too, one of existingBucket or bucket must be chosen.
+     * If using this options, this module assumes that the bucket already exists in your AWS account and has IAM setup according
+     * to https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy which is account wide.
+     */
+    existingBucket?: string;
+
+    /**
+     * Bucket to dump alb logs too, one of existingBucket or bucket must be chosen.
+     */
+    bucket?: string;
+
+    /**
+     * Optional bucket path prefix. If not defined will use server-logs/{service-name}/internal-alb/AWSLogs/{awsaccountid}/elasticloadbalancing/
+     * Be sure to include a trailing /
+     */
+    prefix?: string;
+  };
+
   /**
    * Option for how the service created by this construct should be
    * deployed.
@@ -342,6 +367,7 @@ export class PocketALBApplication extends Resource {
         : this.pocketVPC.publicSubnetIds,
       internal: this.config.internal,
       tags: this.config.tags,
+      accessLogs: this.config.accessLogs,
     });
 
     //When the app uses a CDN we set the ALB to be direct.app-domain


### PR DESCRIPTION
# Goal

In order to do an analysis of access patterns to our ALBs we need to dump the logs to an S3 bucket. From there using a pattern that @jeshuaborges worked on over the holidays we can import the logs to Snowflake for analysis.

This will also let us remove our elasticsearch cluster in favor for some standard data products tooling and SQL much like athena.

## Todos
- [x] Add in S3 access log patterns
- [x] Allow existing bucket use or new bucket use

## Reference

* https://pocket.slack.com/archives/C02JZ4TRF0S/p1672269833285189
* https://github.com/Pocket/data-warehouse/pull/91/files
* https://github.com/Pocket/data-warehouse/pull/92
