### PR TITLE
fix(provider): applying a missing provider

### DIFF
--- a/src/pocket/PocketECSApplication.ts
+++ b/src/pocket/PocketECSApplication.ts
@@ -207,6 +207,7 @@ export class PocketECSApplication extends Construct {
     const ecsCluster = new ApplicationECSCluster(this, 'ecs_cluster', {
       prefix: this.config.prefix,
       tags: this.config.tags,
+      provider: this.config.provider,
     });
 
     let ecsConfig: ApplicationECSServiceProps = {


### PR DESCRIPTION
# Goal

Forgot to pass the provider to the ecs cluster.