### PR TITLE
chore: add 'codepipeline' back to identifier in codepipeline-role

### DIFF
--- a/src/pocket/PocketECSCodePipeline.ts
+++ b/src/pocket/PocketECSCodePipeline.ts
@@ -165,7 +165,7 @@ export class PocketECSCodePipeline extends Construct {
               actions: ['sts:AssumeRole'],
               principals: [
                 {
-                  identifiers: ['amazonaws.com'],
+                  identifiers: ['codepipeline.amazonaws.com'],
                   type: 'Service',
                 },
               ],

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`renders a Pocket ECS Codepipeline template 1`] = `
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -232,7 +232,7 @@ exports[`renders a Pocket ECS Codepipeline template with custom steps 1`] = `
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -483,7 +483,7 @@ exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -707,7 +707,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -925,7 +925,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -1143,7 +1143,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided appspec pa
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -1361,7 +1361,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided artifact b
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -1579,7 +1579,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided code build
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -1797,7 +1797,7 @@ exports[`renders a Pocket ECS Codepipeline template with the provided taskdef pa
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"codepipeline.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }


### PR DESCRIPTION
# Goal
Adds 'codepipeline' back to identifier, was removed erroneously in v4.8.0

Tickets:
* https://mozilla-hub.atlassian.net/browse/POC-189