### PR TITLE
feat(ECSContainer): add datetime and multiline log options to ECS def.

### DIFF
--- a/src/base/ApplicationECSContainerDefinition.spec.ts
+++ b/src/base/ApplicationECSContainerDefinition.spec.ts
@@ -12,6 +12,7 @@ describe('ApplicationECSContainerDefinition', () => {
       config = {
         containerImage: 'testImage',
         logGroup: 'bowlingGroup',
+        logMultilinePattern: '^\\S.+',
         portMappings: [
           {
             hostPort: 3000,
@@ -27,6 +28,7 @@ describe('ApplicationECSContainerDefinition', () => {
       const result = buildDefinitionJSON(config);
 
       expect(result).to.contain('"awslogs-group":"bowlingGroup"');
+      expect(result).to.contain('"awslogs-multiline-pattern":"^\\\\S.+"');
       expect(result).to.contain('"hostPort":3000');
       expect(result).to.contain('"containerPort":4000');
       expect(result).to.contain('"image":"testImage"');

--- a/src/base/ApplicationECSContainerDefinition.spec.ts
+++ b/src/base/ApplicationECSContainerDefinition.spec.ts
@@ -13,6 +13,7 @@ describe('ApplicationECSContainerDefinition', () => {
         containerImage: 'testImage',
         logGroup: 'bowlingGroup',
         logMultilinePattern: '^\\S.+',
+        logDatetimeFormat: '[%b %d, %Y %H:%M:%S]',
         portMappings: [
           {
             hostPort: 3000,
@@ -29,6 +30,9 @@ describe('ApplicationECSContainerDefinition', () => {
 
       expect(result).to.contain('"awslogs-group":"bowlingGroup"');
       expect(result).to.contain('"awslogs-multiline-pattern":"^\\\\S.+"');
+      expect(result).to.contain(
+        '"awslogs-datetime-format":"[%b %d, %Y %H:%M:%S]"'
+      );
       expect(result).to.contain('"hostPort":3000');
       expect(result).to.contain('"containerPort":4000');
       expect(result).to.contain('"image":"testImage"');

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -37,6 +37,8 @@ export interface ApplicationECSContainerDefinitionProps {
   containerImage?: string;
   logGroup?: string;
   logGroupRegion?: string;
+  logMultilinePattern?: string;
+  logDatetimeFormat?: string;
   portMappings?: PortMapping[];
   envVars?: EnvironmentVariable[];
   secretEnvVars?: SecretEnvironmentVariable[];
@@ -70,6 +72,10 @@ export function buildDefinitionJSON(
         'awslogs-group': config.logGroup,
         'awslogs-region': config.logGroupRegion ?? 'us-east-1',
         'awslogs-stream-prefix': 'ecs',
+        // datetime takes precedence if datetime and multiline defined
+        ...(config.logDatetimeFormat && {'awslogs-datetime-format': config.logDatetimeFormat}),
+        // regex parsing - may have negative impact on logging performance
+        ...(config.logMultilinePattern && {'awslogs-multiline-pattern': config.logMultilinePattern}),
       },
     },
     entryPoint: config.entryPoint ?? null,

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -74,11 +74,11 @@ export function buildDefinitionJSON(
         'awslogs-stream-prefix': 'ecs',
         // datetime takes precedence if datetime and multiline defined
         ...(config.logDatetimeFormat && {
-          'awslogs-datetime-format': config.logDatetimeFormat
+          'awslogs-datetime-format': config.logDatetimeFormat,
         }),
         // regex parsing - may have negative impact on logging performance
         ...(config.logMultilinePattern && {
-          'awslogs-multiline-pattern': config.logMultilinePattern
+          'awslogs-multiline-pattern': config.logMultilinePattern,
         }),
       },
     },

--- a/src/base/ApplicationECSContainerDefinition.ts
+++ b/src/base/ApplicationECSContainerDefinition.ts
@@ -73,9 +73,13 @@ export function buildDefinitionJSON(
         'awslogs-region': config.logGroupRegion ?? 'us-east-1',
         'awslogs-stream-prefix': 'ecs',
         // datetime takes precedence if datetime and multiline defined
-        ...(config.logDatetimeFormat && {'awslogs-datetime-format': config.logDatetimeFormat}),
+        ...(config.logDatetimeFormat && {
+          'awslogs-datetime-format': config.logDatetimeFormat
+        }),
         // regex parsing - may have negative impact on logging performance
-        ...(config.logMultilinePattern && {'awslogs-multiline-pattern': config.logMultilinePattern}),
+        ...(config.logMultilinePattern && {
+          'awslogs-multiline-pattern': config.logMultilinePattern
+        }),
       },
     },
     entryPoint: config.entryPoint ?? null,

--- a/src/example.ts
+++ b/src/example.ts
@@ -42,6 +42,7 @@ class Example extends TerraformStack {
           sourceVolume: 'data',
         },
       ],
+      logMultilinePattern: '^\\S.+',
     };
 
     new PocketALBApplication(this, 'example', {

--- a/src/example.ts
+++ b/src/example.ts
@@ -43,6 +43,7 @@ class Example extends TerraformStack {
         },
       ],
       logMultilinePattern: '^\\S.+',
+      logDatetimeFormat: '[%b %d, %Y %H:%M:%S]',
     };
 
     new PocketALBApplication(this, 'example', {


### PR DESCRIPTION
# Goal

Add additional log parameters for ECS logging. This adds the ability to parse multiline log messages per project, either with timestamps, or regex parsing. Default values match the current setup - both options wouldn't be omitted.

## Reference

Documentation here:
* [Link to docs](https://docs.docker.com/config/containers/logging/awslogs/)

Tickets:
* [POC-217](https://mozilla-hub.atlassian.net/browse/POC-217)

## Implementation Decisions
I'll only need the multiline option, adding both options for future flexibility