### PR TITLE
fix(lambda perm): api gateway lambda permission needs more specific principal

### DIFF
--- a/src/pocket/PocketApiGatewayLambdaIntegration.ts
+++ b/src/pocket/PocketApiGatewayLambdaIntegration.ts
@@ -191,7 +191,7 @@ export class PocketApiGateway extends Construct {
         {
           functionName: lambda.lambda.versionedLambda.functionName,
           action: 'lambda:InvokeFunction',
-          principal: 'amazonaws.com',
+          principal: 'apigateway.amazonaws.com',
           // Grants access to invoke lambda on specified stage, method, resource path
           // note the resource path has a leading `/`
           sourceArn: `${this.apiGatewayRestApi.executionArn}/${this.apiGatewayStage.stageName}/${method.httpMethod}${resource.path}`,

--- a/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -224,7 +224,7 @@ exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda 
       \\"test-api-lambda_test-api-lambda_endpoint-lambda_alias_A14F4FF8-allow-gateway-lambda-invoke_F4009ED6\\": {
         \\"action\\": \\"lambda:InvokeFunction\\",
         \\"function_name\\": \\"\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.function_name}\\",
-        \\"principal\\": \\"amazonaws.com\\",
+        \\"principal\\": \\"apigateway.amazonaws.com\\",
         \\"qualifier\\": \\"\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.name}\\",
         \\"source_arn\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.execution_arn}/\${aws_api_gateway_stage.api-gateway-stage.stage_name}/\${aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.http_method}\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.path}\\"
       }


### PR DESCRIPTION
# Goal

Trying to fix this error showing up in fxa-webhook-proxy usage:

```
Error: adding Lambda Permission (FxAWebhookProxy-Prod-ApiGateway-FxA-Events-Function/terraform-20230222220002343400000001): InvalidParameterValueException: The provided principal was invalid. Please check the principal and try again.
--
```

Appears that Lambda Permissions require a more specific principal than just `amazonaws.com` - so reverting to `apigateway.amazonaws.com`.

Blocks: successful CI run of https://github.com/Pocket/fxa-webhook-proxy/
