### PR TITLE
fix(policy principals): more policies need more specific principle

### DIFF
--- a/src/base/ApplicationLambdaSnsTopicSubscription.ts
+++ b/src/base/ApplicationLambdaSnsTopicSubscription.ts
@@ -102,7 +102,7 @@ export class ApplicationLambdaSnsTopicSubscription extends Construct {
    */
   private createLambdaPolicy(): void {
     new LambdaPermission(this, `${this.name}-lambda-permission`, {
-      principal: 'amazonaws.com',
+      principal: 'sns.amazonaws.com',
       action: 'lambda:InvokeFunction',
       functionName: this.config.lambda.functionName,
       sourceArn: this.config.snsTopicArn,
@@ -128,7 +128,7 @@ export class ApplicationLambdaSnsTopicSubscription extends Construct {
             resources: [queue.resource.arn],
             principals: [
               {
-                identifiers: ['amazonaws.com'],
+                identifiers: ['sns.amazonaws.com'],
                 type: 'Service',
               },
             ],

--- a/src/base/ApplicationSqsSnsTopicSubscription.ts
+++ b/src/base/ApplicationSqsSnsTopicSubscription.ts
@@ -94,7 +94,7 @@ export class ApplicationSqsSnsTopicSubscription extends Construct {
               resources: [queue.resource.arn],
               principals: [
                 {
-                  identifiers: ['amazonaws.com'],
+                  identifiers: ['sns.amazonaws.com'],
                   type: 'Service',
                 },
               ],

--- a/src/base/__snapshots__/ApplicationLambdaSnsTopicSubscription.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLambdaSnsTopicSubscription.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an Lambda <> SNS subscriptio
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -49,7 +49,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an Lambda <> SNS subscriptio
       \\"lambda-sns-subscription_lambda-sns-subscription-lambda-permission_03B5A953\\": {
         \\"action\\": \\"lambda:InvokeFunction\\",
         \\"function_name\\": \\"\${data.aws_lambda_function.lambda.function_name}\\",
-        \\"principal\\": \\"amazonaws.com\\",
+        \\"principal\\": \\"sns.amazonaws.com\\",
         \\"source_arn\\": \\"arn:aws:sns:TopicName\\"
       }
     },
@@ -105,7 +105,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -128,7 +128,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
       \\"lambda-sns-subscription_lambda-sns-subscription-lambda-permission_03B5A953\\": {
         \\"action\\": \\"lambda:InvokeFunction\\",
         \\"function_name\\": \\"\${data.aws_lambda_function.lambda.function_name}\\",
-        \\"principal\\": \\"amazonaws.com\\",
+        \\"principal\\": \\"sns.amazonaws.com\\",
         \\"source_arn\\": \\"arn:aws:sns:TopicName\\"
       }
     },

--- a/src/base/__snapshots__/ApplicationSqsSnsTopicSubscription.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationSqsSnsTopicSubscription.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription witg
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -59,7 +59,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription witg
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -132,7 +132,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -165,7 +165,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -241,7 +241,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }
@@ -274,7 +274,7 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
             \\"principals\\": [
               {
                 \\"identifiers\\": [
-                  \\"amazonaws.com\\"
+                  \\"sns.amazonaws.com\\"
                 ],
                 \\"type\\": \\"Service\\"
               }


### PR DESCRIPTION
# Goal

Fixes more bugs introduced by #1028 

Namely, need more specific principals for some policies than 'amazonaws.com'. Reverted to working principal domains in 3 places.

Blocks https://github.com/Pocket/list-api/pull/696