### PR TITLE
fix(export): forgot to expore aws synthetics work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 // anything we want consumable (module, type, class, etc) should be exported here
 export * from './pocket/PocketApiGatewayLambdaIntegration';
 export * from './pocket/PocketALBApplication';
+export * from './pocket/PocketCloudwatchSynthetics';
 export * from './pocket/PocketECSApplication';
 export * from './pocket/PocketECSCodePipeline';
 export * from './pocket/PocketEventBridgeRuleWithMultipleTargets';


### PR DESCRIPTION
Stupidly, I forgot to export the cloudwatch synthetics resources so we could actually use this from this package / module.