### PR TITLE
feat: add prop to configure success termination timeout value

### DIFF
--- a/src/base/ApplicationECSAlbCodeDeploy.ts
+++ b/src/base/ApplicationECSAlbCodeDeploy.ts
@@ -72,7 +72,7 @@ export class ApplicationECSAlbCodeDeploy extends Construct {
           },
           terminateBlueInstancesOnDeploymentSuccess: {
             action: 'TERMINATE',
-            terminationWaitTimeInMinutes: this.config.successTerminationWaitTimeInMinutes ??= 5,
+            terminationWaitTimeInMinutes: (this.config.successTerminationWaitTimeInMinutes ??= 5),
           },
         },
         deploymentStyle: {

--- a/src/base/ApplicationECSAlbCodeDeploy.ts
+++ b/src/base/ApplicationECSAlbCodeDeploy.ts
@@ -72,7 +72,8 @@ export class ApplicationECSAlbCodeDeploy extends Construct {
           },
           terminateBlueInstancesOnDeploymentSuccess: {
             action: 'TERMINATE',
-            terminationWaitTimeInMinutes: (this.config.successTerminationWaitTimeInMinutes ??= 5),
+            terminationWaitTimeInMinutes:
+              (this.config.successTerminationWaitTimeInMinutes ??= 5),
           },
         },
         deploymentStyle: {

--- a/src/base/ApplicationECSAlbCodeDeploy.ts
+++ b/src/base/ApplicationECSAlbCodeDeploy.ts
@@ -19,6 +19,7 @@ export interface ApplicationECSAlbCodeDeployProps
   targetGroupNames: string[];
   tags?: { [key: string]: string };
   dependsOn?: TerraformResource[];
+  successTerminationWaitTimeInMinutes?: number;
   notifications?: {
     notifyOnStarted?: boolean;
     notifyOnSucceeded?: boolean;
@@ -71,7 +72,7 @@ export class ApplicationECSAlbCodeDeploy extends Construct {
           },
           terminateBlueInstancesOnDeploymentSuccess: {
             action: 'TERMINATE',
-            terminationWaitTimeInMinutes: 5,
+            terminationWaitTimeInMinutes: this.config.successTerminationWaitTimeInMinutes ??= 5,
           },
         },
         deploymentStyle: {

--- a/src/base/ApplicationECSService.ts
+++ b/src/base/ApplicationECSService.ts
@@ -205,7 +205,8 @@ export class ApplicationECSService extends Construct {
             this.config.codeDeploySnsNotificationTopicArn,
           tags: this.config.tags,
           dependsOn: [this.service],
-          successTerminationWaitTimeInMinutes: this.config.successTerminationWaitTimeInMinutes,
+          successTerminationWaitTimeInMinutes:
+            this.config.successTerminationWaitTimeInMinutes,
           notifications: this.config.codeDeployNotifications,
           provider: this.config.provider,
         }));

--- a/src/base/ApplicationECSService.ts
+++ b/src/base/ApplicationECSService.ts
@@ -65,6 +65,7 @@ export interface ApplicationECSServiceProps extends TerraformMetaArguments {
   ecsIamConfig: ApplicationECSIAMProps;
   useCodeDeploy: boolean; //defaults to true
   useCodePipeline?: boolean;
+  successTerminationWaitTimeInMinutes?: number;
   codeDeployNotifications?: {
     notifyOnStarted?: boolean; //defaults to true
     notifyOnSucceeded?: boolean; //defaults to true
@@ -204,6 +205,7 @@ export class ApplicationECSService extends Construct {
             this.config.codeDeploySnsNotificationTopicArn,
           tags: this.config.tags,
           dependsOn: [this.service],
+          successTerminationWaitTimeInMinutes: this.config.successTerminationWaitTimeInMinutes,
           notifications: this.config.codeDeployNotifications,
           provider: this.config.provider,
         }));

--- a/src/pocket/PocketALBApplication.ts
+++ b/src/pocket/PocketALBApplication.ts
@@ -116,6 +116,10 @@ export interface PocketALBApplicationProps extends TerraformMetaArguments {
      * Optional SNS topic for CodeDeploy notifications.
      */
     snsNotificationTopicArn?: string;
+    /**
+     * Optional wait time after replacement task completion. Default is 5 minutes.
+     */
+    successTerminationWaitTimeInMinutes?: number;
 
     notifications?: {
       /**
@@ -596,6 +600,7 @@ export class PocketALBApplication extends Construct {
       useCodeDeploy: this.config.codeDeploy.useCodeDeploy,
       codeDeployNotifications: this.config.codeDeploy.notifications,
       useCodePipeline: this.config.codeDeploy.useCodePipeline,
+      successTerminationWaitTimeInMinutes: this.config.codeDeploy.successTerminationWaitTimeInMinutes,
       codeDeploySnsNotificationTopicArn:
         this.config.codeDeploy.snsNotificationTopicArn,
       albConfig: {

--- a/src/pocket/PocketALBApplication.ts
+++ b/src/pocket/PocketALBApplication.ts
@@ -600,7 +600,8 @@ export class PocketALBApplication extends Construct {
       useCodeDeploy: this.config.codeDeploy.useCodeDeploy,
       codeDeployNotifications: this.config.codeDeploy.notifications,
       useCodePipeline: this.config.codeDeploy.useCodePipeline,
-      successTerminationWaitTimeInMinutes: this.config.codeDeploy.successTerminationWaitTimeInMinutes,
+      successTerminationWaitTimeInMinutes:
+        this.config.codeDeploy.successTerminationWaitTimeInMinutes,
       codeDeploySnsNotificationTopicArn:
         this.config.codeDeploy.snsNotificationTopicArn,
       albConfig: {


### PR DESCRIPTION
# Goal
Add configurable prop for termination timeout value on successful blue/green deployment - if successful this will speed up the Qdrant deploy which scales it's service to zero prior to deploying so the default 5 minute wait only serves to keep the service unavailable for a needlessly long time. Default value set to 5 minutes, which matches the previous hardcoded value.

Tickets:
* [POC-189](https://mozilla-hub.atlassian.net/browse/POC-189)

