### PR TITLE
fix(lb alarms): add an alarm for both ELB & target HTTP metrics

### DIFF
--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -3343,6 +3343,54 @@ exports[`PocketALBApplication renders an Pocket App with custom Alarm Descriptio
       }
     },
     \\"aws_cloudwatch_metric_alarm\\": {
+      \\"testPocketApp_alarm-elb5xxerrorrate_4B261705\\": {
+        \\"alarm_actions\\": [
+        ],
+        \\"alarm_description\\": \\"Uh oh. something bad happened.\\",
+        \\"alarm_name\\": \\"testapp-Alarm-ELB5xxErrorRate\\",
+        \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
+        \\"datapoints_to_alarm\\": 5,
+        \\"evaluation_periods\\": 5,
+        \\"insufficient_data_actions\\": [
+        ],
+        \\"metric_query\\": [
+          {
+            \\"id\\": \\"requests\\",
+            \\"metric\\": {
+              \\"dimensions\\": {
+                \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+              },
+              \\"metric_name\\": \\"RequestCount\\",
+              \\"namespace\\": \\"AWS/ApplicationELB\\",
+              \\"period\\": 60,
+              \\"stat\\": \\"Sum\\",
+              \\"unit\\": \\"Count\\"
+            }
+          },
+          {
+            \\"id\\": \\"errors\\",
+            \\"metric\\": {
+              \\"dimensions\\": {
+                \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+              },
+              \\"metric_name\\": \\"HTTPCode_ELB_5XX_Count\\",
+              \\"namespace\\": \\"AWS/ApplicationELB\\",
+              \\"period\\": 60,
+              \\"stat\\": \\"Sum\\",
+              \\"unit\\": \\"Count\\"
+            }
+          },
+          {
+            \\"expression\\": \\"errors/requests*100\\",
+            \\"id\\": \\"expression\\",
+            \\"label\\": \\"ELB 5xx Error Rate\\",
+            \\"return_data\\": true
+          }
+        ],
+        \\"ok_actions\\": [
+        ],
+        \\"threshold\\": 5
+      },
       \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
         \\"alarm_actions\\": [
         ],


### PR DESCRIPTION
# Goal

Recent collection-api incident highlighted that existing monitoring was not alerting when collection sites were all 'down' (in this case, all returning 404, with 5xx spikes from the ELB).

This PR adds another AWS Cloudwatch Alarm, but monitoring the ELB HTTP response metrics. Currently, the only Cloudwatch Alarms setup by default for ALBApplication module is httpLatency & http 5xx _target_ response code metrics, which showed no data (and thus no problems) during the incident (and for the last few weeks it appears).

Once PR is approved & in, I intend to immediately upgrade tf modules for collection-api to confirm both HTTP metric alarms work as desired, though it still may not have been enough to alert during the incident (and there is a separate PR that setups an uptime check plus alarm for that purpose).

Tickets: https://getpocket.atlassian.net/browse/INFRA-1082
