### PR TITLE
feat(pagerduty): extend pagerduty svc ack timeout period

### DIFF
--- a/src/pocket/PocketPagerDuty.ts
+++ b/src/pocket/PocketPagerDuty.ts
@@ -31,7 +31,7 @@ export enum PAGERDUTY_SERVICE_URGENCY {
 
 export class PocketPagerDuty extends Construct {
   static readonly SERVICE_AUTO_RESOLVE_TIMEOUT = '14400';
-  static readonly SERVICE_ACKNOWLEDGEMENT_TIMEOUT = '600';
+  static readonly SERVICE_ACKNOWLEDGEMENT_TIMEOUT = '1800'; // 30 minutes
   static readonly SNS_SUBSCRIPTION_CONFIRMATION_TIMEOUT_IN_MINUTES = 2;
   public readonly snsCriticalAlarmTopic: SnsTopic;
   public readonly snsNonCriticalAlarmTopic: SnsTopic;

--- a/src/pocket/__snapshots__/PocketPagerDuty.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketPagerDuty.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`renders a Pocket PagerDuty for critical and non-critical actions 1`] = 
     },
     \\"pagerduty_service\\": {
       \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"14400\\",
         \\"description\\": \\"PagerDuty Critical\\",
@@ -63,7 +63,7 @@ exports[`renders a Pocket PagerDuty for critical and non-critical actions 1`] = 
         \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
       },
       \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"14400\\",
         \\"description\\": \\"PagerDuty Non-Critical\\",
@@ -277,7 +277,7 @@ exports[`renders a Pocket PagerDuty with custom auto resolve timeout 1`] = `
     },
     \\"pagerduty_service\\": {
       \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"4\\",
         \\"description\\": \\"PagerDuty Critical\\",
@@ -289,7 +289,7 @@ exports[`renders a Pocket PagerDuty with custom auto resolve timeout 1`] = `
         \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
       },
       \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"4\\",
         \\"description\\": \\"PagerDuty Non-Critical\\",
@@ -390,7 +390,7 @@ exports[`renders a Pocket PagerDuty with custom sns topic subscription confirmat
     },
     \\"pagerduty_service\\": {
       \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"14400\\",
         \\"description\\": \\"PagerDuty Critical\\",
@@ -402,7 +402,7 @@ exports[`renders a Pocket PagerDuty with custom sns topic subscription confirmat
         \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
       },
       \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"14400\\",
         \\"description\\": \\"PagerDuty Non-Critical\\",
@@ -505,7 +505,7 @@ exports[`renders a Pocket PagerDuty with sns topic tags 1`] = `
     },
     \\"pagerduty_service\\": {
       \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"14400\\",
         \\"description\\": \\"PagerDuty Critical\\",
@@ -517,7 +517,7 @@ exports[`renders a Pocket PagerDuty with sns topic tags 1`] = `
         \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
       },
       \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"600\\",
+        \\"acknowledgement_timeout\\": \\"1800\\",
         \\"alert_creation\\": \\"create_incidents\\",
         \\"auto_resolve_timeout\\": \\"14400\\",
         \\"description\\": \\"PagerDuty Non-Critical\\",


### PR DESCRIPTION
# Goal

Extends Pagerduty service acknowledgement timeout period from 10 minutes to 30 minutes.

This is only a change to the period of time between the first ack of an alert and when it re-alerts.

