### PR TITLE
chore(updates): [INFRA-1356] Update Jest to v.29 and update test snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,14 +33,14 @@
         "@semantic-release/npm": "10.0.4",
         "@semantic-release/release-notes-generator": "11.0.4",
         "@types/chai": "4.3.5",
-        "@types/jest": "28.1.8",
+        "@types/jest": "^29.5.3",
         "@types/node": "18.16.19",
         "chai": "4.3.7",
         "conventional-changelog-conventionalcommits": "6.1.0",
-        "jest": "28.1.3",
+        "jest": "^29.6.1",
         "semantic-release": "21.0.7",
         "sinon": "15.2.0",
-        "ts-jest": "28.0.8",
+        "ts-jest": "^29.1.1",
         "ts-node": "10.9.1"
       },
       "engines": {
@@ -72,35 +72,35 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
-      "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
+      "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
-      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.8.tgz",
+      "integrity": "sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/generator": "^7.22.7",
+        "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helpers": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.8",
         "@babel/types": "^7.22.5",
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -110,19 +110,16 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
-      "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
+      "integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
       "dependencies": {
         "@babel/types": "^7.22.5",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -134,31 +131,22 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
-      "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
+      "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.5",
+        "@babel/compat-data": "^7.22.6",
         "@babel/helper-validator-option": "^7.22.5",
-        "browserslist": "^4.21.3",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -248,9 +236,9 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-      "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -285,13 +273,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
-      "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
+      "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.6",
         "@babel/types": "^7.22.5"
       },
       "engines": {
@@ -312,9 +300,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
+      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -377,6 +365,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -498,18 +501,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-      "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
+      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
+        "@babel/generator": "^7.22.7",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2078,20 +2081,20 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
-      "integrity": "sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
+      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/console/node_modules/ansi-styles": {
@@ -2165,43 +2168,42 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz",
-      "integrity": "sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
+      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/reporters": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/console": "^29.6.1",
+        "@jest/reporters": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^28.1.3",
-        "jest-config": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-resolve-dependencies": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "jest-watcher": "^28.1.3",
+        "jest-changed-files": "^29.5.0",
+        "jest-config": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-resolve-dependencies": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
+        "jest-watcher": "^29.6.1",
         "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
-        "rimraf": "^3.0.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -2298,88 +2300,89 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
-      "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
+      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^28.1.3"
+        "jest-mock": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz",
-      "integrity": "sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
       "dev": true,
       "dependencies": {
-        "expect": "^28.1.3",
-        "jest-snapshot": "^28.1.3"
+        "expect": "^29.6.1",
+        "jest-snapshot": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
-      "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
+      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^28.0.2"
+        "jest-get-type": "^29.4.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
-      "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
+      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@jest/types": "^29.6.1",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz",
-      "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
+      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/types": "^28.1.3"
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "jest-mock": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-28.1.3.tgz",
-      "integrity": "sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
+      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@jridgewell/trace-mapping": "^0.3.13",
+        "@jest/console": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -2391,17 +2394,16 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
-        "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^9.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -2483,85 +2485,85 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
-      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
       "dev": true,
       "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "28.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-28.1.2.tgz",
-      "integrity": "sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
+      "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.13",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
         "graceful-fs": "^4.2.9"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.1.3.tgz",
-      "integrity": "sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
+      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/console": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz",
-      "integrity": "sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
+      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^28.1.3",
+        "@jest/test-result": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/transform": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
-      "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^28.1.3",
-        "@jridgewell/trace-mapping": "^0.3.13",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.6.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.1"
+        "write-file-atomic": "^4.0.2"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/transform/node_modules/ansi-styles": {
@@ -2635,12 +2637,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
-      "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^28.1.3",
+        "@jest/schemas": "^29.6.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -2648,7 +2650,7 @@
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/types/node_modules/ansi-styles": {
@@ -2875,6 +2877,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@nicolo-ribaudo/semver-v6": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
+      "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4062,9 +4073,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -4076,21 +4087,12 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
@@ -4224,13 +4226,13 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "28.1.8",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
-      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
+      "version": "29.5.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.3.tgz",
+      "integrity": "sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==",
       "dev": true,
       "dependencies": {
-        "expect": "^28.0.0",
-        "pretty-format": "^28.0.0"
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -4796,21 +4798,21 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
-      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
+      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^28.1.3",
+        "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^28.1.3",
+        "babel-preset-jest": "^29.5.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
@@ -4903,9 +4905,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
-      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
+      "integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -4914,7 +4916,7 @@
         "@types/babel__traverse": "^7.0.6"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -4941,16 +4943,16 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
-      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
+      "integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^28.1.3",
+        "babel-plugin-jest-hoist": "^29.5.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -5043,9 +5045,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "dev": true,
       "funding": [
         {
@@ -5062,8 +5064,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
         "node-releases": "^2.0.12",
         "update-browserslist-db": "^1.0.11"
       },
@@ -5191,9 +5193,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001495",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
+      "version": "1.0.30001515",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
+      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
       "dev": true,
       "funding": [
         {
@@ -5930,9 +5932,9 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
     "node_modules/clean-stack": {
@@ -6130,9 +6132,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
     "node_modules/color-convert": {
@@ -6302,9 +6304,9 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "node_modules/convert-to-spaces": {
@@ -6670,12 +6672,12 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true,
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -6742,15 +6744,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.425",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.425.tgz",
-      "integrity": "sha512-wv1NufHxu11zfDbY4fglYQApMswleE9FL/DSeyOyauVXDZ+Kco96JK/tPfBUaDqfRarYp2WH2hJ/5UnVywp9Jg==",
+      "version": "1.4.457",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.457.tgz",
+      "integrity": "sha512-/g3UyNDmDd6ebeWapmAoiyy+Sy2HyJ+/X8KyvNeHfKRFfHaA2W8oF5fxD5F3tjBDcjpwo0iek6YNgxNXDBoEtA==",
       "dev": true
     },
     "node_modules/emittery": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
-      "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7353,19 +7355,20 @@
       }
     },
     "node_modules/expect": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
-      "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3"
+        "@jest/expect-utils": "^29.6.1",
+        "@types/node": "*",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/external-editor": {
@@ -8886,9 +8889,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8983,21 +8986,21 @@
       }
     },
     "node_modules/jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
-      "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
+      "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/core": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^28.1.3"
+        "jest-cli": "^29.6.1"
       },
       "bin": {
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -9009,46 +9012,47 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz",
-      "integrity": "sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.5.0.tgz",
+      "integrity": "sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==",
       "dev": true,
       "dependencies": {
         "execa": "^5.0.0",
         "p-limit": "^3.1.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-circus": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
+      "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-each": "^29.6.1",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
+        "pretty-format": "^29.6.1",
+        "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-circus/node_modules/ansi-styles": {
@@ -9122,21 +9126,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz",
-      "integrity": "sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
+      "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/core": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
+        "jest-config": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -9144,7 +9148,7 @@
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -9226,36 +9230,36 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz",
-      "integrity": "sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
+      "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "babel-jest": "^28.1.3",
+        "@jest/test-sequencer": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "babel-jest": "^29.6.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^28.1.3",
-        "jest-environment-node": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
+        "jest-circus": "^29.6.1",
+        "jest-environment-node": "^29.6.1",
+        "jest-get-type": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^28.1.3",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "@types/node": "*",
@@ -9356,18 +9360,18 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
-      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
+      "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
@@ -9441,31 +9445,31 @@
       }
     },
     "node_modules/jest-docblock": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz",
-      "integrity": "sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
+      "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-each": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz",
-      "integrity": "sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
+      "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "pretty-format": "^28.1.3"
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.6.1",
+        "pretty-format": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-each/node_modules/ansi-styles": {
@@ -9539,82 +9543,82 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz",
-      "integrity": "sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
+      "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true,
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
-      "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
+      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
-      "integrity": "sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
+      "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
-      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
+      "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
+        "jest-diff": "^29.6.1",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
@@ -9688,23 +9692,23 @@
       }
     },
     "node_modules/jest-message-util": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
-      "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
+      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
@@ -9778,16 +9782,17 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.1.3.tgz",
-      "integrity": "sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
+      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*"
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
+        "jest-util": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -9808,45 +9813,45 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
+      "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
       "dev": true,
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz",
-      "integrity": "sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
+      "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "resolve": "^1.20.0",
-        "resolve.exports": "^1.1.0",
+        "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz",
-      "integrity": "sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
+      "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
       "dev": true,
       "dependencies": {
-        "jest-regex-util": "^28.0.2",
-        "jest-snapshot": "^28.1.3"
+        "jest-regex-util": "^29.4.3",
+        "jest-snapshot": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve/node_modules/ansi-styles": {
@@ -9920,35 +9925,35 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz",
-      "integrity": "sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
+      "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^28.1.3",
-        "@jest/environment": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/console": "^29.6.1",
+        "@jest/environment": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
+        "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^28.1.1",
-        "jest-environment-node": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-leak-detector": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-resolve": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-watcher": "^28.1.3",
-        "jest-worker": "^28.1.3",
+        "jest-docblock": "^29.4.3",
+        "jest-environment-node": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-leak-detector": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-resolve": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-watcher": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runner/node_modules/ansi-styles": {
@@ -10022,36 +10027,36 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
-      "integrity": "sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
+      "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/globals": "^28.1.3",
-        "@jest/source-map": "^28.1.2",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/globals": "^29.6.1",
+        "@jest/source-map": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
-        "execa": "^5.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runtime/node_modules/ansi-styles": {
@@ -10125,37 +10130,35 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
-      "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
+      "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/babel__traverse": "^7.0.6",
+        "@jest/expect-utils": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^28.1.3",
+        "expect": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-haste-map": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-diff": "^29.6.1",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^28.1.3",
-        "semver": "^7.3.5"
+        "pretty-format": "^29.6.1",
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
@@ -10229,12 +10232,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
-      "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -10242,7 +10245,7 @@
         "picomatch": "^2.2.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-util/node_modules/ansi-styles": {
@@ -10331,20 +10334,20 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
-      "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
+      "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
+        "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^28.1.3"
+        "pretty-format": "^29.6.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
@@ -10418,22 +10421,22 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz",
-      "integrity": "sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
+      "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
-        "jest-util": "^28.1.3",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.6.1",
         "string-length": "^4.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-watcher/node_modules/ansi-styles": {
@@ -10507,17 +10510,18 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
-      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
+      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
+        "jest-util": "^29.6.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-worker/node_modules/has-flag": {
@@ -11547,9 +11551,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -11886,24 +11890,6 @@
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
-      "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
     "node_modules/node-abi": {
       "version": "3.45.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
@@ -11950,9 +11936,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -15631,9 +15617,9 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
-      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true,
       "engines": {
         "node": ">= 6"
@@ -15890,18 +15876,17 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
-      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^28.1.3",
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.6.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -15956,6 +15941,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -16307,9 +16308,9 @@
       }
     },
     "node_modules/resolve.exports": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
-      "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -17091,15 +17092,6 @@
         "url": "https://opencollective.com/sinon"
       }
     },
-    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
     "node_modules/sinon/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -17683,22 +17675,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -17816,32 +17792,32 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "28.0.8",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
-      "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
-        "jest-util": "^28.0.0",
-        "json5": "^2.2.1",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
-        "semver": "7.x",
+        "semver": "^7.5.3",
         "yargs-parser": "^21.0.1"
       },
       "bin": {
         "ts-jest": "cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/types": "^28.0.0",
-        "babel-jest": "^28.0.0",
-        "jest": "^28.0.0",
-        "typescript": ">=4.3"
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -18121,6 +18097,12 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -18558,46 +18540,46 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
-      "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
+      "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
-      "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.8.tgz",
+      "integrity": "sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/generator": "^7.22.7",
+        "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helpers": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.8",
         "@babel/types": "^7.22.5",
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "json5": "^2.2.2"
       },
       "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+        "convert-source-map": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+          "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
           "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
-      "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
+      "integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
       "requires": {
         "@babel/types": "^7.22.5",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -18606,24 +18588,16 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
-      "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
+      "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.22.5",
+        "@babel/compat-data": "^7.22.6",
         "@babel/helper-validator-option": "^7.22.5",
-        "browserslist": "^4.21.3",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
+        "@nicolo-ribaudo/semver-v6": "^6.3.3",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -18692,9 +18666,9 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-      "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
@@ -18717,13 +18691,13 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
-      "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
+      "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
+        "@babel/traverse": "^7.22.6",
         "@babel/types": "^7.22.5"
       }
     },
@@ -18738,9 +18712,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q=="
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
+      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -18785,6 +18759,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -18870,18 +18853,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-      "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
+      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
+        "@babel/generator": "^7.22.7",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/parser": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -20046,16 +20029,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
-      "integrity": "sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
+      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -20111,38 +20094,37 @@
       }
     },
     "@jest/core": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz",
-      "integrity": "sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
+      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^28.1.3",
-        "@jest/reporters": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/console": "^29.6.1",
+        "@jest/reporters": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^28.1.3",
-        "jest-config": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-resolve-dependencies": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
-        "jest-watcher": "^28.1.3",
+        "jest-changed-files": "^29.5.0",
+        "jest-config": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-resolve-dependencies": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
+        "jest-watcher": "^29.6.1",
         "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
-        "rimraf": "^3.0.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -20205,73 +20187,74 @@
       }
     },
     "@jest/environment": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
-      "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
+      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^28.1.3"
+        "jest-mock": "^29.6.1"
       }
     },
     "@jest/expect": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz",
-      "integrity": "sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
       "dev": true,
       "requires": {
-        "expect": "^28.1.3",
-        "jest-snapshot": "^28.1.3"
+        "expect": "^29.6.1",
+        "jest-snapshot": "^29.6.1"
       }
     },
     "@jest/expect-utils": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
-      "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
+      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^28.0.2"
+        "jest-get-type": "^29.4.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
-      "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
+      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@jest/types": "^29.6.1",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       }
     },
     "@jest/globals": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz",
-      "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
+      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/types": "^28.1.3"
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "jest-mock": "^29.6.1"
       }
     },
     "@jest/reporters": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-28.1.3.tgz",
-      "integrity": "sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
+      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@jridgewell/trace-mapping": "^0.3.13",
+        "@jest/console": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -20283,13 +20266,12 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
-        "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^9.0.1"
       },
       "dependencies": {
@@ -20345,70 +20327,70 @@
       }
     },
     "@jest/schemas": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
-      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
       "dev": true,
       "requires": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.27.8"
       }
     },
     "@jest/source-map": {
-      "version": "28.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-28.1.2.tgz",
-      "integrity": "sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
+      "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.13",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
         "graceful-fs": "^4.2.9"
       }
     },
     "@jest/test-result": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.1.3.tgz",
-      "integrity": "sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
+      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/console": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz",
-      "integrity": "sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
+      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^28.1.3",
+        "@jest/test-result": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
         "slash": "^3.0.0"
       }
     },
     "@jest/transform": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
-      "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^28.1.3",
-        "@jridgewell/trace-mapping": "^0.3.13",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.6.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.1"
+        "write-file-atomic": "^4.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -20463,12 +20445,12 @@
       }
     },
     "@jest/types": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
-      "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^28.1.3",
+        "@jest/schemas": "^29.6.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -20647,6 +20629,12 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
+    },
+    "@nicolo-ribaudo/semver-v6": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
+      "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -21490,9 +21478,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -21504,23 +21492,12 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-          "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "@sinonjs/samsam": {
@@ -21656,13 +21633,13 @@
       }
     },
     "@types/jest": {
-      "version": "28.1.8",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
-      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
+      "version": "29.5.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.3.tgz",
+      "integrity": "sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==",
       "dev": true,
       "requires": {
-        "expect": "^28.0.0",
-        "pretty-format": "^28.0.0"
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/json-schema": {
@@ -22053,15 +22030,15 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "babel-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
-      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
+      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^28.1.3",
+        "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^28.1.3",
+        "babel-preset-jest": "^29.5.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -22132,9 +22109,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
-      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
+      "integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -22164,12 +22141,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
-      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
+      "integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^28.1.3",
+        "babel-plugin-jest-hoist": "^29.5.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -22239,13 +22216,13 @@
       }
     },
     "browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
         "node-releases": "^2.0.12",
         "update-browserslist-db": "^1.0.11"
       }
@@ -22328,9 +22305,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001495",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
+      "version": "1.0.30001515",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
+      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
       "dev": true
     },
     "cardinal": {
@@ -22842,9 +22819,9 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cjs-module-lexer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
     "clean-stack": {
@@ -22980,9 +22957,9 @@
       }
     },
     "collect-v8-coverage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
     "color-convert": {
@@ -23118,9 +23095,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "convert-to-spaces": {
@@ -23383,9 +23360,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true
     },
     "dir-glob": {
@@ -23440,15 +23417,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "electron-to-chromium": {
-      "version": "1.4.425",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.425.tgz",
-      "integrity": "sha512-wv1NufHxu11zfDbY4fglYQApMswleE9FL/DSeyOyauVXDZ+Kco96JK/tPfBUaDqfRarYp2WH2hJ/5UnVywp9Jg==",
+      "version": "1.4.457",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.457.tgz",
+      "integrity": "sha512-/g3UyNDmDd6ebeWapmAoiyy+Sy2HyJ+/X8KyvNeHfKRFfHaA2W8oF5fxD5F3tjBDcjpwo0iek6YNgxNXDBoEtA==",
       "dev": true
     },
     "emittery": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
-      "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -23868,16 +23845,17 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "expect": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
-      "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
+      "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3"
+        "@jest/expect-utils": "^29.6.1",
+        "@types/node": "*",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1"
       }
     },
     "external-editor": {
@@ -24934,9 +24912,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -25006,21 +24984,21 @@
       "dev": true
     },
     "jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
-      "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
+      "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
       "dev": true,
       "requires": {
-        "@jest/core": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/core": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^28.1.3"
+        "jest-cli": "^29.6.1"
       }
     },
     "jest-changed-files": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz",
-      "integrity": "sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.5.0.tgz",
+      "integrity": "sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==",
       "dev": true,
       "requires": {
         "execa": "^5.0.0",
@@ -25028,28 +25006,29 @@
       }
     },
     "jest-circus": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
-      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
+      "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.3",
-        "@jest/expect": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^29.6.1",
+        "@jest/expect": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-each": "^29.6.1",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "^28.1.3",
+        "pretty-format": "^29.6.1",
+        "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -25106,21 +25085,21 @@
       }
     },
     "jest-cli": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz",
-      "integrity": "sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
+      "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
       "dev": true,
       "requires": {
-        "@jest/core": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/core": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
+        "jest-config": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -25177,31 +25156,31 @@
       }
     },
     "jest-config": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz",
-      "integrity": "sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
+      "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "babel-jest": "^28.1.3",
+        "@jest/test-sequencer": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "babel-jest": "^29.6.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^28.1.3",
-        "jest-environment-node": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-runner": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
+        "jest-circus": "^29.6.1",
+        "jest-environment-node": "^29.6.1",
+        "jest-get-type": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-runner": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^28.1.3",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -25264,15 +25243,15 @@
       }
     },
     "jest-diff": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
-      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
+      "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^28.1.1",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -25327,25 +25306,25 @@
       }
     },
     "jest-docblock": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz",
-      "integrity": "sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
+      "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz",
-      "integrity": "sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
+      "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "pretty-format": "^28.1.3"
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.6.1",
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -25400,65 +25379,65 @@
       }
     },
     "jest-environment-node": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz",
-      "integrity": "sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
+      "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3"
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       }
     },
     "jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
-      "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
+      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.1.3",
-        "jest-worker": "^28.1.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       }
     },
     "jest-leak-detector": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
-      "integrity": "sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
+      "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.6.1"
       }
     },
     "jest-matcher-utils": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
-      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
+      "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.3"
+        "jest-diff": "^29.6.1",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -25513,18 +25492,18 @@
       }
     },
     "jest-message-util": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
-      "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
+      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.3",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -25581,13 +25560,14 @@
       }
     },
     "jest-mock": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-28.1.3.tgz",
-      "integrity": "sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
+      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
-        "@types/node": "*"
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
+        "jest-util": "^29.6.1"
       }
     },
     "jest-pnp-resolver": {
@@ -25598,25 +25578,25 @@
       "requires": {}
     },
     "jest-regex-util": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
+      "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz",
-      "integrity": "sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
+      "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^28.1.3",
-        "jest-validate": "^28.1.3",
+        "jest-util": "^29.6.1",
+        "jest-validate": "^29.6.1",
         "resolve": "^1.20.0",
-        "resolve.exports": "^1.1.0",
+        "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -25672,40 +25652,40 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz",
-      "integrity": "sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
+      "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^28.0.2",
-        "jest-snapshot": "^28.1.3"
+        "jest-regex-util": "^29.4.3",
+        "jest-snapshot": "^29.6.1"
       }
     },
     "jest-runner": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz",
-      "integrity": "sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
+      "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^28.1.3",
-        "@jest/environment": "^28.1.3",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/console": "^29.6.1",
+        "@jest/environment": "^29.6.1",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
+        "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^28.1.1",
-        "jest-environment-node": "^28.1.3",
-        "jest-haste-map": "^28.1.3",
-        "jest-leak-detector": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-resolve": "^28.1.3",
-        "jest-runtime": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jest-watcher": "^28.1.3",
-        "jest-worker": "^28.1.3",
+        "jest-docblock": "^29.4.3",
+        "jest-environment-node": "^29.6.1",
+        "jest-haste-map": "^29.6.1",
+        "jest-leak-detector": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-resolve": "^29.6.1",
+        "jest-runtime": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jest-watcher": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -25762,31 +25742,31 @@
       }
     },
     "jest-runtime": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
-      "integrity": "sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
+      "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/globals": "^28.1.3",
-        "@jest/source-map": "^28.1.2",
-        "@jest/test-result": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/globals": "^29.6.1",
+        "@jest/source-map": "^29.6.0",
+        "@jest/test-result": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
-        "execa": "^5.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-mock": "^28.1.3",
-        "jest-regex-util": "^28.0.2",
-        "jest-resolve": "^28.1.3",
-        "jest-snapshot": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-haste-map": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.6.1",
+        "jest-snapshot": "^29.6.1",
+        "jest-util": "^29.6.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -25843,34 +25823,32 @@
       }
     },
     "jest-snapshot": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
-      "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
+      "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^28.1.3",
-        "@jest/transform": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/babel__traverse": "^7.0.6",
+        "@jest/expect-utils": "^29.6.1",
+        "@jest/transform": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^28.1.3",
+        "expect": "^29.6.1",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^28.1.3",
-        "jest-get-type": "^28.0.2",
-        "jest-haste-map": "^28.1.3",
-        "jest-matcher-utils": "^28.1.3",
-        "jest-message-util": "^28.1.3",
-        "jest-util": "^28.1.3",
+        "jest-diff": "^29.6.1",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.6.1",
+        "jest-message-util": "^29.6.1",
+        "jest-util": "^29.6.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^28.1.3",
-        "semver": "^7.3.5"
+        "pretty-format": "^29.6.1",
+        "semver": "^7.5.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -25925,12 +25903,12 @@
       }
     },
     "jest-util": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
-      "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -25996,17 +25974,17 @@
       }
     },
     "jest-validate": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
-      "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
+      "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.3",
+        "@jest/types": "^29.6.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
+        "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^28.1.3"
+        "pretty-format": "^29.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -26061,18 +26039,18 @@
       }
     },
     "jest-watcher": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz",
-      "integrity": "sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
+      "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^28.1.3",
-        "@jest/types": "^28.1.3",
+        "@jest/test-result": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "emittery": "^0.10.2",
-        "jest-util": "^28.1.3",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.6.1",
         "string-length": "^4.0.1"
       },
       "dependencies": {
@@ -26128,12 +26106,13 @@
       }
     },
     "jest-worker": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
-      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
+      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
+        "jest-util": "^29.6.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -26930,9 +26909,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -27178,26 +27157,6 @@
           "requires": {
             "type-detect": "4.0.8"
           }
-        },
-        "@sinonjs/fake-timers": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
-          "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^3.0.0"
-          },
-          "dependencies": {
-            "@sinonjs/commons": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-              "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-              "dev": true,
-              "requires": {
-                "type-detect": "4.0.8"
-              }
-            }
-          }
         }
       }
     },
@@ -27233,9 +27192,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -29686,9 +29645,9 @@
       "dev": true
     },
     "pirates": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
-      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true
     },
     "pkg-conf": {
@@ -29862,13 +29821,12 @@
       }
     },
     "pretty-format": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
-      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^28.1.3",
-        "ansi-regex": "^5.0.1",
+        "@jest/schemas": "^29.6.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -29915,6 +29873,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+    },
+    "pure-rand": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
+      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -30179,9 +30143,9 @@
       "dev": true
     },
     "resolve.exports": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
-      "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true
     },
     "restore-cursor": {
@@ -30693,15 +30657,6 @@
         "supports-color": "^7.2.0"
       },
       "dependencies": {
-        "@sinonjs/fake-timers": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-          "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^3.0.0"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -31160,16 +31115,6 @@
         }
       }
     },
-    "terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      }
-    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -31265,18 +31210,18 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "28.0.8",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
-      "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
-        "jest-util": "^28.0.0",
-        "json5": "^2.2.1",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
-        "semver": "7.x",
+        "semver": "^7.5.3",
         "yargs-parser": "^21.0.1"
       },
       "dependencies": {
@@ -31446,6 +31391,14 @@
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^1.6.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+          "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+          "dev": true
+        }
       }
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -107,14 +107,14 @@
     "@semantic-release/npm": "10.0.4",
     "@semantic-release/release-notes-generator": "11.0.4",
     "@types/chai": "4.3.5",
-    "@types/jest": "28.1.8",
+    "@types/jest": "29.5.3",
     "@types/node": "18.16.19",
     "chai": "4.3.7",
     "conventional-changelog-conventionalcommits": "6.1.0",
-    "jest": "28.1.3",
+    "jest": "29.6.1",
     "semantic-release": "21.0.7",
     "sinon": "15.2.0",
-    "ts-jest": "28.0.8",
+    "ts-jest": "29.1.1",
     "ts-node": "10.9.1"
   },
   "repository": {

--- a/src/base/__snapshots__/ApplicationAutoscaling.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationAutoscaling.spec.ts.snap
@@ -2,100 +2,100 @@
 
 exports[`ApplicationAutoscaling constructor renders autoscaling without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testAutoscaling_scale_in_policy_8085C07C\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testAutoscaling_scale_in_policy_8085C07C": {
+        "depends_on": [
+          "aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955"
         ],
-        \\"name\\": \\"test--ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "test--ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testAutoscaling_scale_out_policy_DE69B04C\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955\\"
+      "testAutoscaling_scale_out_policy_DE69B04C": {
+        "depends_on": [
+          "aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955"
         ],
-        \\"name\\": \\"test--ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "test--ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testAutoscaling_autoscaling_target_DFDF5955.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testAutoscaling_autoscaling_target_DFDF5955\\": {
-        \\"max_capacity\\": 5,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testAutoscaling_autoscaling_target_DFDF5955": {
+        "max_capacity": 5,
+        "min_capacity": 1,
+        "resource_id": "service/ecs-cluster-test/ecs-service-test",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testAutoscaling_scale_in_alarm_D552E48E\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testAutoscaling_scale_in_policy_8085C07C.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testAutoscaling_scale_in_alarm_D552E48E": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testAutoscaling_scale_in_policy_8085C07C.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"test- Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"ecs-cluster-test\\",
-          \\"ServiceName\\": \\"ecs-service-test\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "test- Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "ecs-cluster-test",
+          "ServiceName": "ecs-service-test"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testAutoscaling_scale_out_alarm_DBD72533\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testAutoscaling_scale_out_policy_DE69B04C.arn}\\"
+      "testAutoscaling_scale_out_alarm_DBD72533": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testAutoscaling_scale_out_policy_DE69B04C.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"test- Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"ecs-cluster-test\\",
-          \\"ServiceName\\": \\"ecs-service-test\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "test- Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "ecs-cluster-test",
+          "ServiceName": "ecs-service-test"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     }
   }
@@ -104,38 +104,38 @@ exports[`ApplicationAutoscaling constructor renders autoscaling without tags 1`]
 
 exports[`ApplicationAutoscaling generateAutoScalingPolicy renders a scale-in AutoscalingPolicy 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"test-resource_scale_in_policy_FC19C991\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "test-resource_scale_in_policy_FC19C991": {
+        "depends_on": [
+          "aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94"
         ],
-        \\"name\\": \\"test--ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "test--ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"test-resource_autoscaling_target_50BC4A94\\": {
-        \\"max_capacity\\": 5,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "test-resource_autoscaling_target_50BC4A94": {
+        "max_capacity": 5,
+        "min_capacity": 1,
+        "resource_id": "service/ecs-cluster-test/ecs-service-test",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     }
   }
@@ -144,38 +144,38 @@ exports[`ApplicationAutoscaling generateAutoScalingPolicy renders a scale-in Aut
 
 exports[`ApplicationAutoscaling generateAutoScalingPolicy renders a scale-out AutoscalingPolicy 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"test-resource_scale_out_policy_CE22053C\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "test-resource_scale_out_policy_CE22053C": {
+        "depends_on": [
+          "aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94"
         ],
-        \\"name\\": \\"test--ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "test--ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"test-resource_autoscaling_target_50BC4A94\\": {
-        \\"max_capacity\\": 5,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "test-resource_autoscaling_target_50BC4A94": {
+        "max_capacity": 5,
+        "min_capacity": 1,
+        "resource_id": "service/ecs-cluster-test/ecs-service-test",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     }
   }
@@ -184,14 +184,14 @@ exports[`ApplicationAutoscaling generateAutoScalingPolicy renders a scale-out Au
 
 exports[`ApplicationAutoscaling generateAutoScalingTarget renders an AutoscalingTarget 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_appautoscaling_target\\": {
-      \\"test-resource_autoscaling_target_50BC4A94\\": {
-        \\"max_capacity\\": 5,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+  "resource": {
+    "aws_appautoscaling_target": {
+      "test-resource_autoscaling_target_50BC4A94": {
+        "max_capacity": 5,
+        "min_capacity": 1,
+        "resource_id": "service/ecs-cluster-test/ecs-service-test",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     }
   }
@@ -200,59 +200,59 @@ exports[`ApplicationAutoscaling generateAutoScalingTarget renders an Autoscaling
 
 exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-in Cloudwatch Alarm 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"test-resource_scale_in_policy_FC19C991\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "test-resource_scale_in_policy_FC19C991": {
+        "depends_on": [
+          "aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94"
         ],
-        \\"name\\": \\"test--ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "test--ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"test-resource_autoscaling_target_50BC4A94\\": {
-        \\"max_capacity\\": 5,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "test-resource_autoscaling_target_50BC4A94": {
+        "max_capacity": 5,
+        "min_capacity": 1,
+        "resource_id": "service/ecs-cluster-test/ecs-service-test",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"test-resource_scale_in_alarm_73254138\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.test-resource_scale_in_policy_FC19C991.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "test-resource_scale_in_alarm_73254138": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.test-resource_scale_in_policy_FC19C991.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"test- Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"ecs-cluster-test\\",
-          \\"ServiceName\\": \\"ecs-service-test\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "test- Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "ecs-cluster-test",
+          "ServiceName": "ecs-service-test"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       }
     }
   }
@@ -261,59 +261,59 @@ exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-in
 
 exports[`ApplicationAutoscaling generateCloudwatchMetricAlarm renders a scale-out Cloudwatch Alarm 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"test-resource_scale_out_policy_CE22053C\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "test-resource_scale_out_policy_CE22053C": {
+        "depends_on": [
+          "aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94"
         ],
-        \\"name\\": \\"test--ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "test--ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.test-resource_autoscaling_target_50BC4A94.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"test-resource_autoscaling_target_50BC4A94\\": {
-        \\"max_capacity\\": 5,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/ecs-cluster-test/ecs-service-test\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "test-resource_autoscaling_target_50BC4A94": {
+        "max_capacity": 5,
+        "min_capacity": 1,
+        "resource_id": "service/ecs-cluster-test/ecs-service-test",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"test-resource_scale_out_alarm_5BADC0D8\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.test-resource_scale_out_policy_CE22053C.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "test-resource_scale_out_alarm_5BADC0D8": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.test-resource_scale_out_policy_CE22053C.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"test- Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"ecs-cluster-test\\",
-          \\"ServiceName\\": \\"ecs-service-test\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "test- Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "ecs-cluster-test",
+          "ServiceName": "ecs-service-test"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationBackups.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationBackups.spec.ts.snap
@@ -2,54 +2,54 @@
 
 exports[`ApplicationBackup renders vault with plans with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_backup_plan\\": {
-      \\"testBackup_backup-plan_AB394A83\\": {
-        \\"name\\": \\"TestPlan\\",
-        \\"rule\\": [
+  "resource": {
+    "aws_backup_plan": {
+      "testBackup_backup-plan_AB394A83": {
+        "name": "TestPlan",
+        "rule": [
           {
-            \\"rule_name\\": \\"TestBackupRule\\",
-            \\"schedule\\": \\"cron( 0 5 ? * * *)\\",
-            \\"target_vault_name\\": \\"\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}\\"
+            "rule_name": "TestBackupRule",
+            "schedule": "cron( 0 5 ? * * *)",
+            "target_vault_name": "\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}"
           }
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_backup_selection\\": {
-      \\"testBackup_backup-selection_67969F7D\\": {
-        \\"iam_role_arn\\": \\"arn:aws:iam::1234567890:role/service-role/AWSBackupDefaultServiceRole\\",
-        \\"name\\": \\"prefix-Backup-Selection\\",
-        \\"plan_id\\": \\"\${aws_backup_plan.testBackup_backup-plan_AB394A83.id}\\",
-        \\"resources\\": [
-          \\"arn:aws:rds:us-east-1:123456790:db:test\\"
+    "aws_backup_selection": {
+      "testBackup_backup-selection_67969F7D": {
+        "iam_role_arn": "arn:aws:iam::1234567890:role/service-role/AWSBackupDefaultServiceRole",
+        "name": "prefix-Backup-Selection",
+        "plan_id": "\${aws_backup_plan.testBackup_backup-plan_AB394A83.id}",
+        "resources": [
+          "arn:aws:rds:us-east-1:123456790:db:test"
         ],
-        \\"selection_tag\\": [
+        "selection_tag": [
           {
-            \\"key\\": \\"backups\\",
-            \\"type\\": \\"STRINGEQUALS\\",
-            \\"value\\": \\"True\\"
+            "key": "backups",
+            "type": "STRINGEQUALS",
+            "value": "True"
           }
         ]
       }
     },
-    \\"aws_backup_vault\\": {
-      \\"testBackup_backup-vault_C40F1BAC\\": {
-        \\"kms_key_arn\\": \\"arn:aws:kms:us-east-1:1234567890:key/mrk-1234\\",
-        \\"name\\": \\"prefix-name\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_backup_vault": {
+      "testBackup_backup-vault_C40F1BAC": {
+        "kms_key_arn": "arn:aws:kms:us-east-1:1234567890:key/mrk-1234",
+        "name": "prefix-name",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_backup_vault_policy\\": {
-      \\"testBackup_backup-vault-policy_A278B298\\": {
-        \\"backup_vault_name\\": \\"\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}\\",
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\": \\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\": [{\\\\\\"Effect\\\\\\": \\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\": \\\\\\"backup:CopyIntoBackupVault\\\\\\",\\\\\\"Resource\\\\\\": \\\\\\"*\\\\\\",\\\\\\"Principal\\\\\\": \\\\\\"*\\\\\\",\\\\\\"Condition\\\\\\": {\\\\\\"StringEquals\\\\\\": {\\\\\\"aws:PrincipalOrgID\\\\\\": [\\\\\\"o-1234567890\\\\\\"]}}}]}\\"
+    "aws_backup_vault_policy": {
+      "testBackup_backup-vault-policy_A278B298": {
+        "backup_vault_name": "\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}",
+        "policy": "{\\"Version\\": \\"2012-10-17\\",\\"Statement\\": [{\\"Effect\\": \\"Allow\\",\\"Action\\": \\"backup:CopyIntoBackupVault\\",\\"Resource\\": \\"*\\",\\"Principal\\": \\"*\\",\\"Condition\\": {\\"StringEquals\\": {\\"aws:PrincipalOrgID\\": [\\"o-1234567890\\"]}}}]}"
       }
     }
   }
@@ -58,46 +58,46 @@ exports[`ApplicationBackup renders vault with plans with tags 1`] = `
 
 exports[`ApplicationBackup renders vault with plans without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_backup_plan\\": {
-      \\"testBackup_backup-plan_AB394A83\\": {
-        \\"name\\": \\"TestPlan\\",
-        \\"rule\\": [
+  "resource": {
+    "aws_backup_plan": {
+      "testBackup_backup-plan_AB394A83": {
+        "name": "TestPlan",
+        "rule": [
           {
-            \\"rule_name\\": \\"TestBackupRule\\",
-            \\"schedule\\": \\"cron( 0 5 ? * * *)\\",
-            \\"target_vault_name\\": \\"\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}\\"
+            "rule_name": "TestBackupRule",
+            "schedule": "cron( 0 5 ? * * *)",
+            "target_vault_name": "\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}"
           }
         ]
       }
     },
-    \\"aws_backup_selection\\": {
-      \\"testBackup_backup-selection_67969F7D\\": {
-        \\"iam_role_arn\\": \\"arn:aws:iam::1234567890:role/service-role/AWSBackupDefaultServiceRole\\",
-        \\"name\\": \\"prefix-Backup-Selection\\",
-        \\"plan_id\\": \\"\${aws_backup_plan.testBackup_backup-plan_AB394A83.id}\\",
-        \\"resources\\": [
-          \\"arn:aws:rds:us-east-1:123456790:db:test\\"
+    "aws_backup_selection": {
+      "testBackup_backup-selection_67969F7D": {
+        "iam_role_arn": "arn:aws:iam::1234567890:role/service-role/AWSBackupDefaultServiceRole",
+        "name": "prefix-Backup-Selection",
+        "plan_id": "\${aws_backup_plan.testBackup_backup-plan_AB394A83.id}",
+        "resources": [
+          "arn:aws:rds:us-east-1:123456790:db:test"
         ],
-        \\"selection_tag\\": [
+        "selection_tag": [
           {
-            \\"key\\": \\"backups\\",
-            \\"type\\": \\"STRINGEQUALS\\",
-            \\"value\\": \\"True\\"
+            "key": "backups",
+            "type": "STRINGEQUALS",
+            "value": "True"
           }
         ]
       }
     },
-    \\"aws_backup_vault\\": {
-      \\"testBackup_backup-vault_C40F1BAC\\": {
-        \\"kms_key_arn\\": \\"arn:aws:kms:us-east-1:1234567890:key/mrk-1234\\",
-        \\"name\\": \\"prefix-name\\"
+    "aws_backup_vault": {
+      "testBackup_backup-vault_C40F1BAC": {
+        "kms_key_arn": "arn:aws:kms:us-east-1:1234567890:key/mrk-1234",
+        "name": "prefix-name"
       }
     },
-    \\"aws_backup_vault_policy\\": {
-      \\"testBackup_backup-vault-policy_A278B298\\": {
-        \\"backup_vault_name\\": \\"\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}\\",
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\": \\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\": [{\\\\\\"Effect\\\\\\": \\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\": \\\\\\"backup:CopyIntoBackupVault\\\\\\",\\\\\\"Resource\\\\\\": \\\\\\"*\\\\\\",\\\\\\"Principal\\\\\\": \\\\\\"*\\\\\\",\\\\\\"Condition\\\\\\": {\\\\\\"StringEquals\\\\\\": {\\\\\\"aws:PrincipalOrgID\\\\\\": [\\\\\\"o-1234567890\\\\\\"]}}}]}\\"
+    "aws_backup_vault_policy": {
+      "testBackup_backup-vault-policy_A278B298": {
+        "backup_vault_name": "\${aws_backup_vault.testBackup_backup-vault_C40F1BAC.name}",
+        "policy": "{\\"Version\\": \\"2012-10-17\\",\\"Statement\\": [{\\"Effect\\": \\"Allow\\",\\"Action\\": \\"backup:CopyIntoBackupVault\\",\\"Resource\\": \\"*\\",\\"Principal\\": \\"*\\",\\"Condition\\": {\\"StringEquals\\": {\\"aws:PrincipalOrgID\\": [\\"o-1234567890\\"]}}}]}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationBaseDNS.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationBaseDNS.spec.ts.snap
@@ -2,29 +2,29 @@
 
 exports[`ApplicationBaseDNS constructor renders base DNS with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_route53_zone\\": {
-      \\"testDNS_main_hosted_zone\\": {
-        \\"name\\": \\"gobowling.info\\"
+  "data": {
+    "aws_route53_zone": {
+      "testDNS_main_hosted_zone": {
+        "name": "gobowling.info"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_route53_record\\": {
-      \\"testDNS_subhosted_zone_ns_5F02B4AB\\": {
-        \\"name\\": \\"dev.gobowling.info\\",
-        \\"records\\": \\"\${aws_route53_zone.testDNS_subhosted_zone_0D42EC63.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testDNS_main_hosted_zone.zone_id}\\"
+  "resource": {
+    "aws_route53_record": {
+      "testDNS_subhosted_zone_ns_5F02B4AB": {
+        "name": "dev.gobowling.info",
+        "records": "\${aws_route53_zone.testDNS_subhosted_zone_0D42EC63.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testDNS_main_hosted_zone.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testDNS_subhosted_zone_0D42EC63\\": {
-        \\"name\\": \\"dev.gobowling.info\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_route53_zone": {
+      "testDNS_subhosted_zone_0D42EC63": {
+        "name": "dev.gobowling.info",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     }
@@ -34,26 +34,26 @@ exports[`ApplicationBaseDNS constructor renders base DNS with tags 1`] = `
 
 exports[`ApplicationBaseDNS constructor renders base DNS without tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_route53_zone\\": {
-      \\"testDNS_main_hosted_zone\\": {
-        \\"name\\": \\"gobowling.info\\"
+  "data": {
+    "aws_route53_zone": {
+      "testDNS_main_hosted_zone": {
+        "name": "gobowling.info"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_route53_record\\": {
-      \\"testDNS_subhosted_zone_ns_5F02B4AB\\": {
-        \\"name\\": \\"dev.gobowling.info\\",
-        \\"records\\": \\"\${aws_route53_zone.testDNS_subhosted_zone_0D42EC63.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testDNS_main_hosted_zone.zone_id}\\"
+  "resource": {
+    "aws_route53_record": {
+      "testDNS_subhosted_zone_ns_5F02B4AB": {
+        "name": "dev.gobowling.info",
+        "records": "\${aws_route53_zone.testDNS_subhosted_zone_0D42EC63.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testDNS_main_hosted_zone.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testDNS_subhosted_zone_0D42EC63\\": {
-        \\"name\\": \\"dev.gobowling.info\\"
+    "aws_route53_zone": {
+      "testDNS_subhosted_zone_0D42EC63": {
+        "name": "dev.gobowling.info"
       }
     }
   }
@@ -62,17 +62,17 @@ exports[`ApplicationBaseDNS constructor renders base DNS without tags 1`] = `
 
 exports[`ApplicationBaseDNS generateRoute53Record renders a route 53 record 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_route53_record\\": {
-      \\"test-resource_subhosted_zone_ns_47594402\\": {
-        \\"name\\": \\"dev.gobowling.info\\",
-        \\"records\\": [
-          \\"some\\",
-          \\"records\\"
+  "resource": {
+    "aws_route53_record": {
+      "test-resource_subhosted_zone_ns_47594402": {
+        "name": "dev.gobowling.info",
+        "records": [
+          "some",
+          "records"
         ],
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"some-zone-id\\"
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "some-zone-id"
       }
     }
   }
@@ -81,10 +81,10 @@ exports[`ApplicationBaseDNS generateRoute53Record renders a route 53 record 1`] 
 
 exports[`ApplicationBaseDNS generateRoute53Zone renders a route 53 zone 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_route53_zone\\": {
-      \\"test-resource_subhosted_zone_262A1A23\\": {
-        \\"name\\": \\"dev.gobowling.info\\"
+  "resource": {
+    "aws_route53_zone": {
+      "test-resource_subhosted_zone_262A1A23": {
+        "name": "dev.gobowling.info"
       }
     }
   }
@@ -93,13 +93,13 @@ exports[`ApplicationBaseDNS generateRoute53Zone renders a route 53 zone 1`] = `
 
 exports[`ApplicationBaseDNS generateRoute53Zone renders a route 53 zone with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_route53_zone\\": {
-      \\"test-resource_subhosted_zone_262A1A23\\": {
-        \\"name\\": \\"dev.gobowling.info\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+  "resource": {
+    "aws_route53_zone": {
+      "test-resource_subhosted_zone_262A1A23": {
+        "name": "dev.gobowling.info",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     }
@@ -109,10 +109,10 @@ exports[`ApplicationBaseDNS generateRoute53Zone renders a route 53 zone with tag
 
 exports[`ApplicationBaseDNS retrieveAwsRoute53Zone retrieves a route 53 zone 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_route53_zone\\": {
-      \\"test-resource_some-zone_main_hosted_zone_B55D697C\\": {
-        \\"name\\": \\"gobowling.info\\"
+  "data": {
+    "aws_route53_zone": {
+      "test-resource_some-zone_main_hosted_zone_B55D697C": {
+        "name": "gobowling.info"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationCertificate.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationCertificate.spec.ts.snap
@@ -2,40 +2,40 @@
 
 exports[`ApplicationCertificate constructor renders a cert with a zone domain 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testCert_certificate_3EDC39B5\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testCert_certificate_3EDC39B5": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testCert_certificate_validation_80E8BDA3\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testCert_certificate_3EDC39B5.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testCert_certificate_record_93AF392D\\",
-          \\"aws_acm_certificate.testCert_certificate_3EDC39B5\\"
+    "aws_acm_certificate_validation": {
+      "testCert_certificate_validation_80E8BDA3": {
+        "certificate_arn": "\${aws_acm_certificate.testCert_certificate_3EDC39B5.arn}",
+        "depends_on": [
+          "aws_route53_record.testCert_certificate_record_93AF392D",
+          "aws_acm_certificate.testCert_certificate_3EDC39B5"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testCert_certificate_record_93AF392D.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testCert_certificate_record_93AF392D.fqdn}"
         ]
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testCert_certificate_record_93AF392D\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testCert_certificate_3EDC39B5\\"
+    "aws_route53_record": {
+      "testCert_certificate_record_93AF392D": {
+        "depends_on": [
+          "aws_acm_certificate.testCert_certificate_3EDC39B5"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"gobowling.info\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_type}",
+        "zone_id": "gobowling.info"
       }
     }
   }
@@ -44,40 +44,40 @@ exports[`ApplicationCertificate constructor renders a cert with a zone domain 1`
 
 exports[`ApplicationCertificate constructor renders a cert with a zone id 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testCert_certificate_3EDC39B5\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testCert_certificate_3EDC39B5": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testCert_certificate_validation_80E8BDA3\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testCert_certificate_3EDC39B5.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testCert_certificate_record_93AF392D\\",
-          \\"aws_acm_certificate.testCert_certificate_3EDC39B5\\"
+    "aws_acm_certificate_validation": {
+      "testCert_certificate_validation_80E8BDA3": {
+        "certificate_arn": "\${aws_acm_certificate.testCert_certificate_3EDC39B5.arn}",
+        "depends_on": [
+          "aws_route53_record.testCert_certificate_record_93AF392D",
+          "aws_acm_certificate.testCert_certificate_3EDC39B5"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testCert_certificate_record_93AF392D.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testCert_certificate_record_93AF392D.fqdn}"
         ]
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testCert_certificate_record_93AF392D\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testCert_certificate_3EDC39B5\\"
+    "aws_route53_record": {
+      "testCert_certificate_record_93AF392D": {
+        "depends_on": [
+          "aws_acm_certificate.testCert_certificate_3EDC39B5"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"malibu\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_type}",
+        "zone_id": "malibu"
       }
     }
   }
@@ -86,44 +86,44 @@ exports[`ApplicationCertificate constructor renders a cert with a zone id 1`] = 
 
 exports[`ApplicationCertificate constructor renders a cert with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testCert_certificate_3EDC39B5\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testCert_certificate_3EDC39B5": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testCert_certificate_validation_80E8BDA3\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testCert_certificate_3EDC39B5.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testCert_certificate_record_93AF392D\\",
-          \\"aws_acm_certificate.testCert_certificate_3EDC39B5\\"
+    "aws_acm_certificate_validation": {
+      "testCert_certificate_validation_80E8BDA3": {
+        "certificate_arn": "\${aws_acm_certificate.testCert_certificate_3EDC39B5.arn}",
+        "depends_on": [
+          "aws_route53_record.testCert_certificate_record_93AF392D",
+          "aws_acm_certificate.testCert_certificate_3EDC39B5"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testCert_certificate_record_93AF392D.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testCert_certificate_record_93AF392D.fqdn}"
         ]
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testCert_certificate_record_93AF392D\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testCert_certificate_3EDC39B5\\"
+    "aws_route53_record": {
+      "testCert_certificate_record_93AF392D": {
+        "depends_on": [
+          "aws_acm_certificate.testCert_certificate_3EDC39B5"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"gobowling.info\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testCert_certificate_3EDC39B5.domain_validation_options).0.resource_record_type}",
+        "zone_id": "gobowling.info"
       }
     }
   }
@@ -132,18 +132,18 @@ exports[`ApplicationCertificate constructor renders a cert with tags 1`] = `
 
 exports[`ApplicationCertificate generateAcmCertificate renders an acm certificate with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"test-resource_certificate_15680B70\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "test-resource_certificate_15680B70": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     }
   }
@@ -152,14 +152,14 @@ exports[`ApplicationCertificate generateAcmCertificate renders an acm certificat
 
 exports[`ApplicationCertificate generateAcmCertificate renders an acm certificate without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"test-resource_certificate_15680B70\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "test-resource_certificate_15680B70": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     }
   }
@@ -168,40 +168,40 @@ exports[`ApplicationCertificate generateAcmCertificate renders an acm certificat
 
 exports[`ApplicationCertificate generateAcmCertificateValidation renders an acm certificate validation 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"test-resource_certificate_15680B70\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "test-resource_certificate_15680B70": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"test-resource_certificate_validation_7DB80AF0\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.test-resource_certificate_15680B70.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.test-resource_certificate_record_59EDF3C1\\",
-          \\"aws_acm_certificate.test-resource_certificate_15680B70\\"
+    "aws_acm_certificate_validation": {
+      "test-resource_certificate_validation_7DB80AF0": {
+        "certificate_arn": "\${aws_acm_certificate.test-resource_certificate_15680B70.arn}",
+        "depends_on": [
+          "aws_route53_record.test-resource_certificate_record_59EDF3C1",
+          "aws_acm_certificate.test-resource_certificate_15680B70"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.test-resource_certificate_record_59EDF3C1.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.test-resource_certificate_record_59EDF3C1.fqdn}"
         ]
       }
     },
-    \\"aws_route53_record\\": {
-      \\"test-resource_certificate_record_59EDF3C1\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.test-resource_certificate_15680B70\\"
+    "aws_route53_record": {
+      "test-resource_certificate_record_59EDF3C1": {
+        "depends_on": [
+          "aws_acm_certificate.test-resource_certificate_15680B70"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"dev.gobowling.info\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_type}",
+        "zone_id": "dev.gobowling.info"
       }
     }
   }
@@ -210,28 +210,28 @@ exports[`ApplicationCertificate generateAcmCertificateValidation renders an acm 
 
 exports[`ApplicationCertificate generateRoute53Record renders a route 53 record 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"test-resource_certificate_15680B70\\": {
-        \\"domain_name\\": \\"dev.gobowling.info\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "test-resource_certificate_15680B70": {
+        "domain_name": "dev.gobowling.info",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"test-resource_certificate_record_59EDF3C1\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.test-resource_certificate_15680B70\\"
+    "aws_route53_record": {
+      "test-resource_certificate_record_59EDF3C1": {
+        "depends_on": [
+          "aws_acm_certificate.test-resource_certificate_15680B70"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"dev.gobowling.info\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.test-resource_certificate_15680B70.domain_validation_options).0.resource_record_type}",
+        "zone_id": "dev.gobowling.info"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationDynamoDBTable.spec.ts.snap
@@ -2,20 +2,20 @@
 
 exports[`ApplicationDynamoDBTable renders a dynamodb table with streams enabled 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+  "resource": {
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "billing_mode": "PROVISIONED",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\",
-        \\"stream_enabled\\": true,
-        \\"stream_view_type\\": \\"NEW_AND_OLD_IMAGES\\"
+        "name": "abides-",
+        "stream_enabled": true,
+        "stream_view_type": "NEW_AND_OLD_IMAGES"
       }
     }
   }
@@ -24,281 +24,281 @@ exports[`ApplicationDynamoDBTable renders a dynamodb table with streams enabled 
 
 exports[`ApplicationDynamoDBTable renders dynamo db table global secondary indexes 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_ReadCapacity_policy_document_EF789C68": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_policy_document_9032D023": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testDynamoDBTable_card-index_ReadCapacity_index_policy_81408390": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_card-index_WriteCapacity_index_policy_C3071E31": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+    "aws_appautoscaling_target": {
+      "testDynamoDBTable_card-index_ReadCapacity_index_target_8A2F409F": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 5,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:index:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_card-index_WriteCapacity_index_target_F5D86C4A": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 5,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 5,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:index:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:table:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:table:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       }
     },
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
           {
-            \\"hash_key\\": \\"card-type\\",
-            \\"name\\": \\"card-index\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_on_the_range\\",
-            \\"read_capacity\\": 5,
-            \\"write_capacity\\": 5
+            "hash_key": "card-type",
+            "name": "card-index",
+            "projection_type": "ALL",
+            "range_key": "home_on_the_range",
+            "read_capacity": 5,
+            "write_capacity": 5
           }
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\"
+    "aws_iam_policy": {
+      "testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649": {
+        "name": "abides--ReadCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}"
       },
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\"
+      "testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60": {
+        "name": "abides--WriteCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\"
+    "aws_iam_role": {
+      "testDynamoDBTable_ReadCapacity_role_2B9645BB": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}",
+        "name": "abides--ReadCapacity-AutoScalingRole"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\"
+      "testDynamoDBTable_WriteCapacity_role_4BB8E3F1": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}",
+        "name": "abides--WriteCapacity-AutoScalingRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+    "aws_iam_role_policy_attachment": {
+      "testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB",
+          "aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+      "testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1",
+          "aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}"
       }
     }
   }
@@ -307,27 +307,27 @@ exports[`ApplicationDynamoDBTable renders dynamo db table global secondary index
 
 exports[`ApplicationDynamoDBTable renders dynamo db table that is not protected from being destroyed 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": false
+          "prevent_destroy": false
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     }
   }
@@ -336,281 +336,281 @@ exports[`ApplicationDynamoDBTable renders dynamo db table that is not protected 
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with 2 global secondary indexes 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_ReadCapacity_policy_document_EF789C68": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_policy_document_9032D023": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testDynamoDBTable_card-index-2_ReadCapacity_index_policy_72866E91": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_card-index-2_WriteCapacity_index_policy_BDD340E7": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+    "aws_appautoscaling_target": {
+      "testDynamoDBTable_card-index-2_ReadCapacity_index_target_5B34D257": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 10,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 10,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:index:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_card-index-2_WriteCapacity_index_target_2BCC5603": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 10,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:index:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 10,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}/index/card-index-2",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:index:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:table:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:table:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       }
     },
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
           {
-            \\"hash_key\\": \\"card-type-123\\",
-            \\"name\\": \\"card-index-2\\",
-            \\"projection_type\\": \\"ALL\\",
-            \\"range_key\\": \\"home_home_on_the_range\\",
-            \\"read_capacity\\": 10,
-            \\"write_capacity\\": 10
+            "hash_key": "card-type-123",
+            "name": "card-index-2",
+            "projection_type": "ALL",
+            "range_key": "home_home_on_the_range",
+            "read_capacity": 10,
+            "write_capacity": 10
           }
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\"
+    "aws_iam_policy": {
+      "testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649": {
+        "name": "abides--ReadCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}"
       },
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\"
+      "testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60": {
+        "name": "abides--WriteCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\"
+    "aws_iam_role": {
+      "testDynamoDBTable_ReadCapacity_role_2B9645BB": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}",
+        "name": "abides--ReadCapacity-AutoScalingRole"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\"
+      "testDynamoDBTable_WriteCapacity_role_4BB8E3F1": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}",
+        "name": "abides--WriteCapacity-AutoScalingRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+    "aws_iam_role_policy_attachment": {
+      "testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB",
+          "aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+      "testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1",
+          "aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}"
       }
     }
   }
@@ -619,27 +619,27 @@ exports[`ApplicationDynamoDBTable renders dynamo db table with 2 global secondar
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with minimal config 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     }
   }
@@ -648,27 +648,27 @@ exports[`ApplicationDynamoDBTable renders dynamo db table with minimal config 1`
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with on-demand capacity 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+  "resource": {
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PAY_PER_REQUEST\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PAY_PER_REQUEST",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     }
   }
@@ -677,217 +677,217 @@ exports[`ApplicationDynamoDBTable renders dynamo db table with on-demand capacit
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with read and write capacity 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_ReadCapacity_policy_document_EF789C68": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_policy_document_9032D023": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+    "aws_appautoscaling_target": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:table:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:table:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       }
     },
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\"
+    "aws_iam_policy": {
+      "testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649": {
+        "name": "abides--ReadCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}"
       },
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\"
+      "testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60": {
+        "name": "abides--WriteCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\"
+    "aws_iam_role": {
+      "testDynamoDBTable_ReadCapacity_role_2B9645BB": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}",
+        "name": "abides--ReadCapacity-AutoScalingRole"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\"
+      "testDynamoDBTable_WriteCapacity_role_4BB8E3F1": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}",
+        "name": "abides--WriteCapacity-AutoScalingRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+    "aws_iam_role_policy_attachment": {
+      "testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB",
+          "aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+      "testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1",
+          "aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}"
       }
     }
   }
@@ -896,229 +896,229 @@ exports[`ApplicationDynamoDBTable renders dynamo db table with read and write ca
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with read and write capacity and tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_ReadCapacity_policy_document_EF789C68": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_policy_document_9032D023": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+    "aws_appautoscaling_target": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:table:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       },
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:table:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       }
     },
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name": "abides-",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\"
+    "aws_iam_policy": {
+      "testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649": {
+        "name": "abides--ReadCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}"
       },
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\"
+      "testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60": {
+        "name": "abides--WriteCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_iam_role": {
+      "testDynamoDBTable_ReadCapacity_role_2B9645BB": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}",
+        "name": "abides--ReadCapacity-AutoScalingRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+      "testDynamoDBTable_WriteCapacity_role_4BB8E3F1": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}",
+        "name": "abides--WriteCapacity-AutoScalingRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+    "aws_iam_role_policy_attachment": {
+      "testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB",
+          "aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}"
       },
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+      "testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1",
+          "aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}"
       }
     }
   }
@@ -1127,129 +1127,129 @@ exports[`ApplicationDynamoDBTable renders dynamo db table with read and write ca
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with read capacity 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_ReadCapacity_policy_document_EF789C68\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_ReadCapacity_policy_document_EF789C68": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_policy_558BE4C0": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBReadCapacityUtilization\\"
+        "name": "DynamoDBReadCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBReadCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+    "aws_appautoscaling_target": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_ReadCapacity_table_target_5A95550B": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:ReadCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.arn}",
+        "scalable_dimension": "dynamodb:table:ReadCapacityUnits",
+        "service_namespace": "dynamodb"
       }
     },
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\": {
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}\\"
+    "aws_iam_policy": {
+      "testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649": {
+        "name": "abides--ReadCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_policy_document_EF789C68.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_2B9645BB\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}\\",
-        \\"name\\": \\"abides--ReadCapacity-AutoScalingRole\\"
+    "aws_iam_role": {
+      "testDynamoDBTable_ReadCapacity_role_2B9645BB": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_ReadCapacity_assume_role_policy_document_54F698F0.json}",
+        "name": "abides--ReadCapacity-AutoScalingRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB\\",
-          \\"aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649\\"
+    "aws_iam_role_policy_attachment": {
+      "testDynamoDBTable_ReadCapacity_role_attachment_3C0829C2": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB",
+          "aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_ReadCapacity_autoscaling_policy_52DA6649.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_ReadCapacity_role_2B9645BB.name}"
       }
     }
   }
@@ -1258,129 +1258,129 @@ exports[`ApplicationDynamoDBTable renders dynamo db table with read capacity 1`]
 
 exports[`ApplicationDynamoDBTable renders dynamo db table with write capacity 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"application-autoscaling.amazonaws.com\\"
+                "identifiers": [
+                  "application-autoscaling.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"testDynamoDBTable_WriteCapacity_policy_document_9032D023\\": {
-        \\"statement\\": [
+      "testDynamoDBTable_WriteCapacity_policy_document_9032D023": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"application-autoscaling:*\\",
-              \\"cloudwatch:DescribeAlarms\\",
-              \\"cloudwatch:PutMetricAlarm\\"
+            "actions": [
+              "application-autoscaling:*",
+              "cloudwatch:DescribeAlarms",
+              "cloudwatch:PutMetricAlarm"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"dynamodb:DescribeTable\\",
-              \\"dynamodb:UpdateTable\\"
+            "actions": [
+              "dynamodb:DescribeTable",
+              "dynamodb:UpdateTable"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}\\",
-              \\"\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}",
+              "\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.arn}*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\",
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_policy_45352666": {
+        "depends_on": [
+          "aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE",
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"name\\": \\"DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"policy_type\\": \\"TargetTrackingScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}\\",
-        \\"target_tracking_scaling_policy_configuration\\": {
-          \\"predefined_metric_specification\\": {
-            \\"predefined_metric_type\\": \\"DynamoDBWriteCapacityUtilization\\"
+        "name": "DynamoDBWriteCapacityUtilization:\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "policy_type": "TargetTrackingScaling",
+        "resource_id": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE.service_namespace}",
+        "target_tracking_scaling_policy_configuration": {
+          "predefined_metric_specification": {
+            "predefined_metric_type": "DynamoDBWriteCapacityUtilization"
           },
-          \\"target_value\\": 1
+          "target_value": 1
         }
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE\\": {
-        \\"depends_on\\": [
-          \\"aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4\\"
+    "aws_appautoscaling_target": {
+      "testDynamoDBTable_testDynamoDBTable_dynamodb_table_A3DD49A4_WriteCapacity_table_target_EC052FEE": {
+        "depends_on": [
+          "aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4"
         ],
-        \\"max_capacity\\": 10,
-        \\"min_capacity\\": 3,
-        \\"resource_id\\": \\"table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}\\",
-        \\"role_arn\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}\\",
-        \\"scalable_dimension\\": \\"dynamodb:table:WriteCapacityUnits\\",
-        \\"service_namespace\\": \\"dynamodb\\"
+        "max_capacity": 10,
+        "min_capacity": 3,
+        "resource_id": "table/\${aws_dynamodb_table.testDynamoDBTable_dynamodb_table_A3DD49A4.name}",
+        "role_arn": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.arn}",
+        "scalable_dimension": "dynamodb:table:WriteCapacityUnits",
+        "service_namespace": "dynamodb"
       }
     },
-    \\"aws_dynamodb_table\\": {
-      \\"testDynamoDBTable_dynamodb_table_A3DD49A4\\": {
-        \\"attribute\\": [
+    "aws_dynamodb_table": {
+      "testDynamoDBTable_dynamodb_table_A3DD49A4": {
+        "attribute": [
           {
-            \\"name\\": \\"attribeautiful\\",
-            \\"type\\": \\"shrugs!\\"
+            "name": "attribeautiful",
+            "type": "shrugs!"
           }
         ],
-        \\"billing_mode\\": \\"PROVISIONED\\",
-        \\"global_secondary_index\\": [
+        "billing_mode": "PROVISIONED",
+        "global_secondary_index": [
         ],
-        \\"hash_key\\": \\"123\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"read_capacity\\",
-            \\"write_capacity\\"
+        "hash_key": "123",
+        "lifecycle": {
+          "ignore_changes": [
+            "read_capacity",
+            "write_capacity"
           ],
-          \\"prevent_destroy\\": true
+          "prevent_destroy": true
         },
-        \\"name\\": \\"abides-\\"
+        "name": "abides-"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\": {
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}\\"
+    "aws_iam_policy": {
+      "testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60": {
+        "name": "abides--WriteCapacity-AutoScalingPolicy",
+        "policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_policy_document_9032D023.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}\\",
-        \\"name\\": \\"abides--WriteCapacity-AutoScalingRole\\"
+    "aws_iam_role": {
+      "testDynamoDBTable_WriteCapacity_role_4BB8E3F1": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testDynamoDBTable_WriteCapacity_assume_role_policy_document_5A7EA325.json}",
+        "name": "abides--WriteCapacity-AutoScalingRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1\\",
-          \\"aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60\\"
+    "aws_iam_role_policy_attachment": {
+      "testDynamoDBTable_WriteCapacity_role_attachment_8ABB9833": {
+        "depends_on": [
+          "aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1",
+          "aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}\\"
+        "policy_arn": "\${aws_iam_policy.testDynamoDBTable_WriteCapacity_autoscaling_policy_9632CE60.arn}",
+        "role": "\${aws_iam_role.testDynamoDBTable_WriteCapacity_role_4BB8E3F1.name}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationECR.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECR.spec.ts.snap
@@ -2,25 +2,25 @@
 
 exports[`ApplicationECR renders an ECR with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testECR_ecr-repo-lifecyclepolicy_4B354AF7\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECR_ecr-repo_E42B68DA\\"
+  "resource": {
+    "aws_ecr_lifecycle_policy": {
+      "testECR_ecr-repo-lifecyclepolicy_4B354AF7": {
+        "depends_on": [
+          "aws_ecr_repository.testECR_ecr-repo_E42B68DA"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECR_ecr-repo_E42B68DA.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECR_ecr-repo_E42B68DA.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testECR_ecr-repo_E42B68DA\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testECR_ecr-repo_E42B68DA": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"bowling\\",
-        \\"tags\\": {
-          \\"description\\": \\"tiedtheroomtogether\\",
-          \\"name\\": \\"rug\\"
+        "name": "bowling",
+        "tags": {
+          "description": "tiedtheroomtogether",
+          "name": "rug"
         }
       }
     }
@@ -30,22 +30,22 @@ exports[`ApplicationECR renders an ECR with tags 1`] = `
 
 exports[`ApplicationECR renders an ECR without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testECR_ecr-repo-lifecyclepolicy_4B354AF7\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECR_ecr-repo_E42B68DA\\"
+  "resource": {
+    "aws_ecr_lifecycle_policy": {
+      "testECR_ecr-repo-lifecyclepolicy_4B354AF7": {
+        "depends_on": [
+          "aws_ecr_repository.testECR_ecr-repo_E42B68DA"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECR_ecr-repo_E42B68DA.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECR_ecr-repo_E42B68DA.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testECR_ecr-repo_E42B68DA\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testECR_ecr-repo_E42B68DA": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"bowling\\"
+        "name": "bowling"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationECSAlbCodeDeploy.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSAlbCodeDeploy.spec.ts.snap
@@ -2,121 +2,121 @@
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with a sns 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testCodeDeploy_current_account_0C0AC491\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testCodeDeploy_current_account_0C0AC491": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_region\\": {
-      \\"testCodeDeploy_current_region_B8533BBF\\": {
+    "aws_region": {
+      "testCodeDeploy_current_region_B8533BBF": {
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"testCodeDeploy_ecs_codedeploy_notifications_7223DA1D\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\",
-          \\"codedeploy-application-deployment-succeeded\\",
-          \\"codedeploy-application-deployment-started\\"
+    "aws_codestarnotifications_notification_rule": {
+      "testCodeDeploy_ecs_codedeploy_notifications_7223DA1D": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed",
+          "codedeploy-application-deployment-succeeded",
+          "codedeploy-application-deployment-started"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "resource": "arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "target": [
           {
-            \\"address\\": \\"notify-me\\"
+            "address": "notify-me"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }
@@ -125,134 +125,134 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with a sns 1`] = `
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with no deploy notifications 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testCodeDeploy_current_account_0C0AC491\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testCodeDeploy_current_account_0C0AC491": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_region\\": {
-      \\"testCodeDeploy_current_region_B8533BBF\\": {
+    "aws_region": {
+      "testCodeDeploy_current_region_B8533BBF": {
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"testCodeDeploy_ecs_codedeploy_notifications_7223DA1D\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
+    "aws_codestarnotifications_notification_rule": {
+      "testCodeDeploy_ecs_codedeploy_notifications_7223DA1D": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "resource": "arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         },
-        \\"target\\": [
+        "target": [
           {
-            \\"address\\": \\"notify-me\\"
+            "address": "notify-me"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }
@@ -261,135 +261,135 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with no deploy notific
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with only failed deploy notifications 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testCodeDeploy_current_account_0C0AC491\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testCodeDeploy_current_account_0C0AC491": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_region\\": {
-      \\"testCodeDeploy_current_region_B8533BBF\\": {
+    "aws_region": {
+      "testCodeDeploy_current_region_B8533BBF": {
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"testCodeDeploy_ecs_codedeploy_notifications_7223DA1D\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\"
+    "aws_codestarnotifications_notification_rule": {
+      "testCodeDeploy_ecs_codedeploy_notifications_7223DA1D": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "resource": "arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         },
-        \\"target\\": [
+        "target": [
           {
-            \\"address\\": \\"notify-me\\"
+            "address": "notify-me"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }
@@ -398,135 +398,135 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with only failed deplo
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with only started deploy notifications 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testCodeDeploy_current_account_0C0AC491\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testCodeDeploy_current_account_0C0AC491": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_region\\": {
-      \\"testCodeDeploy_current_region_B8533BBF\\": {
+    "aws_region": {
+      "testCodeDeploy_current_region_B8533BBF": {
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"testCodeDeploy_ecs_codedeploy_notifications_7223DA1D\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-started\\"
+    "aws_codestarnotifications_notification_rule": {
+      "testCodeDeploy_ecs_codedeploy_notifications_7223DA1D": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-started"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "resource": "arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         },
-        \\"target\\": [
+        "target": [
           {
-            \\"address\\": \\"notify-me\\"
+            "address": "notify-me"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }
@@ -535,135 +535,135 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with only started depl
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with only succeeded deploy notifications 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testCodeDeploy_current_account_0C0AC491\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testCodeDeploy_current_account_0C0AC491": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_region\\": {
-      \\"testCodeDeploy_current_region_B8533BBF\\": {
+    "aws_region": {
+      "testCodeDeploy_current_region_B8533BBF": {
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"testCodeDeploy_ecs_codedeploy_notifications_7223DA1D\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-succeeded\\"
+    "aws_codestarnotifications_notification_rule": {
+      "testCodeDeploy_ecs_codedeploy_notifications_7223DA1D": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-succeeded"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "resource": "arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         },
-        \\"target\\": [
+        "target": [
           {
-            \\"address\\": \\"notify-me\\"
+            "address": "notify-me"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }
@@ -672,137 +672,137 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with only succeeded de
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testCodeDeploy_current_account_0C0AC491\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testCodeDeploy_current_account_0C0AC491": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_region\\": {
-      \\"testCodeDeploy_current_region_B8533BBF\\": {
+    "aws_region": {
+      "testCodeDeploy_current_region_B8533BBF": {
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"testCodeDeploy_ecs_codedeploy_notifications_7223DA1D\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\",
-          \\"codedeploy-application-deployment-succeeded\\",
-          \\"codedeploy-application-deployment-started\\"
+    "aws_codestarnotifications_notification_rule": {
+      "testCodeDeploy_ecs_codedeploy_notifications_7223DA1D": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed",
+          "codedeploy-application-deployment-succeeded",
+          "codedeploy-application-deployment-started"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+        "name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "resource": "arn:aws:codedeploy:\${data.aws_region.testCodeDeploy_current_region_B8533BBF.name}:\${data.aws_caller_identity.testCodeDeploy_current_account_0C0AC491.account_id}:application:\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         },
-        \\"target\\": [
+        "target": [
           {
-            \\"address\\": \\"notify-me\\"
+            "address": "notify-me"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\",
-        \\"tags\\": {
-          \\"tag\\": \\"me\\",
-          \\"test\\": \\"1234\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole",
+        "tags": {
+          "tag": "me",
+          "test": "1234"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }
@@ -811,21 +811,21 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy with tags 1`] = `
 
 exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy without a sns 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testCodeDeploy_codedeploy_assume_role_E9FEDA7F\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testCodeDeploy_codedeploy_assume_role_E9FEDA7F": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -833,74 +833,74 @@ exports[`ApplicationECSAlbCodeDeploy renders a CodeDeploy without a sns 1`] = `
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"testCodeDeploy_ecs_code_deploy_C4535318\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"Test-Dev-ECS\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "testCodeDeploy_ecs_code_deploy_C4535318": {
+        "compute_platform": "ECS",
+        "name": "Test-Dev-ECS"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testCodeDeploy_ecs_codedeploy_deployment_group_F092EC5E": {
+        "app_name": "\${aws_codedeploy_app.testCodeDeploy_ecs_code_deploy_C4535318.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"Test-Dev-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "Test-Dev-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"cluster\\",
-          \\"service_name\\": \\"theService\\"
+        "ecs_service": {
+          "cluster_name": "cluster",
+          "service_name": "theService"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"listen-to-me\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "listen-to-me"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"target-1\\"
+                "name": "target-1"
               },
               {
-                \\"name\\": \\"target-2\\"
+                "name": "target-2"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}\\"
+        "service_role_arn": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.arn}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testCodeDeploy_ecs_code_deploy_role_EF679F94\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}\\",
-        \\"name\\": \\"Test-Dev-ECSCodeDeployRole\\"
+    "aws_iam_role": {
+      "testCodeDeploy_ecs_code_deploy_role_EF679F94": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testCodeDeploy_codedeploy_assume_role_E9FEDA7F.json}",
+        "name": "Test-Dev-ECSCodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94\\"
+    "aws_iam_role_policy_attachment": {
+      "testCodeDeploy_ecs_codedeploy_role_attachment_0C2B6B97": {
+        "depends_on": [
+          "aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testCodeDeploy_ecs_code_deploy_role_EF679F94.name}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationECSCluster.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSCluster.spec.ts.snap
@@ -2,19 +2,19 @@
 
 exports[`ApplicationECSCluster renders an ECS cluster with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_ecs_cluster\\": {
-      \\"testECSCluster_ecs_cluster_E3A9AFE5\\": {
-        \\"name\\": \\"bowling-\\",
-        \\"setting\\": [
+  "resource": {
+    "aws_ecs_cluster": {
+      "testECSCluster_ecs_cluster_E3A9AFE5": {
+        "name": "bowling-",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ],
-        \\"tags\\": {
-          \\"description\\": \\"artist\\",
-          \\"name\\": \\"maude\\"
+        "tags": {
+          "description": "artist",
+          "name": "maude"
         }
       }
     }
@@ -24,14 +24,14 @@ exports[`ApplicationECSCluster renders an ECS cluster with tags 1`] = `
 
 exports[`ApplicationECSCluster renders an ECS cluster without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_ecs_cluster\\": {
-      \\"testECSCluster_ecs_cluster_E3A9AFE5\\": {
-        \\"name\\": \\"bowling-\\",
-        \\"setting\\": [
+  "resource": {
+    "aws_ecs_cluster": {
+      "testECSCluster_ecs_cluster_E3A9AFE5": {
+        "name": "bowling-",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }

--- a/src/base/__snapshots__/ApplicationECSIAM.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSIAM.spec.ts.snap
@@ -2,44 +2,44 @@
 
 exports[`ApplicationECSIAM renders ECS IAM with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-task-assume_E7A7BA71\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-task-assume_E7A7BA71": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-execution-role_46F1514F\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+  "resource": {
+    "aws_iam_role": {
+      "testECSService_ecs-execution-role_46F1514F": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-task-role_C04CE6DA\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-task-role_C04CE6DA": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-task-execution-default-attachment_9FDF40D5\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-execution-role_46F1514F.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-task-execution-default-attachment_9FDF40D5": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-execution-role_46F1514F.id}"
       }
     }
   }
@@ -48,52 +48,52 @@ exports[`ApplicationECSIAM renders ECS IAM with minimal config 1`] = `
 
 exports[`ApplicationECSIAM renders ECS IAM with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-task-assume_E7A7BA71\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-task-assume_E7A7BA71": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-execution-role_46F1514F\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\",
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+  "resource": {
+    "aws_iam_role": {
+      "testECSService_ecs-execution-role_46F1514F": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}",
+        "name": "abides-dev-TaskExecutionRole",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         }
       },
-      \\"testECSService_ecs-task-role_C04CE6DA\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\",
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+      "testECSService_ecs-task-role_C04CE6DA": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-task-assume_E7A7BA71.json}",
+        "name": "abides-dev-TaskRole",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-task-execution-default-attachment_9FDF40D5\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-execution-role_46F1514F.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-task-execution-default-attachment_9FDF40D5": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-execution-role_46F1514F.id}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationECSService.spec.ts.snap
@@ -2,226 +2,226 @@
 
 exports[`ApplicationECSService attaches persistent (efs) storage to a ECS task 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"testECSService_ecs-lebowski_226D2007\\": {
-        \\"name_prefix\\": \\"/ecs/abides-dev/lebowski\\",
-        \\"retention_in_days\\": 30
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "testECSService_ecs-lebowski_226D2007": {
+        "name_prefix": "/ecs/abides-dev/lebowski",
+        "retention_in_days": 30
       }
     },
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testECSService_ecr-lebowski_ecr-repo-lifecyclepolicy_19C9732F\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86\\"
+    "aws_ecr_lifecycle_policy": {
+      "testECSService_ecr-lebowski_ecr-repo-lifecyclepolicy_19C9732F": {
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testECSService_ecr-lebowski_ecr-repo_6D07DF86\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testECSService_ecr-lebowski_ecr-repo_6D07DF86": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"abides-dev-lebowski\\"
+        "name": "abides-dev-lebowski"
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86\\"
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testECSService_ecs-lebowski_226D2007.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[{\\\\\\"containerPath\\\\\\":\\\\\\"/someMountPoint\\\\\\",\\\\\\"sourceVolume\\\\\\":\\\\\\"sourceVolume\\\\\\"}],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"lebowski\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86\\"
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testECSService_ecs-lebowski_226D2007.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[{\\"containerPath\\":\\"/someMountPoint\\",\\"sourceVolume\\":\\"sourceVolume\\"}],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"lebowski\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
           {
-            \\"efs_volume_configuration\\": {
-              \\"file_system_id\\": \\"someId\\"
+            "efs_volume_configuration": {
+              "file_system_id": "someId"
             },
-            \\"name\\": \\"sourceVolume\\"
+            "name": "sourceVolume"
           }
         ]
       }
     },
-    \\"aws_efs_file_system_policy\\": {
-      \\"testECSService_efsFsPolicy_AAD586DA\\": {
-        \\"depends_on\\": [
-          \\"time_sleep.testECSService_waitTwoMinutes_F8D60FA5\\"
+    "aws_efs_file_system_policy": {
+      "testECSService_efsFsPolicy_AAD586DA": {
+        "depends_on": [
+          "time_sleep.testECSService_waitTwoMinutes_F8D60FA5"
         ],
-        \\"file_system_id\\": \\"someId\\",
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Id\\\\\\":\\\\\\"abides-dev\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Sid\\\\\\":\\\\\\"abides-dev\\\\\\",\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"AWS\\\\\\":\\\\\\"*\\\\\\"},\\\\\\"Resource\\\\\\":\\\\\\"fakeArn\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"elasticfilesystem:ClientMount\\\\\\",\\\\\\"elasticfilesystem:ClientWrite\\\\\\",\\\\\\"elasticfilesystem:ClientRootAccess\\\\\\"],\\\\\\"Condition\\\\\\":{\\\\\\"Bool\\\\\\":{\\\\\\"elasticfilesystem:AccessedViaMountTarget\\\\\\":\\\\\\"true\\\\\\"}}}]}\\"
+        "file_system_id": "someId",
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Id\\":\\"abides-dev\\",\\"Statement\\":[{\\"Sid\\":\\"abides-dev\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"fakeArn\\",\\"Action\\":[\\"elasticfilesystem:ClientMount\\",\\"elasticfilesystem:ClientWrite\\",\\"elasticfilesystem:ClientRootAccess\\"],\\"Condition\\":{\\"Bool\\":{\\"elasticfilesystem:AccessedViaMountTarget\\":\\"true\\"}}}]}"
       }
     },
-    \\"aws_efs_mount_target\\": {
-      \\"testECSService_efs_mount_target_C9F488D3\\": {
-        \\"file_system_id\\": \\"someId\\",
-        \\"for_each\\": \\"\${toset([\\\\\\"1.1.1.1\\\\\\", \\\\\\"2.2.2.2\\\\\\"])}\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testECSService_efs_mount_sg_BE274D85.id}\\"
+    "aws_efs_mount_target": {
+      "testECSService_efs_mount_target_C9F488D3": {
+        "file_system_id": "someId",
+        "for_each": "\${toset([\\"1.1.1.1\\", \\"2.2.2.2\\"])}",
+        "security_groups": [
+          "\${aws_security_group.testECSService_efs_mount_sg_BE274D85.id}"
         ],
-        \\"subnet_id\\": \\"\${each.value}\\"
+        "subnet_id": "\${each.value}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       },
-      \\"testECSService_efs_mount_sg_BE274D85\\": {
-        \\"description\\": \\"ECS EFS Mount (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testECSService_efs_mount_sg_BE274D85": {
+        "description": "ECS EFS Mount (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 2049,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 2049
+            "self": null,
+            "to_port": 2049
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSMountPoint\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSMountPoint",
+        "vpc_id": "myhouse"
       }
     },
-    \\"time_sleep\\": {
-      \\"testECSService_waitTwoMinutes_F8D60FA5\\": {
-        \\"create_duration\\": \\"2m\\",
-        \\"depends_on\\": [
+    "time_sleep": {
+      "testECSService_waitTwoMinutes_F8D60FA5": {
+        "create_duration": "2m",
+        "depends_on": [
         ]
       }
     }
@@ -231,127 +231,127 @@ exports[`ApplicationECSService attaches persistent (efs) storage to a ECS task 1
 
 exports[`ApplicationECSService renders an ECS service with code deploy 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
+  "resource": {
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
+        "deployment_controller": {
+          "type": "CODE_DEPLOY"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer",
+            "task_definition"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -360,127 +360,127 @@ exports[`ApplicationECSService renders an ECS service with code deploy 1`] = `
 
 exports[`ApplicationECSService renders an ECS service with code deploy and excludes the code deployment command resource when useCodePipeline is true 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
+  "resource": {
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
+        "deployment_controller": {
+          "type": "CODE_DEPLOY"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer",
+            "task_definition"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -489,127 +489,127 @@ exports[`ApplicationECSService renders an ECS service with code deploy and exclu
 
 exports[`ApplicationECSService renders an ECS service with code deploy notifications set for failed only 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
+  "resource": {
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
+        "deployment_controller": {
+          "type": "CODE_DEPLOY"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer",
+            "task_definition"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -618,127 +618,127 @@ exports[`ApplicationECSService renders an ECS service with code deploy notificat
 
 exports[`ApplicationECSService renders an ECS service with full container definition props 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
+  "resource": {
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 400,
-        \\"deployment_minimum_healthy_percent\\": 80,
-        \\"desired_count\\": 4,
-        \\"launch_type\\": \\"ROCKET\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"bowling\\",
-            \\"donnie\\",
-            \\"autobahn\\"
+        "deployment_maximum_percent": 400,
+        "deployment_minimum_healthy_percent": 80,
+        "desired_count": 4,
+        "launch_type": "ROCKET",
+        "lifecycle": {
+          "ignore_changes": [
+            "bowling",
+            "donnie",
+            "autobahn"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"test/log/group\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[{\\\\\\"containerPort\\\\\\":3002,\\\\\\"hostPort\\\\\\":3001}],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"rug\\\\\\",\\\\\\"value\\\\\\":\\\\\\"tiedtheroomtogether\\\\\\"}],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":{\\\\\\"credentialsParameter\\\\\\":\\\\\\"someArn\\\\\\"},\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"donnie\\\\\\",\\\\\\"valueFrom\\\\\\":\\\\\\"throwinrockstonight\\\\\\"}],\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"beverage-here/0.1\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"lebowski\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"test/log/group\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"containerPort\\":3002,\\"hostPort\\":3001}],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[{\\"name\\":\\"rug\\",\\"value\\":\\"tiedtheroomtogether\\"}],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":{\\"credentialsParameter\\":\\"someArn\\"},\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":[{\\"name\\":\\"donnie\\",\\"valueFrom\\":\\"throwinrockstonight\\"}],\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"beverage-here/0.1\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"lebowski\\"}]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -747,195 +747,195 @@ exports[`ApplicationECSService renders an ECS service with full container defini
 
 exports[`ApplicationECSService renders an ECS service with full container definition props and ALB security group config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_alb_listener_rule\\": {
-      \\"testECSService_listener_rule_A3A4BB9D\\": {
-        \\"action\\": [
+  "resource": {
+    "aws_alb_listener_rule": {
+      "testECSService_listener_rule_A3A4BB9D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testECSService_blue_target_group_ecs_target_group_AB8F309D.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testECSService_blue_target_group_ecs_target_group_AB8F309D.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"listen-to-me\\",
-        \\"priority\\": 1
+        "listener_arn": "listen-to-me",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testECSService_blue_target_group_ecs_target_group_AB8F309D\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/health\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testECSService_blue_target_group_ecs_target_group_AB8F309D": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/health",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"shortb\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "shortb",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "target_type": "ip",
+        "vpc_id": "myhouse"
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testECSService_blue_target_group_ecs_target_group_AB8F309D\\",
-          \\"aws_alb_listener_rule.testECSService_listener_rule_A3A4BB9D\\"
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
+          "aws_alb_target_group.testECSService_blue_target_group_ecs_target_group_AB8F309D",
+          "aws_alb_listener_rule.testECSService_listener_rule_A3A4BB9D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"runme\\",
-            \\"container_port\\": 3000,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testECSService_blue_target_group_ecs_target_group_AB8F309D.arn}\\"
+            "container_name": "runme",
+            "container_port": 3000,
+            "target_group_arn": "\${aws_alb_target_group.testECSService_blue_target_group_ecs_target_group_AB8F309D.arn}"
           }
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"test/log/group\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[{\\\\\\"containerPort\\\\\\":3002,\\\\\\"hostPort\\\\\\":3001}],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"rug\\\\\\",\\\\\\"value\\\\\\":\\\\\\"tiedtheroomtogether\\\\\\"}],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":{\\\\\\"credentialsParameter\\\\\\":\\\\\\"someArn\\\\\\"},\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"donnie\\\\\\",\\\\\\"valueFrom\\\\\\":\\\\\\"throwinrockstonight\\\\\\"}],\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"beverage-here/0.1\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"lebowski\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"test/log/group\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"containerPort\\":3002,\\"hostPort\\":3001}],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[{\\"name\\":\\"rug\\",\\"value\\":\\"tiedtheroomtogether\\"}],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":{\\"credentialsParameter\\":\\"someArn\\"},\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":[{\\"name\\":\\"donnie\\",\\"valueFrom\\":\\"throwinrockstonight\\"}],\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"beverage-here/0.1\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"lebowski\\"}]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"strike\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "strike"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 3000
+            "self": null,
+            "to_port": 3000
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -944,126 +944,126 @@ exports[`ApplicationECSService renders an ECS service with full container defini
 
 exports[`ApplicationECSService renders an ECS service with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
+  "resource": {
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -1072,198 +1072,198 @@ exports[`ApplicationECSService renders an ECS service with minimal config 1`] = 
 
 exports[`ApplicationECSService renders an ECS service with mountPoints deduplicated in the task definition 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"testECSService_ecs-container1_FA0D3F88\\": {
-        \\"name_prefix\\": \\"/ecs/abides-dev/container1\\",
-        \\"retention_in_days\\": 30
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "testECSService_ecs-container1_FA0D3F88": {
+        "name_prefix": "/ecs/abides-dev/container1",
+        "retention_in_days": 30
       },
-      \\"testECSService_ecs-container2_E4AB2284\\": {
-        \\"name_prefix\\": \\"/ecs/abides-dev/container2\\",
-        \\"retention_in_days\\": 30
+      "testECSService_ecs-container2_E4AB2284": {
+        "name_prefix": "/ecs/abides-dev/container2",
+        "retention_in_days": 30
       },
-      \\"testECSService_ecs-container3_1286AAA3\\": {
-        \\"name_prefix\\": \\"/ecs/abides-dev/container3\\",
-        \\"retention_in_days\\": 30
+      "testECSService_ecs-container3_1286AAA3": {
+        "name_prefix": "/ecs/abides-dev/container3",
+        "retention_in_days": 30
       }
     },
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testECSService_ecr-container1_ecr-repo-lifecyclepolicy_FAA9164A\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E\\"
+    "aws_ecr_lifecycle_policy": {
+      "testECSService_ecr-container1_ecr-repo-lifecyclepolicy_FAA9164A": {
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E.name}"
       },
-      \\"testECSService_ecr-container2_ecr-repo-lifecyclepolicy_326A08A8\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0\\"
+      "testECSService_ecr-container2_ecr-repo-lifecyclepolicy_326A08A8": {
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0.name}"
       },
-      \\"testECSService_ecr-container3_ecr-repo-lifecyclepolicy_C3FDC63F\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD\\"
+      "testECSService_ecr-container3_ecr-repo-lifecyclepolicy_C3FDC63F": {
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testECSService_ecr-container1_ecr-repo_6BB90A2E\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testECSService_ecr-container1_ecr-repo_6BB90A2E": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"abides-dev-container1\\"
+        "name": "abides-dev-container1"
       },
-      \\"testECSService_ecr-container2_ecr-repo_6980E3F0\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+      "testECSService_ecr-container2_ecr-repo_6980E3F0": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"abides-dev-container2\\"
+        "name": "abides-dev-container2"
       },
-      \\"testECSService_ecr-container3_ecr-repo_F25059FD\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+      "testECSService_ecr-container3_ecr-repo_F25059FD": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"abides-dev-container3\\"
+        "name": "abides-dev-container3"
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E\\",
-          \\"aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0\\",
-          \\"aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD\\"
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E",
+          "aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0",
+          "aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"ROCKET\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "ROCKET",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testECSService_ecs-container1_FA0D3F88.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"container1\\\\\\"},{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testECSService_ecs-container2_E4AB2284.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[{\\\\\\"sourceVolume\\\\\\":\\\\\\"src1\\\\\\",\\\\\\"containerPath\\\\\\":\\\\\\"/src1\\\\\\"},{\\\\\\"sourceVolume\\\\\\":\\\\\\"src2\\\\\\",\\\\\\"containerPath\\\\\\":\\\\\\"/src2\\\\\\"}],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"container2\\\\\\"},{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testECSService_ecs-container3_1286AAA3.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[{\\\\\\"sourceVolume\\\\\\":\\\\\\"src1\\\\\\",\\\\\\"containerPath\\\\\\":\\\\\\"/src1\\\\\\",\\\\\\"readOnly\\\\\\":true},{\\\\\\"sourceVolume\\\\\\":\\\\\\"src3\\\\\\",\\\\\\"containerPath\\\\\\":\\\\\\"/src3\\\\\\"}],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"container3\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E\\",
-          \\"aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0\\",
-          \\"aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD\\"
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testECSService_ecs-container1_FA0D3F88.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"container1\\"},{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testECSService_ecs-container2_E4AB2284.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[{\\"sourceVolume\\":\\"src1\\",\\"containerPath\\":\\"/src1\\"},{\\"sourceVolume\\":\\"src2\\",\\"containerPath\\":\\"/src2\\"}],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"container2\\"},{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testECSService_ecs-container3_1286AAA3.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[{\\"sourceVolume\\":\\"src1\\",\\"containerPath\\":\\"/src1\\",\\"readOnly\\":true},{\\"sourceVolume\\":\\"src3\\",\\"containerPath\\":\\"/src3\\"}],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"container3\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-container1_ecr-repo_6BB90A2E",
+          "aws_ecr_repository.testECSService_ecr-container2_ecr-repo_6980E3F0",
+          "aws_ecr_repository.testECSService_ecr-container3_ecr-repo_F25059FD"
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
           {
-            \\"name\\": \\"src1\\"
+            "name": "src1"
           },
           {
-            \\"name\\": \\"src2\\"
+            "name": "src2"
           },
           {
-            \\"name\\": \\"src3\\"
+            "name": "src3"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -1272,133 +1272,133 @@ exports[`ApplicationECSService renders an ECS service with mountPoints deduplica
 
 exports[`ApplicationECSService renders an ECS service without a log group container definition props 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"testECSService_ecs-lebowski_226D2007\\": {
-        \\"name_prefix\\": \\"/ecs/abides-dev/lebowski\\",
-        \\"retention_in_days\\": 30
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "testECSService_ecs-lebowski_226D2007": {
+        "name_prefix": "/ecs/abides-dev/lebowski",
+        "retention_in_days": 30
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 400,
-        \\"deployment_minimum_healthy_percent\\": 80,
-        \\"desired_count\\": 4,
-        \\"launch_type\\": \\"ROCKET\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"bowling\\",
-            \\"donnie\\",
-            \\"autobahn\\"
+        "deployment_maximum_percent": 400,
+        "deployment_minimum_healthy_percent": 80,
+        "desired_count": 4,
+        "launch_type": "ROCKET",
+        "lifecycle": {
+          "ignore_changes": [
+            "bowling",
+            "donnie",
+            "autobahn"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testECSService_ecs-lebowski_226D2007.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[{\\\\\\"containerPort\\\\\\":3002,\\\\\\"hostPort\\\\\\":3001}],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"rug\\\\\\",\\\\\\"value\\\\\\":\\\\\\"tiedtheroomtogether\\\\\\"}],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":{\\\\\\"credentialsParameter\\\\\\":\\\\\\"someArn\\\\\\"},\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"donnie\\\\\\",\\\\\\"valueFrom\\\\\\":\\\\\\"throwinrockstonight\\\\\\"}],\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"beverage-here/0.1\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"lebowski\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testECSService_ecs-lebowski_226D2007.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"containerPort\\":3002,\\"hostPort\\":3001}],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[{\\"name\\":\\"rug\\",\\"value\\":\\"tiedtheroomtogether\\"}],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":{\\"credentialsParameter\\":\\"someArn\\"},\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":[{\\"name\\":\\"donnie\\",\\"valueFrom\\":\\"throwinrockstonight\\"}],\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"beverage-here/0.1\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"lebowski\\"}]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }
@@ -1407,146 +1407,146 @@ exports[`ApplicationECSService renders an ECS service without a log group contai
 
 exports[`ApplicationECSService renders an ECS service without an image container definition props 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"testECSService_ecs-iam_ecs-task-assume_97906D9E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "testECSService_ecs-iam_ecs-task-assume_97906D9E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testECSService_ecr-lebowski_ecr-repo-lifecyclepolicy_19C9732F\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86\\"
+  "resource": {
+    "aws_ecr_lifecycle_policy": {
+      "testECSService_ecr-lebowski_ecr-repo-lifecyclepolicy_19C9732F": {
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testECSService_ecr-lebowski_ecr-repo_6D07DF86\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testECSService_ecr-lebowski_ecr-repo_6D07DF86": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"abides-dev-lebowski\\"
+        "name": "abides-dev-lebowski"
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testECSService_ecs-service_33F309B3\\": {
-        \\"cluster\\": \\"gorp\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86\\"
+    "aws_ecs_service": {
+      "testECSService_ecs-service_33F309B3": {
+        "cluster": "gorp",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 400,
-        \\"deployment_minimum_healthy_percent\\": 80,
-        \\"desired_count\\": 4,
-        \\"launch_type\\": \\"ROCKET\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"bowling\\",
-            \\"donnie\\",
-            \\"autobahn\\"
+        "deployment_maximum_percent": 400,
+        "deployment_minimum_healthy_percent": 80,
+        "desired_count": 4,
+        "launch_type": "ROCKET",
+        "lifecycle": {
+          "ignore_changes": [
+            "bowling",
+            "donnie",
+            "autobahn"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"abides-dev\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testECSService_ecs_security_group_67979722.id}\\"
+        "name": "abides-dev",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testECSService_ecs_security_group_67979722.id}"
           ],
-          \\"subnets\\": [
-            \\"1.1.1.1\\",
-            \\"2.2.2.2\\"
+          "subnets": [
+            "1.1.1.1",
+            "2.2.2.2"
           ]
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testECSService_ecs-task_A268C927.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testECSService_ecs-task_A268C927\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"test/log/group\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[{\\\\\\"containerPort\\\\\\":3002,\\\\\\"hostPort\\\\\\":3001}],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"rug\\\\\\",\\\\\\"value\\\\\\":\\\\\\"tiedtheroomtogether\\\\\\"}],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":{\\\\\\"credentialsParameter\\\\\\":\\\\\\"someArn\\\\\\"},\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":[{\\\\\\"name\\\\\\":\\\\\\"donnie\\\\\\",\\\\\\"valueFrom\\\\\\":\\\\\\"throwinrockstonight\\\\\\"}],\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"lebowski\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86\\"
+    "aws_ecs_task_definition": {
+      "testECSService_ecs-task_A268C927": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"test/log/group\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"containerPort\\":3002,\\"hostPort\\":3001}],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[{\\"name\\":\\"rug\\",\\"value\\":\\"tiedtheroomtogether\\"}],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":{\\"credentialsParameter\\":\\"someArn\\"},\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":[{\\"name\\":\\"donnie\\",\\"valueFrom\\":\\"throwinrockstonight\\"}],\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"lebowski\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testECSService_ecr-lebowski_ecr-repo_6D07DF86"
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}\\",
-        \\"family\\": \\"abides-dev\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.arn}",
+        "family": "abides-dev",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testECSService_ecs-iam_ecs-task-role_83E10144.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testECSService_ecs-iam_ecs-execution-role_88EFEECE\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testECSService_ecs-iam_ecs-execution-role_88EFEECE": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskExecutionRole"
       },
-      \\"testECSService_ecs-iam_ecs-task-role_83E10144\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}\\",
-        \\"name\\": \\"abides-dev-TaskRole\\"
+      "testECSService_ecs-iam_ecs-task-role_83E10144": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testECSService_ecs-iam_ecs-task-assume_97906D9E.json}",
+        "name": "abides-dev-TaskRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7\\": {
-        \\"policy_arn\\": \\"someArn\\",
-        \\"role\\": \\"\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "testECSService_ecs-iam_ecs-task-execution-default-attachment_7AC36BF7": {
+        "policy_arn": "someArn",
+        "role": "\${aws_iam_role.testECSService_ecs-iam_ecs-execution-role_88EFEECE.id}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testECSService_ecs_security_group_67979722\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testECSService_ecs_security_group_67979722": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"abides-dev-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"myhouse\\"
+        "name_prefix": "abides-dev-ECSSecurityGroup",
+        "vpc_id": "myhouse"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationEventBridgeRule.spec.ts.snap
@@ -2,15 +2,15 @@
 
 exports[`AplicationEventBridgeRule renders an event bridge with description 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"description\\": \\"Test description\\",
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "description": "Test description",
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\"
+        "name": "Test-EventBridge-Rule"
       }
     }
   }
@@ -19,14 +19,14 @@ exports[`AplicationEventBridgeRule renders an event bridge with description 1`] 
 
 exports[`AplicationEventBridgeRule renders an event bridge with event bus name 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"event_bus_name\\": \\"test-bus\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "event_bus_name": "test-bus",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\"
+        "name": "Test-EventBridge-Rule"
       }
     }
   }
@@ -35,29 +35,29 @@ exports[`AplicationEventBridgeRule renders an event bridge with event bus name 1
 
 exports[`AplicationEventBridgeRule renders an event bridge with pre-existing sqs target 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\"
+        "name": "Test-EventBridge-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-rule_event-bridge-target-sqs_E09C359A\\": {
-        \\"arn\\": \\"\${aws_sqs_queue.test-queue.arn}\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-rule_event-bridge-target-sqs_E09C359A": {
+        "arn": "\${aws_sqs_queue.test-queue.arn}",
+        "dead_letter_config": {
         },
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87.name}\\",
-        \\"target_id\\": \\"sqs\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87.name}",
+        "target_id": "sqs"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"test-queue\\": {
-        \\"name\\": \\"Test-SQS-Queue\\"
+    "aws_sqs_queue": {
+      "test-queue": {
+        "name": "Test-SQS-Queue"
       }
     }
   }
@@ -66,14 +66,14 @@ exports[`AplicationEventBridgeRule renders an event bridge with pre-existing sqs
 
 exports[`AplicationEventBridgeRule renders an event bridge with scheduleExpression 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"event_bus_name\\": \\"default\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "event_bus_name": "default",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\",
-        \\"schedule_expression\\": \\"rate(1 minute)\\"
+        "name": "Test-EventBridge-Rule",
+        "schedule_expression": "rate(1 minute)"
       }
     }
   }
@@ -82,33 +82,33 @@ exports[`AplicationEventBridgeRule renders an event bridge with scheduleExpressi
 
 exports[`AplicationEventBridgeRule renders an event bridge with sqs target 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\"
+        "name": "Test-EventBridge-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-rule_event-bridge-target-sqs_E09C359A\\": {
-        \\"arn\\": \\"\${aws_sqs_queue.test-queue.arn}\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-rule_event-bridge-target-sqs_E09C359A": {
+        "arn": "\${aws_sqs_queue.test-queue.arn}",
+        "dead_letter_config": {
         },
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.test-queue\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87\\"
+        "depends_on": [
+          "aws_sqs_queue.test-queue",
+          "aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87"
         ],
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87.name}\\",
-        \\"target_id\\": \\"sqs\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-rule_DA4F2E87.name}",
+        "target_id": "sqs"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"test-queue\\": {
-        \\"name\\": \\"Test-SQS-Queue\\"
+    "aws_sqs_queue": {
+      "test-queue": {
+        "name": "Test-SQS-Queue"
       }
     }
   }
@@ -117,17 +117,17 @@ exports[`AplicationEventBridgeRule renders an event bridge with sqs target 1`] =
 
 exports[`AplicationEventBridgeRule renders an event bridge with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tag\\"
+        "name": "Test-EventBridge-Rule",
+        "tags": {
+          "for": "test",
+          "my": "tag"
         }
       }
     }
@@ -137,14 +137,14 @@ exports[`AplicationEventBridgeRule renders an event bridge with tags 1`] = `
 
 exports[`AplicationEventBridgeRule renders an event bridge without a target 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-rule_DA4F2E87\\": {
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-rule_DA4F2E87": {
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"Test-EventBridge-Rule\\"
+        "name": "Test-EventBridge-Rule"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationEventBus.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationEventBus.spec.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`ApplicationEventBus renders an event bus with name and target 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_bus\\": {
-      \\"test-event-bus_event-bus-test-event-bus_3B38546A\\": {
-        \\"name\\": \\"test-event-bus\\",
-        \\"tags\\": {
-          \\"service\\": \\"test-service\\"
+  "resource": {
+    "aws_cloudwatch_event_bus": {
+      "test-event-bus_event-bus-test-event-bus_3B38546A": {
+        "name": "test-event-bus",
+        "tags": {
+          "service": "test-service"
         }
       }
     }

--- a/src/base/__snapshots__/ApplicationLambdaCodeDeploy.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLambdaCodeDeploy.spec.ts.snap
@@ -2,21 +2,21 @@
 
 exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -24,47 +24,47 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app 1`] = `
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
+        "compute_platform": "Lambda",
+        "name": "Test-Lambda-Code-Deploy-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda-code-deploy_code-deployment-group_3F73EBCE": {
+        "app_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+    "aws_iam_role": {
+      "test-lambda-code-deploy_code-deploy-role_9DA8B07C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}",
+        "name": "Test-Lambda-Code-Deploy-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0": {
+        "depends_on": [
+          "aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}"
       }
     }
   }
@@ -73,21 +73,21 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app 1`] = `
 
 exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with all notifications enabled 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -95,64 +95,64 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with all n
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
+        "compute_platform": "Lambda",
+        "name": "Test-Lambda-Code-Deploy-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda-code-deploy_code-deployment-group_3F73EBCE": {
+        "app_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\",
-          \\"codedeploy-application-deployment-succeeded\\",
-          \\"codedeploy-application-deployment-started\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda-code-deploy_notifications_7F614EE2": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed",
+          "codedeploy-application-deployment-succeeded",
+          "codedeploy-application-deployment-started"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "target": [
           {
-            \\"address\\": \\"test:deploy-topic:arn\\"
+            "address": "test:deploy-topic:arn"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+    "aws_iam_role": {
+      "test-lambda-code-deploy_code-deploy-role_9DA8B07C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}",
+        "name": "Test-Lambda-Code-Deploy-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0": {
+        "depends_on": [
+          "aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}"
       }
     }
   }
@@ -161,21 +161,21 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with all n
 
 exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with default notifications 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -183,62 +183,62 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with defau
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
+        "compute_platform": "Lambda",
+        "name": "Test-Lambda-Code-Deploy-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda-code-deploy_code-deployment-group_3F73EBCE": {
+        "app_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda-code-deploy_notifications_7F614EE2": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "target": [
           {
-            \\"address\\": \\"test:deploy-topic:arn\\"
+            "address": "test:deploy-topic:arn"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+    "aws_iam_role": {
+      "test-lambda-code-deploy_code-deploy-role_9DA8B07C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}",
+        "name": "Test-Lambda-Code-Deploy-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0": {
+        "depends_on": [
+          "aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}"
       }
     }
   }
@@ -247,21 +247,21 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with defau
 
 exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns topic arn 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -269,62 +269,62 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
+        "compute_platform": "Lambda",
+        "name": "Test-Lambda-Code-Deploy-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda-code-deploy_code-deployment-group_3F73EBCE": {
+        "app_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda-code-deploy_notifications_7F614EE2": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "target": [
           {
-            \\"address\\": \\"test:deploy-topic:arn\\"
+            "address": "test:deploy-topic:arn"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+    "aws_iam_role": {
+      "test-lambda-code-deploy_code-deploy-role_9DA8B07C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}",
+        "name": "Test-Lambda-Code-Deploy-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0": {
+        "depends_on": [
+          "aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}"
       }
     }
   }
@@ -333,21 +333,21 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
 
 exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns topic arn and detail type 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -355,62 +355,62 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
+        "compute_platform": "Lambda",
+        "name": "Test-Lambda-Code-Deploy-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda-code-deploy_code-deployment-group_3F73EBCE": {
+        "app_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
-        \\"detail_type\\": \\"FULL\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda-code-deploy_notifications_7F614EE2": {
+        "detail_type": "FULL",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "target": [
           {
-            \\"address\\": \\"test:deploy-topic:arn\\"
+            "address": "test:deploy-topic:arn"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+    "aws_iam_role": {
+      "test-lambda-code-deploy_code-deploy-role_9DA8B07C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}",
+        "name": "Test-Lambda-Code-Deploy-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0": {
+        "depends_on": [
+          "aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}"
       }
     }
   }
@@ -419,21 +419,21 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with sns t
 
 exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with started and succeeded notifications only 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -441,63 +441,63 @@ exports[`ApplicationLambdaCodeDeploy renders a lambda code deploy app with start
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda-code-deploy_code-deploy-app_A7640CFE\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-Lambda\\"
+  "resource": {
+    "aws_codedeploy_app": {
+      "test-lambda-code-deploy_code-deploy-app_A7640CFE": {
+        "compute_platform": "Lambda",
+        "name": "Test-Lambda-Code-Deploy-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda-code-deploy_code-deployment-group_3F73EBCE\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda-code-deploy_code-deployment-group_3F73EBCE": {
+        "app_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda-code-deploy_notifications_7F614EE2\\": {
-        \\"detail_type\\": \\"BASIC\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-succeeded\\",
-          \\"codedeploy-application-deployment-started\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda-code-deploy_notifications_7F614EE2": {
+        "detail_type": "BASIC",
+        "event_type_ids": [
+          "codedeploy-application-deployment-succeeded",
+          "codedeploy-application-deployment-started"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:123:application:\${aws_codedeploy_app.test-lambda-code-deploy_code-deploy-app_A7640CFE.name}",
+        "target": [
           {
-            \\"address\\": \\"test:deploy-topic:arn\\"
+            "address": "test:deploy-topic:arn"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda-code-deploy_code-deploy-role_9DA8B07C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}\\",
-        \\"name\\": \\"Test-Lambda-Code-Deploy-CodeDeployRole\\"
+    "aws_iam_role": {
+      "test-lambda-code-deploy_code-deploy-role_9DA8B07C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda-code-deploy_code-deploy-assume-role-policy-document_484EBB89.json}",
+        "name": "Test-Lambda-Code-Deploy-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda-code-deploy_code-deploy-policy-attachment_84E423E0": {
+        "depends_on": [
+          "aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda-code-deploy_code-deploy-role_9DA8B07C.name}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationLambdaSnsTopicSubscription.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLambdaSnsTopicSubscription.spec.ts.snap
@@ -2,77 +2,77 @@
 
 exports[`ApplicationSqsSnsTopicSubscription renders an Lambda <> SNS subscription without tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"lambda-sns-subscription_sns-dlq-policy-document_8DAB362F\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199\\"
+  "data": {
+    "aws_iam_policy_document": {
+      "lambda-sns-subscription_sns-dlq-policy-document_8DAB362F": {
+        "depends_on": [
+          "aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}"
             ]
           }
         ]
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"lambda\\": {
-        \\"function_name\\": \\"test-lambda\\"
+    "aws_lambda_function": {
+      "lambda": {
+        "function_name": "test-lambda"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_lambda_permission\\": {
-      \\"lambda-sns-subscription_lambda-sns-subscription-lambda-permission_03B5A953\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${data.aws_lambda_function.lambda.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"arn:aws:sns:TopicName\\"
+  "resource": {
+    "aws_lambda_permission": {
+      "lambda-sns-subscription_lambda-sns-subscription-lambda-permission_03B5A953": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${data.aws_lambda_function.lambda.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"lambda-sns-subscription_1ED18AE9\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199\\"
+    "aws_sns_topic_subscription": {
+      "lambda-sns-subscription_1ED18AE9": {
+        "depends_on": [
+          "aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199"
         ],
-        \\"endpoint\\": \\"\${data.aws_lambda_function.lambda.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"redrive_policy\\": \\"{\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}\\\\\\"}\\",
-        \\"topic_arn\\": \\"arn:aws:sns:TopicName\\"
+        "endpoint": "\${data.aws_lambda_function.lambda.arn}",
+        "protocol": "lambda",
+        "redrive_policy": "{\\"deadLetterTargetArn\\":\\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}\\"}",
+        "topic_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"lambda-sns-subscription_sns-topic-dlq_C5D5F199\\": {
-        \\"name\\": \\"test-sns-subscription-SNS-Topic-DLQ\\"
+    "aws_sqs_queue": {
+      "lambda-sns-subscription_sns-topic-dlq_C5D5F199": {
+        "name": "test-sns-subscription-SNS-Topic-DLQ"
       }
     },
-    \\"aws_sqs_queue_policy\\": {
-      \\"lambda-sns-subscription_sns-dlq-policy_31243636\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.lambda-sns-subscription_sns-dlq-policy-document_8DAB362F.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.url}\\"
+    "aws_sqs_queue_policy": {
+      "lambda-sns-subscription_sns-dlq-policy_31243636": {
+        "policy": "\${data.aws_iam_policy_document.lambda-sns-subscription_sns-dlq-policy-document_8DAB362F.json}",
+        "queue_url": "\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.url}"
       }
     }
   }
@@ -81,80 +81,80 @@ exports[`ApplicationSqsSnsTopicSubscription renders an Lambda <> SNS subscriptio
 
 exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"lambda-sns-subscription_sns-dlq-policy-document_8DAB362F\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199\\"
+  "data": {
+    "aws_iam_policy_document": {
+      "lambda-sns-subscription_sns-dlq-policy-document_8DAB362F": {
+        "depends_on": [
+          "aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}"
             ]
           }
         ]
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"lambda\\": {
-        \\"function_name\\": \\"test-lambda\\"
+    "aws_lambda_function": {
+      "lambda": {
+        "function_name": "test-lambda"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_lambda_permission\\": {
-      \\"lambda-sns-subscription_lambda-sns-subscription-lambda-permission_03B5A953\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${data.aws_lambda_function.lambda.function_name}\\",
-        \\"principal\\": \\"sns.amazonaws.com\\",
-        \\"source_arn\\": \\"arn:aws:sns:TopicName\\"
+  "resource": {
+    "aws_lambda_permission": {
+      "lambda-sns-subscription_lambda-sns-subscription-lambda-permission_03B5A953": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${data.aws_lambda_function.lambda.function_name}",
+        "principal": "sns.amazonaws.com",
+        "source_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"lambda-sns-subscription_1ED18AE9\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199\\"
+    "aws_sns_topic_subscription": {
+      "lambda-sns-subscription_1ED18AE9": {
+        "depends_on": [
+          "aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199"
         ],
-        \\"endpoint\\": \\"\${data.aws_lambda_function.lambda.arn}\\",
-        \\"protocol\\": \\"lambda\\",
-        \\"redrive_policy\\": \\"{\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}\\\\\\"}\\",
-        \\"topic_arn\\": \\"arn:aws:sns:TopicName\\"
+        "endpoint": "\${data.aws_lambda_function.lambda.arn}",
+        "protocol": "lambda",
+        "redrive_policy": "{\\"deadLetterTargetArn\\":\\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.arn}\\"}",
+        "topic_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"lambda-sns-subscription_sns-topic-dlq_C5D5F199\\": {
-        \\"name\\": \\"test-sns-subscription-SNS-Topic-DLQ\\",
-        \\"tags\\": {
-          \\"hello\\": \\"there\\"
+    "aws_sqs_queue": {
+      "lambda-sns-subscription_sns-topic-dlq_C5D5F199": {
+        "name": "test-sns-subscription-SNS-Topic-DLQ",
+        "tags": {
+          "hello": "there"
         }
       }
     },
-    \\"aws_sqs_queue_policy\\": {
-      \\"lambda-sns-subscription_sns-dlq-policy_31243636\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.lambda-sns-subscription_sns-dlq-policy-document_8DAB362F.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.url}\\"
+    "aws_sqs_queue_policy": {
+      "lambda-sns-subscription_sns-dlq-policy_31243636": {
+        "policy": "\${data.aws_iam_policy_document.lambda-sns-subscription_sns-dlq-policy-document_8DAB362F.json}",
+        "queue_url": "\${aws_sqs_queue.lambda-sns-subscription_sns-topic-dlq_C5D5F199.url}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationLoadBalancer.spec.ts.snap
@@ -2,132 +2,132 @@
 
 exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_elb_service_account\\": {
-      \\"testALB_elb-service-account_4BDD06CE\\": {
+  "data": {
+    "aws_elb_service_account": {
+      "testALB_elb-service-account_4BDD06CE": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testALB_iam-log-bucket-policy-document_C7E41154\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testALB_iam-log-bucket-policy-document_C7E41154": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"arn:aws:iam::\${data.aws_elb_service_account.testALB_elb-service-account_4BDD06CE.id}:root\\"
+                "identifiers": [
+                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_elb-service-account_4BDD06CE.id}:root"
                 ],
-                \\"type\\": \\"AWS\\"
+                "type": "AWS"
               }
             ],
-            \\"resources\\": [
-              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/*\\"
+            "resources": [
+              "arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_alb\\": {
-      \\"testALB_alb_F6B33218\\": {
-        \\"access_logs\\": {
-          \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
-          \\"enabled\\": true,
-          \\"prefix\\": \\"server-logs/test-/alb\\"
+  "resource": {
+    "aws_alb": {
+      "testALB_alb_F6B33218": {
+        "access_logs": {
+          "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "enabled": true,
+          "prefix": "server-logs/test-/alb"
         },
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TEST\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        "internal": false,
+        "name_prefix": "TEST",
+        "security_groups": [
+          "\${aws_security_group.testALB_alb_security_group_57C45F23.id}"
         ],
-        \\"subnets\\": [
-          \\"a\\",
-          \\"b\\"
+        "subnets": [
+          "a",
+          "b"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"testALB_log-bucket_E9787BB1\\": {
-        \\"bucket\\": \\"logging-bucket\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_s3_bucket": {
+      "testALB_log-bucket_E9787BB1": {
+        "bucket": "logging-bucket",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_s3_bucket_policy\\": {
-      \\"testALB_log-bucket-policy_EB762FB5\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}\\"
+    "aws_s3_bucket_policy": {
+      "testALB_log-bucket-policy_EB762FB5": {
+        "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+        "policy": "\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testALB_alb_security_group_57C45F23\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testALB_alb_security_group_57C45F23": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"test--HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "test--HTTP/S Security Group",
+        "tags": {
+          "Name": "test--HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"123\\"
+        "vpc_id": "123"
       }
     }
   }
@@ -136,132 +136,132 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket 1`] 
 
 exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and prefix 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_elb_service_account\\": {
-      \\"testALB_elb-service-account_4BDD06CE\\": {
+  "data": {
+    "aws_elb_service_account": {
+      "testALB_elb-service-account_4BDD06CE": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testALB_iam-log-bucket-policy-document_C7E41154\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testALB_iam-log-bucket-policy-document_C7E41154": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"arn:aws:iam::\${data.aws_elb_service_account.testALB_elb-service-account_4BDD06CE.id}:root\\"
+                "identifiers": [
+                  "arn:aws:iam::\${data.aws_elb_service_account.testALB_elb-service-account_4BDD06CE.id}:root"
                 ],
-                \\"type\\": \\"AWS\\"
+                "type": "AWS"
               }
             ],
-            \\"resources\\": [
-              \\"arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/*\\"
+            "resources": [
+              "arn:aws:s3:::\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}/*"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_alb\\": {
-      \\"testALB_alb_F6B33218\\": {
-        \\"access_logs\\": {
-          \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
-          \\"enabled\\": true,
-          \\"prefix\\": \\"logs/ahoy/cool/service\\"
+  "resource": {
+    "aws_alb": {
+      "testALB_alb_F6B33218": {
+        "access_logs": {
+          "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "enabled": true,
+          "prefix": "logs/ahoy/cool/service"
         },
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TEST\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        "internal": false,
+        "name_prefix": "TEST",
+        "security_groups": [
+          "\${aws_security_group.testALB_alb_security_group_57C45F23.id}"
         ],
-        \\"subnets\\": [
-          \\"a\\",
-          \\"b\\"
+        "subnets": [
+          "a",
+          "b"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"testALB_log-bucket_E9787BB1\\": {
-        \\"bucket\\": \\"logging-bucket\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_s3_bucket": {
+      "testALB_log-bucket_E9787BB1": {
+        "bucket": "logging-bucket",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_s3_bucket_policy\\": {
-      \\"testALB_log-bucket-policy_EB762FB5\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}\\"
+    "aws_s3_bucket_policy": {
+      "testALB_log-bucket-policy_EB762FB5": {
+        "bucket": "\${aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+        "policy": "\${data.aws_iam_policy_document.testALB_iam-log-bucket-policy-document_C7E41154.json}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testALB_alb_security_group_57C45F23\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testALB_alb_security_group_57C45F23": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"test--HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "test--HTTP/S Security Group",
+        "tags": {
+          "Name": "test--HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"123\\"
+        "vpc_id": "123"
       }
     }
   }
@@ -270,95 +270,95 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with a new bucket and 
 
 exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucket 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_s3_bucket\\": {
-      \\"testALB_log-bucket_E9787BB1\\": {
-        \\"bucket\\": \\"logging-bucket\\"
+  "data": {
+    "aws_s3_bucket": {
+      "testALB_log-bucket_E9787BB1": {
+        "bucket": "logging-bucket"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_alb\\": {
-      \\"testALB_alb_F6B33218\\": {
-        \\"access_logs\\": {
-          \\"bucket\\": \\"\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
-          \\"enabled\\": true,
-          \\"prefix\\": \\"server-logs/test-/alb\\"
+  "resource": {
+    "aws_alb": {
+      "testALB_alb_F6B33218": {
+        "access_logs": {
+          "bucket": "\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "enabled": true,
+          "prefix": "server-logs/test-/alb"
         },
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TEST\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        "internal": false,
+        "name_prefix": "TEST",
+        "security_groups": [
+          "\${aws_security_group.testALB_alb_security_group_57C45F23.id}"
         ],
-        \\"subnets\\": [
-          \\"a\\",
-          \\"b\\"
+        "subnets": [
+          "a",
+          "b"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testALB_alb_security_group_57C45F23\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testALB_alb_security_group_57C45F23": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"test--HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "test--HTTP/S Security Group",
+        "tags": {
+          "Name": "test--HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"123\\"
+        "vpc_id": "123"
       }
     }
   }
@@ -367,95 +367,95 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
 
 exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucket and prefix 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_s3_bucket\\": {
-      \\"testALB_log-bucket_E9787BB1\\": {
-        \\"bucket\\": \\"logging-bucket\\"
+  "data": {
+    "aws_s3_bucket": {
+      "testALB_log-bucket_E9787BB1": {
+        "bucket": "logging-bucket"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_alb\\": {
-      \\"testALB_alb_F6B33218\\": {
-        \\"access_logs\\": {
-          \\"bucket\\": \\"\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}\\",
-          \\"enabled\\": true,
-          \\"prefix\\": \\"logs/ahoy/cool/service\\"
+  "resource": {
+    "aws_alb": {
+      "testALB_alb_F6B33218": {
+        "access_logs": {
+          "bucket": "\${data.aws_s3_bucket.testALB_log-bucket_E9787BB1.bucket}",
+          "enabled": true,
+          "prefix": "logs/ahoy/cool/service"
         },
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TEST\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+        "internal": false,
+        "name_prefix": "TEST",
+        "security_groups": [
+          "\${aws_security_group.testALB_alb_security_group_57C45F23.id}"
         ],
-        \\"subnets\\": [
-          \\"a\\",
-          \\"b\\"
+        "subnets": [
+          "a",
+          "b"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testALB_alb_security_group_57C45F23\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testALB_alb_security_group_57C45F23": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"test--HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "test--HTTP/S Security Group",
+        "tags": {
+          "Name": "test--HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"123\\"
+        "vpc_id": "123"
       }
     }
   }
@@ -464,83 +464,83 @@ exports[`ApplicationLoadBalancer renders an ALB with logs with an existing bucke
 
 exports[`ApplicationLoadBalancer renders an ALB with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_alb\\": {
-      \\"testALB_alb_F6B33218\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TEST\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+  "resource": {
+    "aws_alb": {
+      "testALB_alb_F6B33218": {
+        "internal": false,
+        "name_prefix": "TEST",
+        "security_groups": [
+          "\${aws_security_group.testALB_alb_security_group_57C45F23.id}"
         ],
-        \\"subnets\\": [
-          \\"a\\",
-          \\"b\\"
+        "subnets": [
+          "a",
+          "b"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testALB_alb_security_group_57C45F23\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testALB_alb_security_group_57C45F23": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"test--HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "test--HTTP/S Security Group",
+        "tags": {
+          "Name": "test--HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"123\\"
+        "vpc_id": "123"
       }
     }
   }
@@ -549,77 +549,77 @@ exports[`ApplicationLoadBalancer renders an ALB with tags 1`] = `
 
 exports[`ApplicationLoadBalancer renders an ALB without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_alb\\": {
-      \\"testALB_alb_F6B33218\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TEST\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testALB_alb_security_group_57C45F23.id}\\"
+  "resource": {
+    "aws_alb": {
+      "testALB_alb_F6B33218": {
+        "internal": false,
+        "name_prefix": "TEST",
+        "security_groups": [
+          "\${aws_security_group.testALB_alb_security_group_57C45F23.id}"
         ],
-        \\"subnets\\": [
-          \\"a\\",
-          \\"b\\"
+        "subnets": [
+          "a",
+          "b"
         ]
       }
     },
-    \\"aws_security_group\\": {
-      \\"testALB_alb_security_group_57C45F23\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testALB_alb_security_group_57C45F23": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"test--HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"test--HTTP/S Security Group\\"
+        "name_prefix": "test--HTTP/S Security Group",
+        "tags": {
+          "Name": "test--HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"123\\"
+        "vpc_id": "123"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationMemcache.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationMemcache.spec.ts.snap
@@ -2,68 +2,68 @@
 
 exports[`ApplicationMemcache renders memcached with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testMemcached_vpc_192C8AF1\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testMemcached_vpc_192C8AF1": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"cool-vpc\\"
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_elasticache_cluster\\": {
-      \\"testMemcached_elasticache_cluster_4853BD62\\": {
-        \\"apply_immediately\\": true,
-        \\"cluster_id\\": \\"abides-dev\\",
-        \\"depends_on\\": [
-          \\"aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233\\",
-          \\"aws_security_group.testMemcached_elasticache_security_group_F23969B6\\"
+  "resource": {
+    "aws_elasticache_cluster": {
+      "testMemcached_elasticache_cluster_4853BD62": {
+        "apply_immediately": true,
+        "cluster_id": "abides-dev",
+        "depends_on": [
+          "aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233",
+          "aws_security_group.testMemcached_elasticache_security_group_F23969B6"
         ],
-        \\"engine\\": \\"memcached\\",
-        \\"engine_version\\": \\"1.6.6\\",
-        \\"node_type\\": \\"cache.t2.micro\\",
-        \\"num_cache_nodes\\": 2,
-        \\"parameter_group_name\\": \\"default.memcached1.6\\",
-        \\"port\\": 11211,
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.testMemcached_elasticache_security_group_F23969B6.id}\\"
+        "engine": "memcached",
+        "engine_version": "1.6.6",
+        "node_type": "cache.t2.micro",
+        "num_cache_nodes": 2,
+        "parameter_group_name": "default.memcached1.6",
+        "port": 11211,
+        "security_group_ids": [
+          "\${aws_security_group.testMemcached_elasticache_security_group_F23969B6.id}"
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233.name}\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233.name}"
       }
     },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"testMemcached_elasticache_subnet_group_609E6233\\": {
-        \\"name\\": \\"abides-dev-ElasticacheSubnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"1234-123\\"
+    "aws_elasticache_subnet_group": {
+      "testMemcached_elasticache_subnet_group_609E6233": {
+        "name": "abides-dev-ElasticacheSubnetGroup",
+        "subnet_ids": [
+          "1234-123"
         ]
       }
     },
-    \\"aws_security_group\\": {
-      \\"testMemcached_elasticache_security_group_F23969B6\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"ingress\\": [
+    "aws_security_group": {
+      "testMemcached_elasticache_security_group_F23969B6": {
+        "description": "Managed by Terraform",
+        "ingress": [
           {
-            \\"cidr_blocks\\": null,
-            \\"description\\": null,
-            \\"from_port\\": 11211,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": [
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 11211,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 11211
+            "self": null,
+            "to_port": 11211
           }
         ],
-        \\"name_prefix\\": \\"abides-dev\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testMemcached_vpc_192C8AF1.id}\\"
+        "name_prefix": "abides-dev",
+        "vpc_id": "\${data.aws_vpc.testMemcached_vpc_192C8AF1.id}"
       }
     }
   }
@@ -72,68 +72,68 @@ exports[`ApplicationMemcache renders memcached with minimal config 1`] = `
 
 exports[`ApplicationMemcache renders memcached with node change 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testMemcached_vpc_192C8AF1\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testMemcached_vpc_192C8AF1": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"cool-vpc\\"
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_elasticache_cluster\\": {
-      \\"testMemcached_elasticache_cluster_4853BD62\\": {
-        \\"apply_immediately\\": true,
-        \\"cluster_id\\": \\"abides-dev\\",
-        \\"depends_on\\": [
-          \\"aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233\\",
-          \\"aws_security_group.testMemcached_elasticache_security_group_F23969B6\\"
+  "resource": {
+    "aws_elasticache_cluster": {
+      "testMemcached_elasticache_cluster_4853BD62": {
+        "apply_immediately": true,
+        "cluster_id": "abides-dev",
+        "depends_on": [
+          "aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233",
+          "aws_security_group.testMemcached_elasticache_security_group_F23969B6"
         ],
-        \\"engine\\": \\"memcached\\",
-        \\"engine_version\\": \\"1.6.6\\",
-        \\"node_type\\": \\"cache.m4.2xlarge\\",
-        \\"num_cache_nodes\\": 5,
-        \\"parameter_group_name\\": \\"default.memcached1.6\\",
-        \\"port\\": 11211,
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.testMemcached_elasticache_security_group_F23969B6.id}\\"
+        "engine": "memcached",
+        "engine_version": "1.6.6",
+        "node_type": "cache.m4.2xlarge",
+        "num_cache_nodes": 5,
+        "parameter_group_name": "default.memcached1.6",
+        "port": 11211,
+        "security_group_ids": [
+          "\${aws_security_group.testMemcached_elasticache_security_group_F23969B6.id}"
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233.name}\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233.name}"
       }
     },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"testMemcached_elasticache_subnet_group_609E6233\\": {
-        \\"name\\": \\"abides-dev-ElasticacheSubnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"1234-123\\"
+    "aws_elasticache_subnet_group": {
+      "testMemcached_elasticache_subnet_group_609E6233": {
+        "name": "abides-dev-ElasticacheSubnetGroup",
+        "subnet_ids": [
+          "1234-123"
         ]
       }
     },
-    \\"aws_security_group\\": {
-      \\"testMemcached_elasticache_security_group_F23969B6\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"ingress\\": [
+    "aws_security_group": {
+      "testMemcached_elasticache_security_group_F23969B6": {
+        "description": "Managed by Terraform",
+        "ingress": [
           {
-            \\"cidr_blocks\\": null,
-            \\"description\\": null,
-            \\"from_port\\": 11211,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": [
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 11211,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 11211
+            "self": null,
+            "to_port": 11211
           }
         ],
-        \\"name_prefix\\": \\"abides-dev\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testMemcached_vpc_192C8AF1.id}\\"
+        "name_prefix": "abides-dev",
+        "vpc_id": "\${data.aws_vpc.testMemcached_vpc_192C8AF1.id}"
       }
     }
   }
@@ -142,80 +142,80 @@ exports[`ApplicationMemcache renders memcached with node change 1`] = `
 
 exports[`ApplicationMemcache renders memcached with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testMemcached_vpc_192C8AF1\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testMemcached_vpc_192C8AF1": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"cool-vpc\\"
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_elasticache_cluster\\": {
-      \\"testMemcached_elasticache_cluster_4853BD62\\": {
-        \\"apply_immediately\\": true,
-        \\"cluster_id\\": \\"abides-dev\\",
-        \\"depends_on\\": [
-          \\"aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233\\",
-          \\"aws_security_group.testMemcached_elasticache_security_group_F23969B6\\"
+  "resource": {
+    "aws_elasticache_cluster": {
+      "testMemcached_elasticache_cluster_4853BD62": {
+        "apply_immediately": true,
+        "cluster_id": "abides-dev",
+        "depends_on": [
+          "aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233",
+          "aws_security_group.testMemcached_elasticache_security_group_F23969B6"
         ],
-        \\"engine\\": \\"memcached\\",
-        \\"engine_version\\": \\"1.6.6\\",
-        \\"node_type\\": \\"cache.t2.micro\\",
-        \\"num_cache_nodes\\": 2,
-        \\"parameter_group_name\\": \\"default.memcached1.6\\",
-        \\"port\\": 11211,
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.testMemcached_elasticache_security_group_F23969B6.id}\\"
+        "engine": "memcached",
+        "engine_version": "1.6.6",
+        "node_type": "cache.t2.micro",
+        "num_cache_nodes": 2,
+        "parameter_group_name": "default.memcached1.6",
+        "port": 11211,
+        "security_group_ids": [
+          "\${aws_security_group.testMemcached_elasticache_security_group_F23969B6.id}"
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233.name}\\",
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.testMemcached_elasticache_subnet_group_609E6233.name}",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         }
       }
     },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"testMemcached_elasticache_subnet_group_609E6233\\": {
-        \\"name\\": \\"abides-dev-ElasticacheSubnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"1234-123\\"
+    "aws_elasticache_subnet_group": {
+      "testMemcached_elasticache_subnet_group_609E6233": {
+        "name": "abides-dev-ElasticacheSubnetGroup",
+        "subnet_ids": [
+          "1234-123"
         ],
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testMemcached_elasticache_security_group_F23969B6\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"ingress\\": [
+    "aws_security_group": {
+      "testMemcached_elasticache_security_group_F23969B6": {
+        "description": "Managed by Terraform",
+        "ingress": [
           {
-            \\"cidr_blocks\\": null,
-            \\"description\\": null,
-            \\"from_port\\": 11211,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": [
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 11211,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 11211
+            "self": null,
+            "to_port": 11211
           }
         ],
-        \\"name_prefix\\": \\"abides-dev\\",
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+        "name_prefix": "abides-dev",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testMemcached_vpc_192C8AF1.id}\\"
+        "vpc_id": "\${data.aws_vpc.testMemcached_vpc_192C8AF1.id}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationRDSCluster.spec.ts.snap
@@ -2,118 +2,118 @@
 
 exports[`ApplicationRDSCluster renders a RDS cluster 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testRDSCluster_vpc_F47EEEFE\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testRDSCluster_vpc_F47EEEFE": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"rug\\"
+            "name": "vpc-id",
+            "values": [
+              "rug"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_db_subnet_group\\": {
-      \\"testRDSCluster_rds_subnet_group_88022457\\": {
-        \\"name_prefix\\": \\"bowling-\\",
-        \\"subnet_ids\\": [
-          \\"0\\",
-          \\"1\\"
+  "resource": {
+    "aws_db_subnet_group": {
+      "testRDSCluster_rds_subnet_group_88022457": {
+        "name_prefix": "bowling-",
+        "subnet_ids": [
+          "0",
+          "1"
         ],
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "tags": {
+          "whodis": "walter"
         }
       }
     },
-    \\"aws_rds_cluster\\": {
-      \\"testRDSCluster_rds_cluster_B5FD08B5\\": {
-        \\"cluster_identifier_prefix\\": \\"bowling-\\",
-        \\"copy_tags_to_snapshot\\": true,
-        \\"database_name\\": \\"walter\\",
-        \\"db_subnet_group_name\\": \\"\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}\\",
-        \\"engine\\": \\"aurora-mysql\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"master_username\\",
-            \\"master_password\\"
+    "aws_rds_cluster": {
+      "testRDSCluster_rds_cluster_B5FD08B5": {
+        "cluster_identifier_prefix": "bowling-",
+        "copy_tags_to_snapshot": true,
+        "database_name": "walter",
+        "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
+        "engine": "aurora-mysql",
+        "lifecycle": {
+          "ignore_changes": [
+            "master_username",
+            "master_password"
           ]
         },
-        \\"master_password\\": \\"bowling\\",
-        \\"master_username\\": \\"walter\\",
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "master_password": "bowling",
+        "master_username": "walter",
+        "tags": {
+          "whodis": "walter"
         },
-        \\"vpc_security_group_ids\\": [
-          \\"\${aws_security_group.testRDSCluster_rds_security_group_4A9D257E.id}\\"
+        "vpc_security_group_ids": [
+          "\${aws_security_group.testRDSCluster_rds_security_group_4A9D257E.id}"
         ]
       }
     },
-    \\"aws_secretsmanager_secret\\": {
-      \\"testRDSCluster_rds_secret_A2014138\\": {
-        \\"depends_on\\": [
-          \\"aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5\\"
+    "aws_secretsmanager_secret": {
+      "testRDSCluster_rds_secret_A2014138": {
+        "depends_on": [
+          "aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5"
         ],
-        \\"description\\": \\"Secret For \${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}\\",
-        \\"name\\": \\"bowling-/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}\\",
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "description": "Secret For \${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}",
+        "name": "bowling-/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}",
+        "tags": {
+          "whodis": "walter"
         }
       }
     },
-    \\"aws_secretsmanager_secret_version\\": {
-      \\"testRDSCluster_rds_secret_version_55C44893\\": {
-        \\"depends_on\\": [
-          \\"aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138\\"
+    "aws_secretsmanager_secret_version": {
+      "testRDSCluster_rds_secret_version_55C44893": {
+        "depends_on": [
+          "aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138"
         ],
-        \\"secret_id\\": \\"\${aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138.id}\\",
-        \\"secret_string\\": \\"{\\\\\\"engine\\\\\\":\\\\\\"aurora-mysql\\\\\\",\\\\\\"host\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}\\\\\\",\\\\\\"username\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}\\\\\\",\\\\\\"password\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}\\\\\\",\\\\\\"dbname\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\\\\\",\\\\\\"port\\\\\\":3306,\\\\\\"database_url\\\\\\":\\\\\\"mysql://\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}:\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}@\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}:3306/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\\\\\"}\\"
+        "secret_id": "\${aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138.id}",
+        "secret_string": "{\\"engine\\":\\"aurora-mysql\\",\\"host\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}\\",\\"username\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}\\",\\"password\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}\\",\\"dbname\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\",\\"port\\":3306,\\"database_url\\":\\"mysql://\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}:\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}@\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}:3306/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\"}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testRDSCluster_rds_security_group_4A9D257E\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testRDSCluster_rds_security_group_4A9D257E": {
+        "description": "Managed by Terraform",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.cidr_block}\\"
+            "cidr_blocks": [
+              "\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.cidr_block}"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 3306,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 3306
+            "description": null,
+            "from_port": 3306,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": null,
+            "self": null,
+            "to_port": 3306
           }
         ],
-        \\"name_prefix\\": \\"bowling-\\",
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "name_prefix": "bowling-",
+        "tags": {
+          "whodis": "walter"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.id}\\"
+        "vpc_id": "\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.id}"
       }
     }
   }
@@ -122,118 +122,118 @@ exports[`ApplicationRDSCluster renders a RDS cluster 1`] = `
 
 exports[`ApplicationRDSCluster renders a RDS cluster with a database URL 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testRDSCluster_vpc_F47EEEFE\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testRDSCluster_vpc_F47EEEFE": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"rug\\"
+            "name": "vpc-id",
+            "values": [
+              "rug"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_db_subnet_group\\": {
-      \\"testRDSCluster_rds_subnet_group_88022457\\": {
-        \\"name_prefix\\": \\"bowling-\\",
-        \\"subnet_ids\\": [
-          \\"0\\",
-          \\"1\\"
+  "resource": {
+    "aws_db_subnet_group": {
+      "testRDSCluster_rds_subnet_group_88022457": {
+        "name_prefix": "bowling-",
+        "subnet_ids": [
+          "0",
+          "1"
         ],
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "tags": {
+          "whodis": "walter"
         }
       }
     },
-    \\"aws_rds_cluster\\": {
-      \\"testRDSCluster_rds_cluster_B5FD08B5\\": {
-        \\"cluster_identifier_prefix\\": \\"bowling-\\",
-        \\"copy_tags_to_snapshot\\": true,
-        \\"database_name\\": \\"walter\\",
-        \\"db_subnet_group_name\\": \\"\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}\\",
-        \\"engine\\": \\"aurora-mysql\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"master_username\\",
-            \\"master_password\\"
+    "aws_rds_cluster": {
+      "testRDSCluster_rds_cluster_B5FD08B5": {
+        "cluster_identifier_prefix": "bowling-",
+        "copy_tags_to_snapshot": true,
+        "database_name": "walter",
+        "db_subnet_group_name": "\${aws_db_subnet_group.testRDSCluster_rds_subnet_group_88022457.name}",
+        "engine": "aurora-mysql",
+        "lifecycle": {
+          "ignore_changes": [
+            "master_username",
+            "master_password"
           ]
         },
-        \\"master_password\\": \\"bowling\\",
-        \\"master_username\\": \\"walter\\",
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "master_password": "bowling",
+        "master_username": "walter",
+        "tags": {
+          "whodis": "walter"
         },
-        \\"vpc_security_group_ids\\": [
-          \\"\${aws_security_group.testRDSCluster_rds_security_group_4A9D257E.id}\\"
+        "vpc_security_group_ids": [
+          "\${aws_security_group.testRDSCluster_rds_security_group_4A9D257E.id}"
         ]
       }
     },
-    \\"aws_secretsmanager_secret\\": {
-      \\"testRDSCluster_rds_secret_A2014138\\": {
-        \\"depends_on\\": [
-          \\"aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5\\"
+    "aws_secretsmanager_secret": {
+      "testRDSCluster_rds_secret_A2014138": {
+        "depends_on": [
+          "aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5"
         ],
-        \\"description\\": \\"Secret For \${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}\\",
-        \\"name\\": \\"bowling-/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}\\",
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "description": "Secret For \${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}",
+        "name": "bowling-/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.cluster_identifier}",
+        "tags": {
+          "whodis": "walter"
         }
       }
     },
-    \\"aws_secretsmanager_secret_version\\": {
-      \\"testRDSCluster_rds_secret_version_55C44893\\": {
-        \\"depends_on\\": [
-          \\"aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138\\"
+    "aws_secretsmanager_secret_version": {
+      "testRDSCluster_rds_secret_version_55C44893": {
+        "depends_on": [
+          "aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138"
         ],
-        \\"secret_id\\": \\"\${aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138.id}\\",
-        \\"secret_string\\": \\"{\\\\\\"engine\\\\\\":\\\\\\"aurora-mysql\\\\\\",\\\\\\"host\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}\\\\\\",\\\\\\"username\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}\\\\\\",\\\\\\"password\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}\\\\\\",\\\\\\"dbname\\\\\\":\\\\\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\\\\\",\\\\\\"port\\\\\\":3306,\\\\\\"database_url\\\\\\":\\\\\\"mysql://\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}:\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}@\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}:3306/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\\\\\"}\\"
+        "secret_id": "\${aws_secretsmanager_secret.testRDSCluster_rds_secret_A2014138.id}",
+        "secret_string": "{\\"engine\\":\\"aurora-mysql\\",\\"host\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}\\",\\"username\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}\\",\\"password\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}\\",\\"dbname\\":\\"\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\",\\"port\\":3306,\\"database_url\\":\\"mysql://\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_username}:\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.master_password}@\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.endpoint}:3306/\${aws_rds_cluster.testRDSCluster_rds_cluster_B5FD08B5.database_name}\\"}"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testRDSCluster_rds_security_group_4A9D257E\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testRDSCluster_rds_security_group_4A9D257E": {
+        "description": "Managed by Terraform",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.cidr_block}\\"
+            "cidr_blocks": [
+              "\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.cidr_block}"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 3306,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 3306
+            "description": null,
+            "from_port": 3306,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": null,
+            "self": null,
+            "to_port": 3306
           }
         ],
-        \\"name_prefix\\": \\"bowling-\\",
-        \\"tags\\": {
-          \\"whodis\\": \\"walter\\"
+        "name_prefix": "bowling-",
+        "tags": {
+          "whodis": "walter"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.id}\\"
+        "vpc_id": "\${data.aws_vpc.testRDSCluster_vpc_F47EEEFE.id}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationRedis.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationRedis.spec.ts.snap
@@ -2,70 +2,70 @@
 
 exports[`ApplicationRedis renders redis with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testRedis_vpc_442CAD26\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testRedis_vpc_442CAD26": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"cool-vpc\\"
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_elasticache_replication_group\\": {
-      \\"testRedis_elasticache_replication_group_E03AAD61\\": {
-        \\"apply_immediately\\": true,
-        \\"automatic_failover_enabled\\": true,
-        \\"depends_on\\": [
-          \\"aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7\\",
-          \\"aws_security_group.testRedis_elasticache_security_group_36C6CB6D\\"
+  "resource": {
+    "aws_elasticache_replication_group": {
+      "testRedis_elasticache_replication_group_E03AAD61": {
+        "apply_immediately": true,
+        "automatic_failover_enabled": true,
+        "depends_on": [
+          "aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7",
+          "aws_security_group.testRedis_elasticache_security_group_36C6CB6D"
         ],
-        \\"description\\": \\"abides-dev | Managed by terraform\\",
-        \\"engine_version\\": \\"7.0\\",
-        \\"multi_az_enabled\\": true,
-        \\"node_type\\": \\"cache.t3.micro\\",
-        \\"num_cache_clusters\\": 2,
-        \\"parameter_group_name\\": \\"default.redis7\\",
-        \\"port\\": 6379,
-        \\"replication_group_id\\": \\"abides-dev\\",
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}\\"
+        "description": "abides-dev | Managed by terraform",
+        "engine_version": "7.0",
+        "multi_az_enabled": true,
+        "node_type": "cache.t3.micro",
+        "num_cache_clusters": 2,
+        "parameter_group_name": "default.redis7",
+        "port": 6379,
+        "replication_group_id": "abides-dev",
+        "security_group_ids": [
+          "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7.name}\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7.name}"
       }
     },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"testRedis_elasticache_subnet_group_389F6AE7\\": {
-        \\"name\\": \\"abides-dev-ElasticacheSubnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"1234-123\\"
+    "aws_elasticache_subnet_group": {
+      "testRedis_elasticache_subnet_group_389F6AE7": {
+        "name": "abides-dev-ElasticacheSubnetGroup",
+        "subnet_ids": [
+          "1234-123"
         ]
       }
     },
-    \\"aws_security_group\\": {
-      \\"testRedis_elasticache_security_group_36C6CB6D\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"ingress\\": [
+    "aws_security_group": {
+      "testRedis_elasticache_security_group_36C6CB6D": {
+        "description": "Managed by Terraform",
+        "ingress": [
           {
-            \\"cidr_blocks\\": null,
-            \\"description\\": null,
-            \\"from_port\\": 6379,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": [
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 6379
+            "self": null,
+            "to_port": 6379
           }
         ],
-        \\"name_prefix\\": \\"abides-dev\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testRedis_vpc_442CAD26.id}\\"
+        "name_prefix": "abides-dev",
+        "vpc_id": "\${data.aws_vpc.testRedis_vpc_442CAD26.id}"
       }
     }
   }
@@ -74,70 +74,70 @@ exports[`ApplicationRedis renders redis with minimal config 1`] = `
 
 exports[`ApplicationRedis renders redis with node change 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testRedis_vpc_442CAD26\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testRedis_vpc_442CAD26": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"cool-vpc\\"
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_elasticache_replication_group\\": {
-      \\"testRedis_elasticache_replication_group_E03AAD61\\": {
-        \\"apply_immediately\\": true,
-        \\"automatic_failover_enabled\\": true,
-        \\"depends_on\\": [
-          \\"aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7\\",
-          \\"aws_security_group.testRedis_elasticache_security_group_36C6CB6D\\"
+  "resource": {
+    "aws_elasticache_replication_group": {
+      "testRedis_elasticache_replication_group_E03AAD61": {
+        "apply_immediately": true,
+        "automatic_failover_enabled": true,
+        "depends_on": [
+          "aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7",
+          "aws_security_group.testRedis_elasticache_security_group_36C6CB6D"
         ],
-        \\"description\\": \\"abides-dev | Managed by terraform\\",
-        \\"engine_version\\": \\"7.0\\",
-        \\"multi_az_enabled\\": true,
-        \\"node_type\\": \\"cache.m4.2xlarge\\",
-        \\"num_cache_clusters\\": 5,
-        \\"parameter_group_name\\": \\"default.redis7\\",
-        \\"port\\": 6379,
-        \\"replication_group_id\\": \\"abides-dev\\",
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}\\"
+        "description": "abides-dev | Managed by terraform",
+        "engine_version": "7.0",
+        "multi_az_enabled": true,
+        "node_type": "cache.m4.2xlarge",
+        "num_cache_clusters": 5,
+        "parameter_group_name": "default.redis7",
+        "port": 6379,
+        "replication_group_id": "abides-dev",
+        "security_group_ids": [
+          "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7.name}\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7.name}"
       }
     },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"testRedis_elasticache_subnet_group_389F6AE7\\": {
-        \\"name\\": \\"abides-dev-ElasticacheSubnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"1234-123\\"
+    "aws_elasticache_subnet_group": {
+      "testRedis_elasticache_subnet_group_389F6AE7": {
+        "name": "abides-dev-ElasticacheSubnetGroup",
+        "subnet_ids": [
+          "1234-123"
         ]
       }
     },
-    \\"aws_security_group\\": {
-      \\"testRedis_elasticache_security_group_36C6CB6D\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"ingress\\": [
+    "aws_security_group": {
+      "testRedis_elasticache_security_group_36C6CB6D": {
+        "description": "Managed by Terraform",
+        "ingress": [
           {
-            \\"cidr_blocks\\": null,
-            \\"description\\": null,
-            \\"from_port\\": 6379,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": [
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 6379
+            "self": null,
+            "to_port": 6379
           }
         ],
-        \\"name_prefix\\": \\"abides-dev\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testRedis_vpc_442CAD26.id}\\"
+        "name_prefix": "abides-dev",
+        "vpc_id": "\${data.aws_vpc.testRedis_vpc_442CAD26.id}"
       }
     }
   }
@@ -146,82 +146,82 @@ exports[`ApplicationRedis renders redis with node change 1`] = `
 
 exports[`ApplicationRedis renders redis with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_vpc\\": {
-      \\"testRedis_vpc_442CAD26\\": {
-        \\"filter\\": [
+  "data": {
+    "aws_vpc": {
+      "testRedis_vpc_442CAD26": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"cool-vpc\\"
+            "name": "vpc-id",
+            "values": [
+              "cool-vpc"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_elasticache_replication_group\\": {
-      \\"testRedis_elasticache_replication_group_E03AAD61\\": {
-        \\"apply_immediately\\": true,
-        \\"automatic_failover_enabled\\": true,
-        \\"depends_on\\": [
-          \\"aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7\\",
-          \\"aws_security_group.testRedis_elasticache_security_group_36C6CB6D\\"
+  "resource": {
+    "aws_elasticache_replication_group": {
+      "testRedis_elasticache_replication_group_E03AAD61": {
+        "apply_immediately": true,
+        "automatic_failover_enabled": true,
+        "depends_on": [
+          "aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7",
+          "aws_security_group.testRedis_elasticache_security_group_36C6CB6D"
         ],
-        \\"description\\": \\"abides-dev | Managed by terraform\\",
-        \\"engine_version\\": \\"7.0\\",
-        \\"multi_az_enabled\\": true,
-        \\"node_type\\": \\"cache.t3.micro\\",
-        \\"num_cache_clusters\\": 2,
-        \\"parameter_group_name\\": \\"default.redis7\\",
-        \\"port\\": 6379,
-        \\"replication_group_id\\": \\"abides-dev\\",
-        \\"security_group_ids\\": [
-          \\"\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}\\"
+        "description": "abides-dev | Managed by terraform",
+        "engine_version": "7.0",
+        "multi_az_enabled": true,
+        "node_type": "cache.t3.micro",
+        "num_cache_clusters": 2,
+        "parameter_group_name": "default.redis7",
+        "port": 6379,
+        "replication_group_id": "abides-dev",
+        "security_group_ids": [
+          "\${aws_security_group.testRedis_elasticache_security_group_36C6CB6D.id}"
         ],
-        \\"subnet_group_name\\": \\"\${aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7.name}\\",
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+        "subnet_group_name": "\${aws_elasticache_subnet_group.testRedis_elasticache_subnet_group_389F6AE7.name}",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         }
       }
     },
-    \\"aws_elasticache_subnet_group\\": {
-      \\"testRedis_elasticache_subnet_group_389F6AE7\\": {
-        \\"name\\": \\"abides-dev-ElasticacheSubnetGroup\\",
-        \\"subnet_ids\\": [
-          \\"1234-123\\"
+    "aws_elasticache_subnet_group": {
+      "testRedis_elasticache_subnet_group_389F6AE7": {
+        "name": "abides-dev-ElasticacheSubnetGroup",
+        "subnet_ids": [
+          "1234-123"
         ],
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testRedis_elasticache_security_group_36C6CB6D\\": {
-        \\"description\\": \\"Managed by Terraform\\",
-        \\"ingress\\": [
+    "aws_security_group": {
+      "testRedis_elasticache_security_group_36C6CB6D": {
+        "description": "Managed by Terraform",
+        "ingress": [
           {
-            \\"cidr_blocks\\": null,
-            \\"description\\": null,
-            \\"from_port\\": 6379,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"tcp\\",
-            \\"security_groups\\": [
+            "cidr_blocks": null,
+            "description": null,
+            "from_port": 6379,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 6379
+            "self": null,
+            "to_port": 6379
           }
         ],
-        \\"name_prefix\\": \\"abides-dev\\",
-        \\"tags\\": {
-          \\"donnie\\": \\"throwinrockstonight\\",
-          \\"letsgo\\": \\"bowling\\"
+        "name_prefix": "abides-dev",
+        "tags": {
+          "donnie": "throwinrockstonight",
+          "letsgo": "bowling"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testRedis_vpc_442CAD26.id}\\"
+        "vpc_id": "\${data.aws_vpc.testRedis_vpc_442CAD26.id}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationSQSQueue.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationSQSQueue.spec.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`ApplicationSQSQueue renders an sqs queue with max message size 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"testSQS_sqs_queue_B45AAD64\\": {
-        \\"fifo_queue\\": false,
-        \\"max_message_size\\": 86753,
-        \\"name\\": \\"TEST\\"
+  "resource": {
+    "aws_sqs_queue": {
+      "testSQS_sqs_queue_B45AAD64": {
+        "fifo_queue": false,
+        "max_message_size": 86753,
+        "name": "TEST"
       }
     }
   }
@@ -16,14 +16,14 @@ exports[`ApplicationSQSQueue renders an sqs queue with max message size 1`] = `
 
 exports[`ApplicationSQSQueue renders an sqs queue with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"testSQS_sqs_queue_B45AAD64\\": {
-        \\"fifo_queue\\": false,
-        \\"name\\": \\"TEST\\",
-        \\"tags\\": {
-          \\"environment\\": \\"prod\\",
-          \\"test\\": \\"123\\"
+  "resource": {
+    "aws_sqs_queue": {
+      "testSQS_sqs_queue_B45AAD64": {
+        "fifo_queue": false,
+        "name": "TEST",
+        "tags": {
+          "environment": "prod",
+          "test": "123"
         }
       }
     }
@@ -33,11 +33,11 @@ exports[`ApplicationSQSQueue renders an sqs queue with tags 1`] = `
 
 exports[`ApplicationSQSQueue renders an sqs queue without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_sqs_queue\\": {
-      \\"testSQS_sqs_queue_B45AAD64\\": {
-        \\"fifo_queue\\": false,
-        \\"name\\": \\"TEST\\"
+  "resource": {
+    "aws_sqs_queue": {
+      "testSQS_sqs_queue_B45AAD64": {
+        "fifo_queue": false,
+        "name": "TEST"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationSqsSnsTopicSubscription.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationSqsSnsTopicSubscription.spec.ts.snap
@@ -2,104 +2,104 @@
 
 exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription witg dlq passed 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"sqs-sns-subscription_sns-dlq-policy-document_46022E28\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.dlq\\"
+  "data": {
+    "aws_iam_policy_document": {
+      "sqs-sns-subscription_sns-dlq-policy-document_46022E28": {
+        "depends_on": [
+          "aws_sqs_queue.dlq"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.dlq.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.dlq.arn}"
             ]
           }
         ]
       },
-      \\"sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs\\"
+      "sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA": {
+        "depends_on": [
+          "aws_sqs_queue.sqs"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.sqs.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.sqs.arn}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic_subscription\\": {
-      \\"sqs-sns-subscription_5757EDDD\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.dlq\\"
+  "resource": {
+    "aws_sns_topic_subscription": {
+      "sqs-sns-subscription_5757EDDD": {
+        "depends_on": [
+          "aws_sqs_queue.dlq"
         ],
-        \\"endpoint\\": \\"\${aws_sqs_queue.sqs.arn}\\",
-        \\"protocol\\": \\"sqs\\",
-        \\"redrive_policy\\": \\"{\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.dlq.arn}\\\\\\"}\\",
-        \\"topic_arn\\": \\"arn:aws:sns:TopicName\\"
+        "endpoint": "\${aws_sqs_queue.sqs.arn}",
+        "protocol": "sqs",
+        "redrive_policy": "{\\"deadLetterTargetArn\\":\\"\${aws_sqs_queue.dlq.arn}\\"}",
+        "topic_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"dlq\\": {
-        \\"name\\": \\"test-sqs-dlq\\"
+    "aws_sqs_queue": {
+      "dlq": {
+        "name": "test-sqs-dlq"
       },
-      \\"sqs\\": {
-        \\"name\\": \\"test-sqs\\"
+      "sqs": {
+        "name": "test-sqs"
       }
     },
-    \\"aws_sqs_queue_policy\\": {
-      \\"sqs-sns-subscription_sns-dlq-policy_736EBF83\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.dlq.url}\\"
+    "aws_sqs_queue_policy": {
+      "sqs-sns-subscription_sns-dlq-policy_736EBF83": {
+        "policy": "\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}",
+        "queue_url": "\${aws_sqs_queue.dlq.url}"
       },
-      \\"sqs-sns-subscription_sns-sqs-policy_ADC74422\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.sqs.url}\\"
+      "sqs-sns-subscription_sns-sqs-policy_ADC74422": {
+        "policy": "\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}",
+        "queue_url": "\${aws_sqs_queue.sqs.url}"
       }
     }
   }
@@ -108,107 +108,107 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription witg
 
 exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"sqs-sns-subscription_sns-dlq-policy-document_46022E28\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678\\"
+  "data": {
+    "aws_iam_policy_document": {
+      "sqs-sns-subscription_sns-dlq-policy-document_46022E28": {
+        "depends_on": [
+          "aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}"
             ]
           }
         ]
       },
-      \\"sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs\\"
+      "sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA": {
+        "depends_on": [
+          "aws_sqs_queue.sqs"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.sqs.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.sqs.arn}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic_subscription\\": {
-      \\"sqs-sns-subscription_5757EDDD\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678\\"
+  "resource": {
+    "aws_sns_topic_subscription": {
+      "sqs-sns-subscription_5757EDDD": {
+        "depends_on": [
+          "aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678"
         ],
-        \\"endpoint\\": \\"\${aws_sqs_queue.sqs.arn}\\",
-        \\"protocol\\": \\"sqs\\",
-        \\"redrive_policy\\": \\"{\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}\\\\\\"}\\",
-        \\"topic_arn\\": \\"arn:aws:sns:TopicName\\"
+        "endpoint": "\${aws_sqs_queue.sqs.arn}",
+        "protocol": "sqs",
+        "redrive_policy": "{\\"deadLetterTargetArn\\":\\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}\\"}",
+        "topic_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"sqs\\": {
-        \\"name\\": \\"test-sqs\\"
+    "aws_sqs_queue": {
+      "sqs": {
+        "name": "test-sqs"
       },
-      \\"sqs-sns-subscription_sns-topic-dql_23368678\\": {
-        \\"name\\": \\"test-sns-subscription-SNS-Topic-DLQ\\",
-        \\"tags\\": {
-          \\"hello\\": \\"there\\"
+      "sqs-sns-subscription_sns-topic-dql_23368678": {
+        "name": "test-sns-subscription-SNS-Topic-DLQ",
+        "tags": {
+          "hello": "there"
         }
       }
     },
-    \\"aws_sqs_queue_policy\\": {
-      \\"sqs-sns-subscription_sns-dlq-policy_736EBF83\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.url}\\"
+    "aws_sqs_queue_policy": {
+      "sqs-sns-subscription_sns-dlq-policy_736EBF83": {
+        "policy": "\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}",
+        "queue_url": "\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.url}"
       },
-      \\"sqs-sns-subscription_sns-sqs-policy_ADC74422\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.sqs.url}\\"
+      "sqs-sns-subscription_sns-sqs-policy_ADC74422": {
+        "policy": "\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}",
+        "queue_url": "\${aws_sqs_queue.sqs.url}"
       }
     }
   }
@@ -217,104 +217,104 @@ exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription with
 
 exports[`ApplicationSqsSnsTopicSubscription renders an SQS SNS subscription without tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"sqs-sns-subscription_sns-dlq-policy-document_46022E28\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678\\"
+  "data": {
+    "aws_iam_policy_document": {
+      "sqs-sns-subscription_sns-dlq-policy-document_46022E28": {
+        "depends_on": [
+          "aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}"
             ]
           }
         ]
       },
-      \\"sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs\\"
+      "sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA": {
+        "depends_on": [
+          "aws_sqs_queue.sqs"
         ],
-        \\"statement\\": [
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\"
+            "actions": [
+              "sqs:SendMessage"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"ArnEquals\\",
-                \\"values\\": [
-                  \\"arn:aws:sns:TopicName\\"
+                "test": "ArnEquals",
+                "values": [
+                  "arn:aws:sns:TopicName"
                 ],
-                \\"variable\\": \\"aws:SourceArn\\"
+                "variable": "aws:SourceArn"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"sns.amazonaws.com\\"
+                "identifiers": [
+                  "sns.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ],
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.sqs.arn}\\"
+            "resources": [
+              "\${aws_sqs_queue.sqs.arn}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic_subscription\\": {
-      \\"sqs-sns-subscription_5757EDDD\\": {
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678\\"
+  "resource": {
+    "aws_sns_topic_subscription": {
+      "sqs-sns-subscription_5757EDDD": {
+        "depends_on": [
+          "aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678"
         ],
-        \\"endpoint\\": \\"\${aws_sqs_queue.sqs.arn}\\",
-        \\"protocol\\": \\"sqs\\",
-        \\"redrive_policy\\": \\"{\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}\\\\\\"}\\",
-        \\"topic_arn\\": \\"arn:aws:sns:TopicName\\"
+        "endpoint": "\${aws_sqs_queue.sqs.arn}",
+        "protocol": "sqs",
+        "redrive_policy": "{\\"deadLetterTargetArn\\":\\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.arn}\\"}",
+        "topic_arn": "arn:aws:sns:TopicName"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"sqs\\": {
-        \\"name\\": \\"test-sqs\\"
+    "aws_sqs_queue": {
+      "sqs": {
+        "name": "test-sqs"
       },
-      \\"sqs-sns-subscription_sns-topic-dql_23368678\\": {
-        \\"name\\": \\"test-sns-subscription-SNS-Topic-DLQ\\"
+      "sqs-sns-subscription_sns-topic-dql_23368678": {
+        "name": "test-sns-subscription-SNS-Topic-DLQ"
       }
     },
-    \\"aws_sqs_queue_policy\\": {
-      \\"sqs-sns-subscription_sns-dlq-policy_736EBF83\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.url}\\"
+    "aws_sqs_queue_policy": {
+      "sqs-sns-subscription_sns-dlq-policy_736EBF83": {
+        "policy": "\${data.aws_iam_policy_document.sqs-sns-subscription_sns-dlq-policy-document_46022E28.json}",
+        "queue_url": "\${aws_sqs_queue.sqs-sns-subscription_sns-topic-dql_23368678.url}"
       },
-      \\"sqs-sns-subscription_sns-sqs-policy_ADC74422\\": {
-        \\"policy\\": \\"\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}\\",
-        \\"queue_url\\": \\"\${aws_sqs_queue.sqs.url}\\"
+      "sqs-sns-subscription_sns-sqs-policy_ADC74422": {
+        "policy": "\${data.aws_iam_policy_document.sqs-sns-subscription_sns-sqs-policy-document_ABFC60AA.json}",
+        "queue_url": "\${aws_sqs_queue.sqs.url}"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationTargetGroup.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationTargetGroup.spec.ts.snap
@@ -2,26 +2,26 @@
 
 exports[`ApplicationTargetGroup renders a Target Group with tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_alb_target_group\\": {
-      \\"testTargetGroup_ecs_target_group_A0C76C7F\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+  "resource": {
+    "aws_alb_target_group": {
+      "testTargetGroup_ecs_target_group_A0C76C7F": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"A1BC\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "A1BC",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"123\\"
+        "target_type": "ip",
+        "vpc_id": "123"
       }
     }
   }
@@ -30,22 +30,22 @@ exports[`ApplicationTargetGroup renders a Target Group with tags 1`] = `
 
 exports[`ApplicationTargetGroup renders a Target Group without tags 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_alb_target_group\\": {
-      \\"testTargetGroup_ecs_target_group_A0C76C7F\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+  "resource": {
+    "aws_alb_target_group": {
+      "testTargetGroup_ecs_target_group_A0C76C7F": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"ABC\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"123\\"
+        "name_prefix": "ABC",
+        "port": 80,
+        "protocol": "HTTP",
+        "target_type": "ip",
+        "vpc_id": "123"
       }
     }
   }

--- a/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
+++ b/src/base/__snapshots__/ApplicationVersionedLambda.spec.ts.snap
@@ -2,138 +2,138 @@
 
 exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.js.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.js.zip",
+        "source": [
           {
-            \\"content\\": \\"exports.handler = (event, context) => { console.log(event) }\\",
-            \\"filename\\": \\"index.js\\"
+            "content": "exports.handler = (event, context) => { console.log(event) }",
+            "filename": "index.js"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"nodejs14.x\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "nodejs14.x",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -142,138 +142,138 @@ exports[`ApplicationVersionedLambda renders a lambda with a node v14 runtime 1`]
 
 exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -282,138 +282,138 @@ exports[`ApplicationVersionedLambda renders a versioned lambda 1`] = `
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with description 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -422,144 +422,144 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with description 
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with environment variables 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"MY\\": \\"env_var\\",
-            \\"for\\": \\"test\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "environment": {
+          "variables": {
+            "MY": "env_var",
+            "for": "test"
           }
         },
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -568,147 +568,147 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with environment 
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with execution policy statements 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"*\\"
+            "actions": [
+              "*"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -717,138 +717,138 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with execution po
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with log retention 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 10
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 10
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -857,139 +857,139 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with log retentio
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with publish ignored 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\",
-            \\"publish\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash",
+            "publish"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -998,138 +998,138 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with publish igno
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -1138,158 +1138,158 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with s3 bucket 1`
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14,
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tag\\"
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14,
+        "tags": {
+          "for": "test",
+          "my": "tag"
         }
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tag\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}",
+        "tags": {
+          "for": "test",
+          "my": "tag"
         }
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tag\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole",
+        "tags": {
+          "for": "test",
+          "my": "tag"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tag\\"
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "tags": {
+          "for": "test",
+          "my": "tag"
         },
-        \\"timeout\\": 5
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true,
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tag\\"
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true,
+        "tags": {
+          "for": "test",
+          "my": "tag"
         }
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -1298,138 +1298,138 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with tags 1`] = `
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 500
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 500
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }
@@ -1438,161 +1438,161 @@ exports[`ApplicationVersionedLambda renders a versioned lambda with timeout 1`] 
 
 exports[`ApplicationVersionedLambda renders a versioned lambda with vpc 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-versioned-lambda_lambda-default-file_E2490368\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-versioned-lambda_lambda-default-file_E2490368": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-versioned-lambda_assume-policy-document_54E2E6E3\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-versioned-lambda_assume-policy-document_54E2E6E3": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-versioned-lambda_execution-policy-document_BA37CD4D\\": {
-        \\"statement\\": [
+      "test-versioned-lambda_execution-policy-document_BA37CD4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ec2:DescribeNetworkInterfaces\\",
-              \\"ec2:CreateNetworkInterface\\",
-              \\"ec2:DeleteNetworkInterface\\",
-              \\"ec2:DescribeInstances\\",
-              \\"ec2:AttachNetworkInterface\\"
+            "actions": [
+              "ec2:DescribeNetworkInterfaces",
+              "ec2:CreateNetworkInterface",
+              "ec2:DeleteNetworkInterface",
+              "ec2:DescribeInstances",
+              "ec2:AttachNetworkInterface"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-versioned-lambda_log-group_CB8A67E7\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-versioned-lambda_log-group_CB8A67E7": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-versioned-lambda_execution-policy_A934214F\\": {
-        \\"name\\": \\"Test-Lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}\\"
+    "aws_iam_policy": {
+      "test-versioned-lambda_execution-policy_A934214F": {
+        "name": "Test-Lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-versioned-lambda_execution-policy-document_BA37CD4D.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-versioned-lambda_execution-role_068103E3\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}\\",
-        \\"name\\": \\"Test-Lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-versioned-lambda_execution-role_068103E3": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-versioned-lambda_assume-policy-document_54E2E6E3.json}",
+        "name": "Test-Lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-versioned-lambda_execution-role-policy-attachment_30E5BCA4\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-versioned-lambda_execution-role_068103E3\\",
-          \\"aws_iam_policy.test-versioned-lambda_execution-policy_A934214F\\"
+    "aws_iam_role_policy_attachment": {
+      "test-versioned-lambda_execution-role-policy-attachment_30E5BCA4": {
+        "depends_on": [
+          "aws_iam_role.test-versioned-lambda_execution-role_068103E3",
+          "aws_iam_policy.test-versioned-lambda_execution-policy_A934214F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-versioned-lambda_execution-policy_A934214F.arn}",
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-versioned-lambda_alias_60AF9CE1\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-versioned-lambda_D818669D\\"
+    "aws_lambda_alias": {
+      "test-versioned-lambda_alias_60AF9CE1": {
+        "depends_on": [
+          "aws_lambda_function.test-versioned-lambda_D818669D"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-versioned-lambda_D818669D.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-versioned-lambda_D818669D.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-versioned-lambda_D818669D\\": {
-        \\"filename\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}\\",
-        \\"function_name\\": \\"Test-Lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-versioned-lambda_D818669D": {
+        "filename": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_path}",
+        "function_name": "Test-Lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}\\",
-        \\"timeout\\": 5,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [
-            \\"sec1\\",
-            \\"sec2\\"
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-versioned-lambda_execution-role_068103E3.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-versioned-lambda_lambda-default-file_E2490368.output_base64sha256}",
+        "timeout": 5,
+        "vpc_config": {
+          "security_group_ids": [
+            "sec1",
+            "sec2"
           ],
-          \\"subnet_ids\\": [
-            \\"1\\",
-            \\"2\\"
+          "subnet_ids": [
+            "1",
+            "2"
           ]
         }
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-versioned-lambda_code-bucket_C658EE92\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-versioned-lambda_code-bucket_C658EE92": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-versioned-lambda_code-bucket-public-access-block_9662548B\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-versioned-lambda_code-bucket-public-access-block_9662548B": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-versioned-lambda_code-bucket_C658EE92.id}"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketALBApplication.spec.ts.snap
@@ -2,681 +2,681 @@
 
 exports[`PocketALBApplication renders a Pocket App with attached persistent storage 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"testPocketApp_ecs_service_ecs-someMountPoint_BC9739A3\\": {
-        \\"name_prefix\\": \\"/ecs/testapp/someMountPoint\\",
-        \\"retention_in_days\\": 30
+    "aws_cloudwatch_log_group": {
+      "testPocketApp_ecs_service_ecs-someMountPoint_BC9739A3": {
+        "name_prefix": "/ecs/testapp/someMountPoint",
+        "retention_in_days": 30
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo-lifecyclepolicy_6B94567D\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3\\"
+    "aws_ecr_lifecycle_policy": {
+      "testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo-lifecyclepolicy_6B94567D": {
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"testapp-somemountpoint\\"
+        "name": "testapp-somemountpoint"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3\\",
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3",
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testPocketApp_ecs_service_ecs-someMountPoint_BC9739A3.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":0,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[{\\\\\\"containerPath\\\\\\":\\\\\\"/qdrant/storage\\\\\\",\\\\\\"sourceVolume\\\\\\":\\\\\\"sourceVolume\\\\\\"}],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":null,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"someMountPoint\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3\\"
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testPocketApp_ecs_service_ecs-someMountPoint_BC9739A3.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[],\\"linuxParameters\\":null,\\"cpu\\":0,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[{\\"containerPath\\":\\"/qdrant/storage\\",\\"sourceVolume\\":\\"sourceVolume\\"}],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":null,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"someMountPoint\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-someMountPoint_ecr-repo_B9A958B3"
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
           {
-            \\"efs_volume_configuration\\": {
-              \\"file_system_id\\": \\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}\\"
+            "efs_volume_configuration": {
+              "file_system_id": "\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}"
             },
-            \\"name\\": \\"sourceVolume\\"
+            "name": "sourceVolume"
           }
         ]
       }
     },
-    \\"aws_efs_file_system\\": {
-      \\"testPocketApp_efsFs_92747227\\": {
-        \\"creation_token\\": \\"someToken\\",
-        \\"encrypted\\": true
+    "aws_efs_file_system": {
+      "testPocketApp_efsFs_92747227": {
+        "creation_token": "someToken",
+        "encrypted": true
       }
     },
-    \\"aws_efs_file_system_policy\\": {
-      \\"testPocketApp_ecs_service_efsFsPolicy_CDE65D86\\": {
-        \\"depends_on\\": [
-          \\"time_sleep.testPocketApp_ecs_service_waitTwoMinutes_E07A2D17\\"
+    "aws_efs_file_system_policy": {
+      "testPocketApp_ecs_service_efsFsPolicy_CDE65D86": {
+        "depends_on": [
+          "time_sleep.testPocketApp_ecs_service_waitTwoMinutes_E07A2D17"
         ],
-        \\"file_system_id\\": \\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}\\",
-        \\"policy\\": \\"{\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Id\\\\\\":\\\\\\"testapp\\\\\\",\\\\\\"Statement\\\\\\":[{\\\\\\"Sid\\\\\\":\\\\\\"testapp\\\\\\",\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Principal\\\\\\":{\\\\\\"AWS\\\\\\":\\\\\\"*\\\\\\"},\\\\\\"Resource\\\\\\":\\\\\\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.arn}\\\\\\",\\\\\\"Action\\\\\\":[\\\\\\"elasticfilesystem:ClientMount\\\\\\",\\\\\\"elasticfilesystem:ClientWrite\\\\\\",\\\\\\"elasticfilesystem:ClientRootAccess\\\\\\"],\\\\\\"Condition\\\\\\":{\\\\\\"Bool\\\\\\":{\\\\\\"elasticfilesystem:AccessedViaMountTarget\\\\\\":\\\\\\"true\\\\\\"}}}]}\\"
+        "file_system_id": "\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}",
+        "policy": "{\\"Version\\":\\"2012-10-17\\",\\"Id\\":\\"testapp\\",\\"Statement\\":[{\\"Sid\\":\\"testapp\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.arn}\\",\\"Action\\":[\\"elasticfilesystem:ClientMount\\",\\"elasticfilesystem:ClientWrite\\",\\"elasticfilesystem:ClientRootAccess\\"],\\"Condition\\":{\\"Bool\\":{\\"elasticfilesystem:AccessedViaMountTarget\\":\\"true\\"}}}]}"
       }
     },
-    \\"aws_efs_mount_target\\": {
-      \\"testPocketApp_ecs_service_efs_mount_target_97B5C5E6\\": {
-        \\"file_system_id\\": \\"\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}\\",
-        \\"for_each\\": \\"\${toset(data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids)}\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_ecs_service_efs_mount_sg_01974774.id}\\"
+    "aws_efs_mount_target": {
+      "testPocketApp_ecs_service_efs_mount_target_97B5C5E6": {
+        "file_system_id": "\${aws_efs_file_system.testPocketApp_efsFs_92747227.id}",
+        "for_each": "\${toset(data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids)}",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_ecs_service_efs_mount_sg_01974774.id}"
         ],
-        \\"subnet_id\\": \\"\${each.value}\\"
+        "subnet_id": "\${each.value}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_efs_mount_sg_01974774\\": {
-        \\"description\\": \\"ECS EFS Mount (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_efs_mount_sg_01974774": {
+        "description": "ECS EFS Mount (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 2049,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 2049
+            "self": null,
+            "to_port": 2049
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSMountPoint\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSMountPoint",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"time_sleep\\": {
-      \\"testPocketApp_ecs_service_waitTwoMinutes_E07A2D17\\": {
-        \\"create_duration\\": \\"2m\\",
-        \\"depends_on\\": [
+    "time_sleep": {
+      "testPocketApp_ecs_service_waitTwoMinutes_E07A2D17": {
+        "create_duration": "2m",
+        "depends_on": [
         ]
       }
     }
@@ -686,581 +686,581 @@ exports[`PocketALBApplication renders a Pocket App with attached persistent stor
 
 exports[`PocketALBApplication renders a Pocket App with attached waf 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_wafv2_web_acl_association\\": {
-      \\"testPocketApp_application_waf_association_03F7C3FB\\": {
-        \\"resource_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"web_acl_arn\\": \\"justAString\\"
+    "aws_wafv2_web_acl_association": {
+      "testPocketApp_application_waf_association_03F7C3FB": {
+        "resource_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "web_acl_arn": "justAString"
       }
     }
   }
@@ -1269,717 +1269,717 @@ exports[`PocketALBApplication renders a Pocket App with attached waf 1`] = `
 
 exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\": {
-        \\"statement\\": [
+      "testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+      "testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"green\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "green"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_codedeploy_app\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"testapp-ECS\\"
+    "aws_codedeploy_app": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565": {
+        "compute_platform": "ECS",
+        "name": "testapp-ECS"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1": {
+        "app_name": "\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"depends_on\\": [
-          \\"aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+        "depends_on": [
+          "aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"testapp-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "testapp-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"service_name\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "ecs_service": {
+          "cluster_name": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "service_name": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}\\"
+                "name": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}"
               },
               {
-                \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}\\"
+                "name": "\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}\\"
+        "service_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
+        "deployment_controller": {
+          "type": "CODE_DEPLOY"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer",
+            "task_definition"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       },
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}\\",
-        \\"name\\": \\"testapp-ECSCodeDeployRole\\"
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}",
+        "name": "testapp-ECSCodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+    "aws_iam_role_policy_attachment": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F": {
+        "depends_on": [
+          "aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"local_file\\": {
-      \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\": {
-        \\"content\\": \\"{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}\\",
-        \\"filename\\": \\"appspec.json\\"
+    "local_file": {
+      "testPocketApp_ecs_service_appspec_6EB2FE4D": {
+        "content": "{\\"version\\":1,\\"Resources\\":[{\\"TargetService\\":{\\"Type\\":\\"AWS::ECS::Service\\",\\"Properties\\":{\\"TaskDefinition\\":\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",\\"LoadBalancerInfo\\":{\\"ContainerName\\":\\"main_container\\",\\"ContainerPort\\":8675309}}}}]}",
+        "filename": "appspec.json"
       }
     },
-    \\"null_resource\\": {
-      \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\": {
-        \\"depends_on\\": [
-          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+    "null_resource": {
+      "testPocketApp_ecs_service_create-task-definition-file_5769615D": {
+        "depends_on": [
+          "aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45"
         ],
-        \\"provisioner\\": {
-          \\"local-exec\\": {
-            \\"command\\": \\"aws --region us-east-1 ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json\\"
+        "provisioner": {
+          "local-exec": {
+            "command": "aws --region us-east-1 ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json"
           }
         },
-        \\"triggers\\": {
-          \\"alwaysRun\\": \\"\${timestamp()}\\"
+        "triggers": {
+          "alwaysRun": "\${timestamp()}"
         }
       },
-      \\"testPocketApp_ecs_service_update-task-definition_23CCF5D1\\": {
-        \\"depends_on\\": [
-          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\",
-          \\"aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\",
-          \\"aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\"
+      "testPocketApp_ecs_service_update-task-definition_23CCF5D1": {
+        "depends_on": [
+          "aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45",
+          "aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565",
+          "aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1"
         ],
-        \\"provisioner\\": {
-          \\"local-exec\\": {
-            \\"command\\": \\"export app_spec_content_string='{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}' && export revision=\\\\\\"revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}\\\\\\" && aws --region us-east-1 deploy create-deployment  --application-name=\\\\\\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\\\\\"  --deployment-group-name=\\\\\\"\${aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1.deployment_group_name}\\\\\\" --description=\\\\\\"Triggered from Terraform/CodeBuild due to a task definition update\\\\\\" --revision=\\\\\\"$revision\\\\\\"\\"
+        "provisioner": {
+          "local-exec": {
+            "command": "export app_spec_content_string='{\\"version\\":1,\\"Resources\\":[{\\"TargetService\\":{\\"Type\\":\\"AWS::ECS::Service\\",\\"Properties\\":{\\"TaskDefinition\\":\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",\\"LoadBalancerInfo\\":{\\"ContainerName\\":\\"main_container\\",\\"ContainerPort\\":8675309}}}}]}' && export revision=\\"revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}\\" && aws --region us-east-1 deploy create-deployment  --application-name=\\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\"  --deployment-group-name=\\"\${aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1.deployment_group_name}\\" --description=\\"Triggered from Terraform/CodeBuild due to a task definition update\\" --revision=\\"$revision\\""
           }
         },
-        \\"triggers\\": {
-          \\"task_arn\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "triggers": {
+          "task_arn": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
         }
       }
     }
@@ -1989,702 +1989,702 @@ exports[`PocketALBApplication renders an Pocket App with code deploy 1`] = `
 
 exports[`PocketALBApplication renders an Pocket App with code deploy and creates appspec.json and taskdef.json when using code pipeline 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\": {
-        \\"statement\\": [
+      "testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+      "testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"green\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "green"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_codedeploy_app\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"testapp-ECS\\"
+    "aws_codedeploy_app": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565": {
+        "compute_platform": "ECS",
+        "name": "testapp-ECS"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1": {
+        "app_name": "\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"depends_on\\": [
-          \\"aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+        "depends_on": [
+          "aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"testapp-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "testapp-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"service_name\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "ecs_service": {
+          "cluster_name": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "service_name": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}\\"
+                "name": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}"
               },
               {
-                \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}\\"
+                "name": "\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}\\"
+        "service_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
+        "deployment_controller": {
+          "type": "CODE_DEPLOY"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer",
+            "task_definition"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       },
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}\\",
-        \\"name\\": \\"testapp-ECSCodeDeployRole\\"
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}",
+        "name": "testapp-ECSCodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+    "aws_iam_role_policy_attachment": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F": {
+        "depends_on": [
+          "aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"local_file\\": {
-      \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\": {
-        \\"content\\": \\"{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}\\",
-        \\"filename\\": \\"appspec.json\\"
+    "local_file": {
+      "testPocketApp_ecs_service_appspec_6EB2FE4D": {
+        "content": "{\\"version\\":1,\\"Resources\\":[{\\"TargetService\\":{\\"Type\\":\\"AWS::ECS::Service\\",\\"Properties\\":{\\"TaskDefinition\\":\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",\\"LoadBalancerInfo\\":{\\"ContainerName\\":\\"main_container\\",\\"ContainerPort\\":8675309}}}}]}",
+        "filename": "appspec.json"
       }
     },
-    \\"null_resource\\": {
-      \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\": {
-        \\"depends_on\\": [
-          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+    "null_resource": {
+      "testPocketApp_ecs_service_create-task-definition-file_5769615D": {
+        "depends_on": [
+          "aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45"
         ],
-        \\"provisioner\\": {
-          \\"local-exec\\": {
-            \\"command\\": \\"aws --region us-east-1 ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json\\"
+        "provisioner": {
+          "local-exec": {
+            "command": "aws --region us-east-1 ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json"
           }
         },
-        \\"triggers\\": {
-          \\"alwaysRun\\": \\"\${timestamp()}\\"
+        "triggers": {
+          "alwaysRun": "\${timestamp()}"
         }
       }
     }
@@ -2694,717 +2694,717 @@ exports[`PocketALBApplication renders an Pocket App with code deploy and creates
 
 exports[`PocketALBApplication renders an Pocket App with code deploy notifications set to failed only 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF\\": {
-        \\"statement\\": [
+      "testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+      "testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"green\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "green"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_codedeploy_app\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\": {
-        \\"compute_platform\\": \\"ECS\\",
-        \\"name\\": \\"testapp-ECS\\"
+    "aws_codedeploy_app": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565": {
+        "compute_platform": "ECS",
+        "name": "testapp-ECS"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1": {
+        "app_name": "\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"blue_green_deployment_config\\": {
-          \\"deployment_ready_option\\": {
-            \\"action_on_timeout\\": \\"CONTINUE_DEPLOYMENT\\"
+        "blue_green_deployment_config": {
+          "deployment_ready_option": {
+            "action_on_timeout": "CONTINUE_DEPLOYMENT"
           },
-          \\"terminate_blue_instances_on_deployment_success\\": {
-            \\"action\\": \\"TERMINATE\\",
-            \\"termination_wait_time_in_minutes\\": 5
+          "terminate_blue_instances_on_deployment_success": {
+            "action": "TERMINATE",
+            "termination_wait_time_in_minutes": 5
           }
         },
-        \\"depends_on\\": [
-          \\"aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C\\"
+        "depends_on": [
+          "aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.ECSAllAtOnce\\",
-        \\"deployment_group_name\\": \\"testapp-ECS\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.ECSAllAtOnce",
+        "deployment_group_name": "testapp-ECS",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"ecs_service\\": {
-          \\"cluster_name\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"service_name\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "ecs_service": {
+          "cluster_name": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "service_name": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"load_balancer_info\\": {
-          \\"target_group_pair_info\\": {
-            \\"prod_traffic_route\\": {
-              \\"listener_arns\\": [
-                \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\"
+        "load_balancer_info": {
+          "target_group_pair_info": {
+            "prod_traffic_route": {
+              "listener_arns": [
+                "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}"
               ]
             },
-            \\"target_group\\": [
+            "target_group": [
               {
-                \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}\\"
+                "name": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.name}"
               },
               {
-                \\"name\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}\\"
+                "name": "\${aws_alb_target_group.testPocketApp_ecs_service_green_target_group_ecs_target_group_0E777BA1.name}"
               }
             ]
           }
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}\\"
+        "service_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.arn}"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"CODE_DEPLOY\\"
+        "deployment_controller": {
+          "type": "CODE_DEPLOY"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\",
-            \\"task_definition\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer",
+            "task_definition"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       },
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}\\",
-        \\"name\\": \\"testapp-ECSCodeDeployRole\\"
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs_codedeploy_codedeploy_assume_role_840D1ECF.json}",
+        "name": "testapp-ECSCodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D\\"
+    "aws_iam_role_policy_attachment": {
+      "testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_role_attachment_F9A8369F": {
+        "depends_on": [
+          "aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS\\",
-        \\"role\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+        "role": "\${aws_iam_role.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_role_287C837D.name}"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"local_file\\": {
-      \\"testPocketApp_ecs_service_appspec_6EB2FE4D\\": {
-        \\"content\\": \\"{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}\\",
-        \\"filename\\": \\"appspec.json\\"
+    "local_file": {
+      "testPocketApp_ecs_service_appspec_6EB2FE4D": {
+        "content": "{\\"version\\":1,\\"Resources\\":[{\\"TargetService\\":{\\"Type\\":\\"AWS::ECS::Service\\",\\"Properties\\":{\\"TaskDefinition\\":\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",\\"LoadBalancerInfo\\":{\\"ContainerName\\":\\"main_container\\",\\"ContainerPort\\":8675309}}}}]}",
+        "filename": "appspec.json"
       }
     },
-    \\"null_resource\\": {
-      \\"testPocketApp_ecs_service_create-task-definition-file_5769615D\\": {
-        \\"depends_on\\": [
-          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\"
+    "null_resource": {
+      "testPocketApp_ecs_service_create-task-definition-file_5769615D": {
+        "depends_on": [
+          "aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45"
         ],
-        \\"provisioner\\": {
-          \\"local-exec\\": {
-            \\"command\\": \\"aws --region us-east-1 ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json\\"
+        "provisioner": {
+          "local-exec": {
+            "command": "aws --region us-east-1 ecs describe-task-definition --task-definition \${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.family} --query 'taskDefinition' >> taskdef.json"
           }
         },
-        \\"triggers\\": {
-          \\"alwaysRun\\": \\"\${timestamp()}\\"
+        "triggers": {
+          "alwaysRun": "\${timestamp()}"
         }
       },
-      \\"testPocketApp_ecs_service_update-task-definition_23CCF5D1\\": {
-        \\"depends_on\\": [
-          \\"aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45\\",
-          \\"aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565\\",
-          \\"aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1\\"
+      "testPocketApp_ecs_service_update-task-definition_23CCF5D1": {
+        "depends_on": [
+          "aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45",
+          "aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565",
+          "aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1"
         ],
-        \\"provisioner\\": {
-          \\"local-exec\\": {
-            \\"command\\": \\"export app_spec_content_string='{\\\\\\"version\\\\\\":1,\\\\\\"Resources\\\\\\":[{\\\\\\"TargetService\\\\\\":{\\\\\\"Type\\\\\\":\\\\\\"AWS::ECS::Service\\\\\\",\\\\\\"Properties\\\\\\":{\\\\\\"TaskDefinition\\\\\\":\\\\\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\\\\\",\\\\\\"LoadBalancerInfo\\\\\\":{\\\\\\"ContainerName\\\\\\":\\\\\\"main_container\\\\\\",\\\\\\"ContainerPort\\\\\\":8675309}}}}]}' && export revision=\\\\\\"revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}\\\\\\" && aws --region us-east-1 deploy create-deployment  --application-name=\\\\\\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\\\\\"  --deployment-group-name=\\\\\\"\${aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1.deployment_group_name}\\\\\\" --description=\\\\\\"Triggered from Terraform/CodeBuild due to a task definition update\\\\\\" --revision=\\\\\\"$revision\\\\\\"\\"
+        "provisioner": {
+          "local-exec": {
+            "command": "export app_spec_content_string='{\\"version\\":1,\\"Resources\\":[{\\"TargetService\\":{\\"Type\\":\\"AWS::ECS::Service\\",\\"Properties\\":{\\"TaskDefinition\\":\\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\",\\"LoadBalancerInfo\\":{\\"ContainerName\\":\\"main_container\\",\\"ContainerPort\\":8675309}}}}]}' && export revision=\\"revisionType=AppSpecContent,appSpecContent={content='$app_spec_content_string'}\\" && aws --region us-east-1 deploy create-deployment  --application-name=\\"\${aws_codedeploy_app.testPocketApp_ecs_service_ecs_codedeploy_ecs_code_deploy_480D0565.name}\\"  --deployment-group-name=\\"\${aws_codedeploy_deployment_group.testPocketApp_ecs_service_ecs_codedeploy_ecs_codedeploy_deployment_group_44B006D1.deployment_group_name}\\" --description=\\"Triggered from Terraform/CodeBuild due to a task definition update\\" --revision=\\"$revision\\""
           }
         },
-        \\"triggers\\": {
-          \\"task_arn\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "triggers": {
+          "task_arn": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
         }
       }
     }
@@ -3414,644 +3414,644 @@ exports[`PocketALBApplication renders an Pocket App with code deploy notificatio
 
 exports[`PocketALBApplication renders an Pocket App with custom Alarm Description 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
-        \\"alarm_actions\\": [
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_alarm-httpresponsetime_327A4315": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Uh oh. This is very slow.\\",
-        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        "alarm_description": "Uh oh. This is very slow.",
+        "alarm_name": "testapp-Alarm-HTTPResponseTime",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "LoadBalancer": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"TargetResponseTime\\",
-        \\"namespace\\": \\"AWS/ApplicationELB\\",
-        \\"ok_actions\\": [
+        "metric_name": "TargetResponseTime",
+        "namespace": "AWS/ApplicationELB",
+        "ok_actions": [
         ],
-        \\"period\\": 300,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 300
+        "period": 300,
+        "statistic": "Average",
+        "threshold": 300
       },
-      \\"testPocketApp_alarm-httptarget5xxerrorrate_39F471E9\\": {
-        \\"alarm_actions\\": [
+      "testPocketApp_alarm-httptarget5xxerrorrate_39F471E9": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Uh oh. something bad happened.\\",
-        \\"alarm_name\\": \\"testapp-Alarm-HTTPTarget5xxErrorRate\\",
-        \\"comparison_operator\\": \\"GreaterThanOrEqualToThreshold\\",
-        \\"datapoints_to_alarm\\": 5,
-        \\"evaluation_periods\\": 5,
-        \\"insufficient_data_actions\\": [
+        "alarm_description": "Uh oh. something bad happened.",
+        "alarm_name": "testapp-Alarm-HTTPTarget5xxErrorRate",
+        "comparison_operator": "GreaterThanOrEqualToThreshold",
+        "datapoints_to_alarm": 5,
+        "evaluation_periods": 5,
+        "insufficient_data_actions": [
         ],
-        \\"metric_query\\": [
+        "metric_query": [
           {
-            \\"id\\": \\"requests\\",
-            \\"metric\\": {
-              \\"dimensions\\": {
-                \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+            "id": "requests",
+            "metric": {
+              "dimensions": {
+                "LoadBalancer": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}"
               },
-              \\"metric_name\\": \\"RequestCount\\",
-              \\"namespace\\": \\"AWS/ApplicationELB\\",
-              \\"period\\": 60,
-              \\"stat\\": \\"Sum\\",
-              \\"unit\\": \\"Count\\"
+              "metric_name": "RequestCount",
+              "namespace": "AWS/ApplicationELB",
+              "period": 60,
+              "stat": "Sum",
+              "unit": "Count"
             }
           },
           {
-            \\"id\\": \\"errors\\",
-            \\"metric\\": {
-              \\"dimensions\\": {
-                \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+            "id": "errors",
+            "metric": {
+              "dimensions": {
+                "LoadBalancer": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}"
               },
-              \\"metric_name\\": \\"HTTPCode_Target_5XX_Count\\",
-              \\"namespace\\": \\"AWS/ApplicationELB\\",
-              \\"period\\": 60,
-              \\"stat\\": \\"Sum\\",
-              \\"unit\\": \\"Count\\"
+              "metric_name": "HTTPCode_Target_5XX_Count",
+              "namespace": "AWS/ApplicationELB",
+              "period": 60,
+              "stat": "Sum",
+              "unit": "Count"
             }
           },
           {
-            \\"expression\\": \\"errors/requests*100\\",
-            \\"id\\": \\"expression\\",
-            \\"label\\": \\"HTTP 5xx Error Rate\\",
-            \\"return_data\\": true
+            "expression": "errors/requests*100",
+            "id": "expression",
+            "label": "HTTP 5xx Error Rate",
+            "return_data": true
           }
         ],
-        \\"ok_actions\\": [
+        "ok_actions": [
         ],
-        \\"threshold\\": 5
+        "threshold": 5
       },
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -4060,575 +4060,575 @@ exports[`PocketALBApplication renders an Pocket App with custom Alarm Descriptio
 
 exports[`PocketALBApplication renders an Pocket App with logs and dashboard in a specified region 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"central region\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"central region\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"central region\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"central region\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"central region\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"central region\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"central region\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"central region\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -4637,598 +4637,598 @@ exports[`PocketALBApplication renders an Pocket App with logs and dashboard in a
 
 exports[`PocketALBApplication renders an application alarms 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_alarm-httpresponsetime_327A4315\\": {
-        \\"alarm_actions\\": [
-          \\"sns-arn-for-latency\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_alarm-httpresponsetime_327A4315": {
+        "alarm_actions": [
+          "sns-arn-for-latency"
         ],
-        \\"alarm_description\\": \\"Average HTTP response time exceeds threshold\\",
-        \\"alarm_name\\": \\"testapp-Alarm-HTTPResponseTime\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 2,
-        \\"dimensions\\": {
-          \\"LoadBalancer\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\"
+        "alarm_description": "Average HTTP response time exceeds threshold",
+        "alarm_name": "testapp-Alarm-HTTPResponseTime",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 2,
+        "dimensions": {
+          "LoadBalancer": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 2,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"TargetResponseTime\\",
-        \\"namespace\\": \\"AWS/ApplicationELB\\",
-        \\"ok_actions\\": [
-          \\"sns-arn-for-latency\\"
+        "metric_name": "TargetResponseTime",
+        "namespace": "AWS/ApplicationELB",
+        "ok_actions": [
+          "sns-arn-for-latency"
         ],
-        \\"period\\": 300,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 0.5
+        "period": 300,
+        "statistic": "Average",
+        "threshold": 0.5
       },
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -5237,588 +5237,588 @@ exports[`PocketALBApplication renders an application alarms 1`] = `
 
 exports[`PocketALBApplication renders an application custom default alarms 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_alarm-custom_F535C2DE\\": {
-        \\"alarm_name\\": \\"testapp-Alarm-Custom\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"Test\\": \\"Alarm\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_alarm-custom_F535C2DE": {
+        "alarm_name": "testapp-Alarm-Custom",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "Test": "Alarm"
         },
-        \\"evaluation_periods\\": 1,
-        \\"metric_name\\": \\"Custom\\",
-        \\"namespace\\": \\"TM/Alarm\\",
-        \\"period\\": 300,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 500
+        "evaluation_periods": 1,
+        "metric_name": "Custom",
+        "namespace": "TM/Alarm",
+        "period": 300,
+        "statistic": "Sum",
+        "threshold": 500
       },
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -5827,635 +5827,635 @@ exports[`PocketALBApplication renders an application custom default alarms 1`] =
 
 exports[`PocketALBApplication renders an application with autoscaling group and tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1,
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1,
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\",
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude",
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "propagate_tags": "SERVICE",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -6464,575 +6464,575 @@ exports[`PocketALBApplication renders an application with autoscaling group and 
 
 exports[`PocketALBApplication renders an application with custom task sizes 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"8675\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "8675",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"309\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "309",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -7041,635 +7041,635 @@ exports[`PocketALBApplication renders an application with custom task sizes 1`] 
 
 exports[`PocketALBApplication renders an application with default autoscaling group and tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1,
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1,
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\",
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude",
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "propagate_tags": "SERVICE",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -7678,575 +7678,575 @@ exports[`PocketALBApplication renders an application with default autoscaling gr
 
 exports[`PocketALBApplication renders an application with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -8255,600 +8255,600 @@ exports[`PocketALBApplication renders an application with minimal config 1`] = `
 
 exports[`PocketALBApplication renders an application with modified container def protocol, cpu and memory reservation 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"testPocketApp_ecs_service_ecs-xray-daemon_55253A74\\": {
-        \\"name_prefix\\": \\"/ecs/testapp/xray-daemon\\",
-        \\"retention_in_days\\": 30
+    "aws_cloudwatch_log_group": {
+      "testPocketApp_ecs_service_ecs-xray-daemon_55253A74": {
+        "name_prefix": "/ecs/testapp/xray-daemon",
+        "retention_in_days": 30
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo-lifecyclepolicy_B1867100\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\"
+    "aws_ecr_lifecycle_policy": {
+      "testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo-lifecyclepolicy_B1867100": {
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"testapp-xray-daemon\\"
+        "name": "testapp-xray-daemon"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\",
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C",
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testPocketApp_ecs_service_ecs-xray-daemon_55253A74.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[{\\\\\\"hostPort\\\\\\":0,\\\\\\"containerPort\\\\\\":2000,\\\\\\"protocol\\\\\\":\\\\\\"udp\\\\\\"}],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":10,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":50,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"xray-daemon\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\"
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testPocketApp_ecs_service_ecs-xray-daemon_55253A74.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"hostPort\\":0,\\"containerPort\\":2000,\\"protocol\\":\\"udp\\"}],\\"linuxParameters\\":null,\\"cpu\\":10,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":50,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"xray-daemon\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C"
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -8857,691 +8857,691 @@ exports[`PocketALBApplication renders an application with modified container def
 
 exports[`PocketALBApplication renders an external application 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"direct.testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "direct.testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       },
-      \\"testPocketApp_cdn_certificate_F1CBB9BB\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+      "testPocketApp_cdn_certificate_F1CBB9BB": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       },
-      \\"testPocketApp_cdn_certificate_certificate_validation_BA2932DC\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_cdn_certificate_certificate_record_63BAB662\\",
-          \\"aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB\\"
+      "testPocketApp_cdn_certificate_certificate_validation_BA2932DC": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_cdn_certificate_certificate_record_63BAB662",
+          "aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_cdn_certificate_certificate_record_63BAB662.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_cdn_certificate_certificate_record_63BAB662.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": false,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": false,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_public_subnet_ids_01F0B902.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudfront_distribution\\": {
-      \\"testPocketApp_cloudfront_distribution_FD7F01BF\\": {
-        \\"aliases\\": [
-          \\"testing.bowling.gov\\"
+    "aws_cloudfront_distribution": {
+      "testPocketApp_cloudfront_distribution_FD7F01BF": {
+        "aliases": [
+          "testing.bowling.gov"
         ],
-        \\"comment\\": \\"CDN for direct.testing.bowling.gov\\",
-        \\"default_cache_behavior\\": {
-          \\"allowed_methods\\": [
-            \\"GET\\",
-            \\"HEAD\\",
-            \\"OPTIONS\\",
-            \\"PUT\\",
-            \\"POST\\",
-            \\"PATCH\\",
-            \\"DELETE\\"
+        "comment": "CDN for direct.testing.bowling.gov",
+        "default_cache_behavior": {
+          "allowed_methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS",
+            "PUT",
+            "POST",
+            "PATCH",
+            "DELETE"
           ],
-          \\"cached_methods\\": [
-            \\"GET\\",
-            \\"HEAD\\",
-            \\"OPTIONS\\"
+          "cached_methods": [
+            "GET",
+            "HEAD",
+            "OPTIONS"
           ],
-          \\"compress\\": true,
-          \\"default_ttl\\": 0,
-          \\"forwarded_values\\": {
-            \\"cookies\\": {
-              \\"forward\\": \\"none\\"
+          "compress": true,
+          "default_ttl": 0,
+          "forwarded_values": {
+            "cookies": {
+              "forward": "none"
             },
-            \\"headers\\": [
-              \\"Accept\\",
-              \\"Origin\\",
-              \\"Authorization\\"
+            "headers": [
+              "Accept",
+              "Origin",
+              "Authorization"
             ],
-            \\"query_string\\": true
+            "query_string": true
           },
-          \\"max_ttl\\": 31536000,
-          \\"min_ttl\\": 0,
-          \\"target_origin_id\\": \\"Alb\\",
-          \\"viewer_protocol_policy\\": \\"redirect-to-https\\"
+          "max_ttl": 31536000,
+          "min_ttl": 0,
+          "target_origin_id": "Alb",
+          "viewer_protocol_policy": "redirect-to-https"
         },
-        \\"enabled\\": true,
-        \\"origin\\": [
+        "enabled": true,
+        "origin": [
           {
-            \\"custom_origin_config\\": {
-              \\"http_port\\": 80,
-              \\"https_port\\": 443,
-              \\"origin_protocol_policy\\": \\"https-only\\",
-              \\"origin_ssl_protocols\\": [
-                \\"TLSv1.1\\",
-                \\"TLSv1.2\\"
+            "custom_origin_config": {
+              "http_port": 80,
+              "https_port": 443,
+              "origin_protocol_policy": "https-only",
+              "origin_ssl_protocols": [
+                "TLSv1.1",
+                "TLSv1.2"
               ]
             },
-            \\"domain_name\\": \\"\${aws_route53_record.testPocketApp_alb_record_7B56ED33.fqdn}\\",
-            \\"origin_id\\": \\"Alb\\"
+            "domain_name": "\${aws_route53_record.testPocketApp_alb_record_7B56ED33.fqdn}",
+            "origin_id": "Alb"
           }
         ],
-        \\"price_class\\": \\"PriceClass_200\\",
-        \\"restrictions\\": {
-          \\"geo_restriction\\": {
-            \\"restriction_type\\": \\"none\\"
+        "price_class": "PriceClass_200",
+        "restrictions": {
+          "geo_restriction": {
+            "restriction_type": "none"
           }
         },
-        \\"viewer_certificate\\": {
-          \\"acm_certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.arn}\\",
-          \\"minimum_protocol_version\\": \\"TLSv1.1_2016\\",
-          \\"ssl_support_method\\": \\"sni-only\\"
+        "viewer_certificate": {
+          "acm_certificate_arn": "\${aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.arn}",
+          "minimum_protocol_version": "TLSv1.1_2016",
+          "ssl_support_method": "sni-only"
         }
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"direct.testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "direct.testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       },
-      \\"testPocketApp_cdn_certificate_certificate_record_63BAB662\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB\\"
+      "testPocketApp_cdn_certificate_certificate_record_63BAB662": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_cdn_certificate_F1CBB9BB.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_cdn_record_DD10AA15\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_cloudfront_distribution.testPocketApp_cloudfront_distribution_FD7F01BF.domain_name}\\",
-          \\"zone_id\\": \\"\${aws_cloudfront_distribution.testPocketApp_cloudfront_distribution_FD7F01BF.hosted_zone_id}\\"
+      "testPocketApp_cdn_record_DD10AA15": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_cloudfront_distribution.testPocketApp_cloudfront_distribution_FD7F01BF.domain_name}",
+          "zone_id": "\${aws_cloudfront_distribution.testPocketApp_cloudfront_distribution_FD7F01BF.hosted_zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"2\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "2",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -9550,575 +9550,575 @@ exports[`PocketALBApplication renders an external application 1`] = `
 
 exports[`PocketALBApplication renders an internal application 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": true,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": true,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP"
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01"
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -10127,635 +10127,635 @@ exports[`PocketALBApplication renders an internal application 1`] = `
 
 exports[`PocketALBApplication renders an internal application with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_main_hosted_zone_9442EEB0\\": {
-        \\"name\\": \\"bowling.gov\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_main_hosted_zone_9442EEB0": {
+        "name": "bowling.gov"
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"testPocketApp_alb_certificate_417C14FF\\": {
-        \\"domain_name\\": \\"testing.bowling.gov\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "testPocketApp_alb_certificate_417C14FF": {
+        "domain_name": "testing.bowling.gov",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"testPocketApp_alb_certificate_certificate_validation_7D899C6A\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F\\",
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_acm_certificate_validation": {
+      "testPocketApp_alb_certificate_certificate_validation_7D899C6A": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "depends_on": [
+          "aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F",
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.testPocketApp_alb_certificate_certificate_record_3C49201F.fqdn}"
         ]
       }
     },
-    \\"aws_alb\\": {
-      \\"testPocketApp_application_load_balancer_alb_D538DEEE\\": {
-        \\"internal\\": true,
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"security_groups\\": [
-          \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+    "aws_alb": {
+      "testPocketApp_application_load_balancer_alb_D538DEEE": {
+        "internal": true,
+        "name_prefix": "TSTAPP",
+        "security_groups": [
+          "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
         ],
-        \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_listener\\": {
-      \\"testPocketApp_listener_http_A9E227C2\\": {
-        \\"default_action\\": [
+    "aws_alb_listener": {
+      "testPocketApp_listener_http_A9E227C2": {
+        "default_action": [
           {
-            \\"redirect\\": {
-              \\"port\\": \\"443\\",
-              \\"protocol\\": \\"HTTPS\\",
-              \\"status_code\\": \\"HTTP_301\\"
+            "redirect": {
+              "port": "443",
+              "protocol": "HTTPS",
+              "status_code": "HTTP_301"
             },
-            \\"type\\": \\"redirect\\"
+            "type": "redirect"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_listener_https_7F49DE83\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}\\",
-        \\"default_action\\": [
+      "testPocketApp_listener_https_7F49DE83": {
+        "certificate_arn": "\${aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.arn}",
+        "default_action": [
           {
-            \\"fixed_response\\": {
-              \\"content_type\\": \\"text/plain\\",
-              \\"message_body\\": \\"\\",
-              \\"status_code\\": \\"503\\"
+            "fixed_response": {
+              "content_type": "text/plain",
+              "message_body": "",
+              "status_code": "503"
             },
-            \\"type\\": \\"fixed-response\\"
+            "type": "fixed-response"
           }
         ],
-        \\"load_balancer_arn\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}\\",
-        \\"port\\": 443,
-        \\"protocol\\": \\"HTTPS\\",
-        \\"ssl_policy\\": \\"ELBSecurityPolicy-TLS-1-1-2017-01\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "load_balancer_arn": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn}",
+        "port": 443,
+        "protocol": "HTTPS",
+        "ssl_policy": "ELBSecurityPolicy-TLS-1-1-2017-01",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_listener_rule\\": {
-      \\"testPocketApp_ecs_service_listener_rule_C03BB04D\\": {
-        \\"action\\": [
+    "aws_alb_listener_rule": {
+      "testPocketApp_ecs_service_listener_rule_C03BB04D": {
+        "action": [
           {
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\",
-            \\"type\\": \\"forward\\"
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}",
+            "type": "forward"
           }
         ],
-        \\"condition\\": [
+        "condition": [
           {
-            \\"path_pattern\\": {
-              \\"values\\": [
-                \\"*\\"
+            "path_pattern": {
+              "values": [
+                "*"
               ]
             }
           }
         ],
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"action\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "action"
           ]
         },
-        \\"listener_arn\\": \\"\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}\\",
-        \\"priority\\": 1,
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "listener_arn": "\${aws_alb_listener.testPocketApp_listener_https_7F49DE83.arn}",
+        "priority": 1,
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_alb_target_group\\": {
-      \\"testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\": {
-        \\"deregistration_delay\\": \\"120\\",
-        \\"health_check\\": {
-          \\"healthy_threshold\\": 5,
-          \\"interval\\": 15,
-          \\"path\\": \\"/test\\",
-          \\"protocol\\": \\"HTTP\\",
-          \\"unhealthy_threshold\\": 3
+    "aws_alb_target_group": {
+      "testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885": {
+        "deregistration_delay": "120",
+        "health_check": {
+          "healthy_threshold": 5,
+          "interval": 15,
+          "path": "/test",
+          "protocol": "HTTP",
+          "unhealthy_threshold": 3
         },
-        \\"name_prefix\\": \\"TSTAPP\\",
-        \\"port\\": 80,
-        \\"protocol\\": \\"HTTP\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\",
-          \\"type\\": \\"blue\\"
+        "name_prefix": "TSTAPP",
+        "port": 80,
+        "protocol": "HTTP",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude",
+          "type": "blue"
         },
-        \\"target_type\\": \\"ip\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "target_type": "ip",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     },
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_Target_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_Target_2XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#2ca02c\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"Target Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":0,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"HTTPCode_ELB_4XX_Count\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"left\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ff7f0e\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"RequestCount\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#1f77b4\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"HTTPCode_ELB_5XX_Count\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#d62728\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"stat\\\\\\":\\\\\\"Sum\\\\\\",\\\\\\"title\\\\\\":\\\\\\"ALB Requests\\\\\\"}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":12,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"AWS/ApplicationELB\\\\\\",\\\\\\"TargetResponseTime\\\\\\",\\\\\\"LoadBalancer\\\\\\",\\\\\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\\\\\",{\\\\\\"label\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#aec7e8\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p95\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#ffbb78\\\\\\"}],[\\\\\\"...\\\\\\",{\\\\\\"stat\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"label\\\\\\":\\\\\\"p99\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#98df8a\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60}},{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_Target_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}],[\\".\\",\\"HTTPCode_Target_2XX_Count\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#2ca02c\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"Target Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":0,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_4XX_Count\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"yAxis\\":\\"left\\",\\"color\\":\\"#ff7f0e\\"}],[\\".\\",\\"RequestCount\\",\\".\\",\\".\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#1f77b4\\"}],[\\".\\",\\"HTTPCode_ELB_5XX_Count\\",\\".\\",\\".\\",{\\"color\\":\\"#d62728\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"period\\":60,\\"stat\\":\\"Sum\\",\\"title\\":\\"ALB Requests\\"}},{\\"type\\":\\"metric\\",\\"x\\":12,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"TargetResponseTime\\",\\"LoadBalancer\\",\\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.arn_suffix}\\",{\\"label\\":\\"Average\\",\\"color\\":\\"#aec7e8\\"}],[\\"...\\",{\\"stat\\":\\"p95\\",\\"label\\":\\"p95\\",\\"color\\":\\"#ffbb78\\"}],[\\"...\\",{\\"stat\\":\\"p99\\",\\"label\\":\\"p99\\",\\"color\\":\\"#98df8a\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60}},{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885\\",
-          \\"aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885",
+          "aws_alb_listener_rule.testPocketApp_ecs_service_listener_rule_C03BB04D"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
           {
-            \\"container_name\\": \\"main_container\\",
-            \\"container_port\\": 8675309,
-            \\"target_group_arn\\": \\"\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}\\"
+            "container_name": "main_container",
+            "container_port": 8675309,
+            "target_group_arn": "\${aws_alb_target_group.testPocketApp_ecs_service_blue_target_group_ecs_target_group_A4B85885.arn}"
           }
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "propagate_tags": "SERVICE",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_route53_record\\": {
-      \\"testPocketApp_alb_certificate_certificate_record_3C49201F\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.testPocketApp_alb_certificate_417C14FF\\"
+    "aws_route53_record": {
+      "testPocketApp_alb_certificate_certificate_record_3C49201F": {
+        "depends_on": [
+          "aws_acm_certificate.testPocketApp_alb_certificate_417C14FF"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.testPocketApp_alb_certificate_417C14FF.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_alb_record_7B56ED33\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}\\",
-          \\"zone_id\\": \\"\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}\\"
+      "testPocketApp_alb_record_7B56ED33": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.dns_name}",
+          "zone_id": "\${aws_alb.testPocketApp_application_load_balancer_alb_D538DEEE.zone_id}"
         },
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"weighted_routing_policy[0].weight\\"
+        "lifecycle": {
+          "ignore_changes": [
+            "weighted_routing_policy[0].weight"
           ]
         },
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"set_identifier\\": \\"1\\",
-        \\"type\\": \\"A\\",
-        \\"weighted_routing_policy\\": {
-          \\"weight\\": 1
+        "name": "testing.bowling.gov",
+        "set_identifier": "1",
+        "type": "A",
+        "weighted_routing_policy": {
+          "weight": 1
         },
-        \\"zone_id\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}\\"
+        "zone_id": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.zone_id}"
       },
-      \\"testPocketApp_base_dns_subhosted_zone_ns_497FFB83\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"records\\": \\"\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}\\"
+      "testPocketApp_base_dns_subhosted_zone_ns_497FFB83": {
+        "name": "testing.bowling.gov",
+        "records": "\${aws_route53_zone.testPocketApp_base_dns_subhosted_zone_1E1E3243.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.testPocketApp_base_dns_main_hosted_zone_9442EEB0.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"testPocketApp_base_dns_subhosted_zone_1E1E3243\\": {
-        \\"name\\": \\"testing.bowling.gov\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_route53_zone": {
+      "testPocketApp_base_dns_subhosted_zone_1E1E3243": {
+        "name": "testing.bowling.gov",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_application_load_balancer_alb_security_group_91A27046\\": {
-        \\"description\\": \\"External security group  (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_application_load_balancer_alb_security_group_91A27046": {
+        "description": "External security group  (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 443,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 443
+            "description": null,
+            "from_port": 443,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 443
           },
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": null,
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": null,
-            \\"prefix_list_ids\\": null,
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": null,
-            \\"self\\": null,
-            \\"to_port\\": 80
+            "description": null,
+            "from_port": 80,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "TCP",
+            "security_groups": null,
+            "self": null,
+            "to_port": 80
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-HTTP/S Security Group\\",
-        \\"tags\\": {
-          \\"Name\\": \\"testapp-HTTP/S Security Group\\",
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-HTTP/S Security Group",
+        "tags": {
+          "Name": "testapp-HTTP/S Security Group",
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       },
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
           {
-            \\"cidr_blocks\\": [
+            "cidr_blocks": [
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 80,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"TCP\\",
-            \\"security_groups\\": [
-              \\"\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}\\"
+            "protocol": "TCP",
+            "security_groups": [
+              "\${aws_security_group.testPocketApp_application_load_balancer_alb_security_group_91A27046.id}"
             ],
-            \\"self\\": null,
-            \\"to_port\\": 8675309
+            "self": null,
+            "to_port": 8675309
           }
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketApiGatewayLambdaIntegration.spec.ts.snap
@@ -2,284 +2,284 @@
 
 exports[`PocketApiGatewayLambdaIntegration renders an api gateway with a lambda integration 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-api-lambda_endpoint-lambda_assume-policy-document_345E1069\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-api-lambda_endpoint-lambda_assume-policy-document_345E1069": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-api-lambda_endpoint-lambda_execution-policy-document_4437ECD0\\": {
-        \\"statement\\": [
+      "test-api-lambda_endpoint-lambda_execution-policy-document_4437ECD0": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"test-api-lambda_base-dns_main_hosted_zone_5F97294A\\": {
-        \\"name\\": \\"getpocket.dev\\"
+    "aws_route53_zone": {
+      "test-api-lambda_base-dns_main_hosted_zone_5F97294A": {
+        "name": "getpocket.dev"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_acm_certificate\\": {
-      \\"test-api-lambda_api-gateway-certificate_8D77B940\\": {
-        \\"domain_name\\": \\"exampleapi.getpocket.dev\\",
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+  "resource": {
+    "aws_acm_certificate": {
+      "test-api-lambda_api-gateway-certificate_8D77B940": {
+        "domain_name": "exampleapi.getpocket.dev",
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"validation_method\\": \\"DNS\\"
+        "validation_method": "DNS"
       }
     },
-    \\"aws_acm_certificate_validation\\": {
-      \\"test-api-lambda_api-gateway-certificate_certificate_validation_6C09E593\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_route53_record.test-api-lambda_api-gateway-certificate_certificate_record_BED7C8FC\\",
-          \\"aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940\\"
+    "aws_acm_certificate_validation": {
+      "test-api-lambda_api-gateway-certificate_certificate_validation_6C09E593": {
+        "certificate_arn": "\${aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.arn}",
+        "depends_on": [
+          "aws_route53_record.test-api-lambda_api-gateway-certificate_certificate_record_BED7C8FC",
+          "aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940"
         ],
-        \\"validation_record_fqdns\\": [
-          \\"\${aws_route53_record.test-api-lambda_api-gateway-certificate_certificate_record_BED7C8FC.fqdn}\\"
+        "validation_record_fqdns": [
+          "\${aws_route53_record.test-api-lambda_api-gateway-certificate_certificate_record_BED7C8FC.fqdn}"
         ]
       }
     },
-    \\"aws_api_gateway_base_path_mapping\\": {
-      \\"test-api-lambda_api-gateway-base-path-mapping_CC4D8627\\": {
-        \\"api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\",
-        \\"base_path\\": \\"fxaProxy\\",
-        \\"domain_name\\": \\"\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.domain_name}\\",
-        \\"stage_name\\": \\"\${aws_api_gateway_stage.api-gateway-stage.stage_name}\\"
+    "aws_api_gateway_base_path_mapping": {
+      "test-api-lambda_api-gateway-base-path-mapping_CC4D8627": {
+        "api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}",
+        "base_path": "fxaProxy",
+        "domain_name": "\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.domain_name}",
+        "stage_name": "\${aws_api_gateway_stage.api-gateway-stage.stage_name}"
       }
     },
-    \\"aws_api_gateway_deployment\\": {
-      \\"api-gateway-deployment\\": {
-        \\"depends_on\\": [
-          \\"aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8\\",
-          \\"aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A\\",
-          \\"aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1\\",
-          \\"aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8\\"
+    "aws_api_gateway_deployment": {
+      "api-gateway-deployment": {
+        "depends_on": [
+          "aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8",
+          "aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A",
+          "aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1",
+          "aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8"
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\",
-        \\"triggers\\": {
-          \\"deployedAt\\": \\"1637693316456\\",
-          \\"redeployment\\": \\"\${sha1(jsonencode({\\\\\\"resources\\\\\\" = [aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8.id, aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.id, aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id, aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.id]}))}\\"
+        "rest_api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}",
+        "triggers": {
+          "deployedAt": "1637693316456",
+          "redeployment": "\${sha1(jsonencode({\\"resources\\" = [aws_api_gateway_integration.test-api-lambda_endpoint-integration_8D80A8F8.id, aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.id, aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id, aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.id]}))}"
         }
       }
     },
-    \\"aws_api_gateway_domain_name\\": {
-      \\"test-api-lambda_api-gateway-domain-name_6DBA5B05\\": {
-        \\"certificate_arn\\": \\"\${aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_acm_certificate_validation.test-api-lambda_api-gateway-certificate_certificate_validation_6C09E593\\"
+    "aws_api_gateway_domain_name": {
+      "test-api-lambda_api-gateway-domain-name_6DBA5B05": {
+        "certificate_arn": "\${aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.arn}",
+        "depends_on": [
+          "aws_acm_certificate_validation.test-api-lambda_api-gateway-certificate_certificate_validation_6C09E593"
         ],
-        \\"domain_name\\": \\"exampleapi.getpocket.dev\\"
+        "domain_name": "exampleapi.getpocket.dev"
       }
     },
-    \\"aws_api_gateway_integration\\": {
-      \\"test-api-lambda_endpoint-integration_8D80A8F8\\": {
-        \\"http_method\\": \\"POST\\",
-        \\"integration_http_method\\": \\"POST\\",
-        \\"resource_id\\": \\"\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id}\\",
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\",
-        \\"type\\": \\"AWS_PROXY\\",
-        \\"uri\\": \\"\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.invoke_arn}\\"
+    "aws_api_gateway_integration": {
+      "test-api-lambda_endpoint-integration_8D80A8F8": {
+        "http_method": "POST",
+        "integration_http_method": "POST",
+        "resource_id": "\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id}",
+        "rest_api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}",
+        "type": "AWS_PROXY",
+        "uri": "\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.invoke_arn}"
       }
     },
-    \\"aws_api_gateway_method\\": {
-      \\"test-api-lambda_endpoint-method_B2F73D1A\\": {
-        \\"authorization\\": \\"NONE\\",
-        \\"http_method\\": \\"POST\\",
-        \\"resource_id\\": \\"\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id}\\",
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\"
+    "aws_api_gateway_method": {
+      "test-api-lambda_endpoint-method_B2F73D1A": {
+        "authorization": "NONE",
+        "http_method": "POST",
+        "resource_id": "\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.id}",
+        "rest_api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}"
       }
     },
-    \\"aws_api_gateway_resource\\": {
-      \\"test-api-lambda_endpoint_02B05EB1\\": {
-        \\"parent_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.root_resource_id}\\",
-        \\"path_part\\": \\"endpoint\\",
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\"
+    "aws_api_gateway_resource": {
+      "test-api-lambda_endpoint_02B05EB1": {
+        "parent_id": "\${aws_api_gateway_rest_api.api-gateway-rest.root_resource_id}",
+        "path_part": "endpoint",
+        "rest_api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}"
       }
     },
-    \\"aws_api_gateway_rest_api\\": {
-      \\"api-gateway-rest\\": {
-        \\"name\\": \\"test-api-lambda\\"
+    "aws_api_gateway_rest_api": {
+      "api-gateway-rest": {
+        "name": "test-api-lambda"
       }
     },
-    \\"aws_api_gateway_stage\\": {
-      \\"api-gateway-stage\\": {
-        \\"deployment_id\\": \\"\${aws_api_gateway_deployment.api-gateway-deployment.id}\\",
-        \\"rest_api_id\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.id}\\",
-        \\"stage_name\\": \\"test\\"
+    "aws_api_gateway_stage": {
+      "api-gateway-stage": {
+        "deployment_id": "\${aws_api_gateway_deployment.api-gateway-deployment.id}",
+        "rest_api_id": "\${aws_api_gateway_rest_api.api-gateway-rest.id}",
+        "stage_name": "test"
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-api-lambda_endpoint-lambda_log-group_E143678F\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964\\"
+    "aws_cloudwatch_log_group": {
+      "test-api-lambda_endpoint-lambda_log-group_E143678F": {
+        "depends_on": [
+          "aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-api-lambda_endpoint-lambda_execution-policy_6847E583\\": {
-        \\"name\\": \\"lambda-endpoint-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-api-lambda_endpoint-lambda_execution-policy-document_4437ECD0.json}\\"
+    "aws_iam_policy": {
+      "test-api-lambda_endpoint-lambda_execution-policy_6847E583": {
+        "name": "lambda-endpoint-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-api-lambda_endpoint-lambda_execution-policy-document_4437ECD0.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-api-lambda_endpoint-lambda_execution-role_46759F27\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-api-lambda_endpoint-lambda_assume-policy-document_345E1069.json}\\",
-        \\"name\\": \\"lambda-endpoint-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-api-lambda_endpoint-lambda_execution-role_46759F27": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-api-lambda_endpoint-lambda_assume-policy-document_345E1069.json}",
+        "name": "lambda-endpoint-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-api-lambda_endpoint-lambda_execution-role-policy-attachment_5BF51F3C\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27\\",
-          \\"aws_iam_policy.test-api-lambda_endpoint-lambda_execution-policy_6847E583\\"
+    "aws_iam_role_policy_attachment": {
+      "test-api-lambda_endpoint-lambda_execution-role-policy-attachment_5BF51F3C": {
+        "depends_on": [
+          "aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27",
+          "aws_iam_policy.test-api-lambda_endpoint-lambda_execution-policy_6847E583"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-api-lambda_endpoint-lambda_execution-policy_6847E583.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-api-lambda_endpoint-lambda_execution-policy_6847E583.arn}",
+        "role": "\${aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-api-lambda_endpoint-lambda_alias_A14F4FF8\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964\\"
+    "aws_lambda_alias": {
+      "test-api-lambda_endpoint-lambda_alias_A14F4FF8": {
+        "depends_on": [
+          "aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-api-lambda_endpoint-lambda_3FA91964.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-api-lambda_endpoint-lambda_3FA91964\\": {
-        \\"filename\\": \\"\${data.archive_file.test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136.output_path}\\",
-        \\"function_name\\": \\"lambda-endpoint-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-api-lambda_endpoint-lambda_3FA91964": {
+        "filename": "\${data.archive_file.test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136.output_path}",
+        "function_name": "lambda-endpoint-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-api-lambda_endpoint-lambda_execution-role_46759F27.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-api-lambda_endpoint-lambda_lambda-default-file_8FD40136.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_lambda_permission\\": {
-      \\"test-api-lambda_test-api-lambda_endpoint-lambda_alias_A14F4FF8-allow-gateway-lambda-invoke_F4009ED6\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"function_name\\": \\"\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.function_name}\\",
-        \\"principal\\": \\"apigateway.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.name}\\",
-        \\"source_arn\\": \\"\${aws_api_gateway_rest_api.api-gateway-rest.execution_arn}/\${aws_api_gateway_stage.api-gateway-stage.stage_name}/\${aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.http_method}\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.path}\\"
+    "aws_lambda_permission": {
+      "test-api-lambda_test-api-lambda_endpoint-lambda_alias_A14F4FF8-allow-gateway-lambda-invoke_F4009ED6": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.function_name}",
+        "principal": "apigateway.amazonaws.com",
+        "qualifier": "\${aws_lambda_alias.test-api-lambda_endpoint-lambda_alias_A14F4FF8.name}",
+        "source_arn": "\${aws_api_gateway_rest_api.api-gateway-rest.execution_arn}/\${aws_api_gateway_stage.api-gateway-stage.stage_name}/\${aws_api_gateway_method.test-api-lambda_endpoint-method_B2F73D1A.http_method}\${aws_api_gateway_resource.test-api-lambda_endpoint_02B05EB1.path}"
       }
     },
-    \\"aws_route53_record\\": {
-      \\"test-api-lambda_api-gateway-certificate_certificate_record_BED7C8FC\\": {
-        \\"depends_on\\": [
-          \\"aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940\\"
+    "aws_route53_record": {
+      "test-api-lambda_api-gateway-certificate_certificate_record_BED7C8FC": {
+        "depends_on": [
+          "aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940"
         ],
-        \\"name\\": \\"\${tolist(aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.domain_validation_options).0.resource_record_name}\\",
-        \\"records\\": [
-          \\"\${tolist(aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.domain_validation_options).0.resource_record_value}\\"
+        "name": "\${tolist(aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.domain_validation_options).0.resource_record_name}",
+        "records": [
+          "\${tolist(aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.domain_validation_options).0.resource_record_value}"
         ],
-        \\"ttl\\": 60,
-        \\"type\\": \\"\${tolist(aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.domain_validation_options).0.resource_record_type}\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.test-api-lambda_base-dns_subhosted_zone_B29688D6.zone_id}\\"
+        "ttl": 60,
+        "type": "\${tolist(aws_acm_certificate.test-api-lambda_api-gateway-certificate_8D77B940.domain_validation_options).0.resource_record_type}",
+        "zone_id": "\${aws_route53_zone.test-api-lambda_base-dns_subhosted_zone_B29688D6.zone_id}"
       },
-      \\"test-api-lambda_apigateway-route53-domain-record_A8180A05\\": {
-        \\"alias\\": {
-          \\"evaluate_target_health\\": true,
-          \\"name\\": \\"\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.cloudfront_domain_name}\\",
-          \\"zone_id\\": \\"\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.cloudfront_zone_id}\\"
+      "test-api-lambda_apigateway-route53-domain-record_A8180A05": {
+        "alias": {
+          "evaluate_target_health": true,
+          "name": "\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.cloudfront_domain_name}",
+          "zone_id": "\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.cloudfront_zone_id}"
         },
-        \\"depends_on\\": [
-          \\"aws_acm_certificate_validation.test-api-lambda_api-gateway-certificate_certificate_validation_6C09E593\\"
+        "depends_on": [
+          "aws_acm_certificate_validation.test-api-lambda_api-gateway-certificate_certificate_validation_6C09E593"
         ],
-        \\"name\\": \\"\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.domain_name}\\",
-        \\"type\\": \\"A\\",
-        \\"zone_id\\": \\"\${aws_route53_zone.test-api-lambda_base-dns_subhosted_zone_B29688D6.zone_id}\\"
+        "name": "\${aws_api_gateway_domain_name.test-api-lambda_api-gateway-domain-name_6DBA5B05.domain_name}",
+        "type": "A",
+        "zone_id": "\${aws_route53_zone.test-api-lambda_base-dns_subhosted_zone_B29688D6.zone_id}"
       },
-      \\"test-api-lambda_base-dns_subhosted_zone_ns_B7A2A51A\\": {
-        \\"name\\": \\"exampleapi.getpocket.dev\\",
-        \\"records\\": \\"\${aws_route53_zone.test-api-lambda_base-dns_subhosted_zone_B29688D6.name_servers}\\",
-        \\"ttl\\": 86400,
-        \\"type\\": \\"NS\\",
-        \\"zone_id\\": \\"\${data.aws_route53_zone.test-api-lambda_base-dns_main_hosted_zone_5F97294A.zone_id}\\"
+      "test-api-lambda_base-dns_subhosted_zone_ns_B7A2A51A": {
+        "name": "exampleapi.getpocket.dev",
+        "records": "\${aws_route53_zone.test-api-lambda_base-dns_subhosted_zone_B29688D6.name_servers}",
+        "ttl": 86400,
+        "type": "NS",
+        "zone_id": "\${data.aws_route53_zone.test-api-lambda_base-dns_main_hosted_zone_5F97294A.zone_id}"
       }
     },
-    \\"aws_route53_zone\\": {
-      \\"test-api-lambda_base-dns_subhosted_zone_B29688D6\\": {
-        \\"name\\": \\"exampleapi.getpocket.dev\\"
+    "aws_route53_zone": {
+      "test-api-lambda_base-dns_subhosted_zone_B29688D6": {
+        "name": "exampleapi.getpocket.dev"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-api-lambda_endpoint-lambda_code-bucket_8153D419\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-lambda-endpoint\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-api-lambda_endpoint-lambda_code-bucket_8153D419": {
+        "acl": "private",
+        "bucket": "pocket-lambda-endpoint",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-api-lambda_endpoint-lambda_code-bucket-public-access-block_704E5627\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-api-lambda_endpoint-lambda_code-bucket_8153D419.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-api-lambda_endpoint-lambda_code-bucket-public-access-block_704E5627": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-api-lambda_endpoint-lambda_code-bucket_8153D419.id}"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketCloudwatchSynthetics.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketCloudwatchSynthetics.spec.ts.snap
@@ -2,234 +2,234 @@
 
 exports[`Pocket Cloudwatch Synthetics adds optional Alarms & Alarm Actions to Synthetic Checks  1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_access_C1AC681E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-synthetics_test-synthetics_synthetic_check_access_C1AC681E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:PutObject\\",
-              \\"s3:GetObject\\"
+            "actions": [
+              "s3:PutObject",
+              "s3:GetObject"
             ],
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}/*\\"
+            "resources": [
+              "\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\"
+            "actions": [
+              "s3:GetObject"
             ],
-            \\"resources\\": [
-              \\"arn:aws:s3:::pocket-syntheticchecks-dev/*\\"
+            "resources": [
+              "arn:aws:s3:::pocket-syntheticchecks-dev/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetBucketLocation\\"
+            "actions": [
+              "s3:GetBucketLocation"
             ],
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}\\"
+            "resources": [
+              "\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:ListAllMyBuckets\\"
+            "actions": [
+              "s3:ListAllMyBuckets"
             ],
-            \\"resources\\": [
-              \\"*\\"
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"cloudwatch:PutMetricData\\"
+            "actions": [
+              "cloudwatch:PutMetricData"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEquals\\",
-                \\"values\\": [
-                  \\"CloudWatchSynthetics\\"
+                "test": "StringEquals",
+                "values": [
+                  "CloudWatchSynthetics"
                 ],
-                \\"variable\\": \\"cloudwatch:namespace\\"
+                "variable": "cloudwatch:namespace"
               }
             ],
-            \\"resources\\": [
-              \\"*\\"
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ec2:AttachNetworkInterface\\",
-              \\"ec2:CreateNetworkInterface\\",
-              \\"ec2:DeleteNetworkInterface\\",
-              \\"ec2:DescribeNetworkInterfaces\\"
+            "actions": [
+              "ec2:AttachNetworkInterface",
+              "ec2:CreateNetworkInterface",
+              "ec2:DeleteNetworkInterface",
+              "ec2:DescribeNetworkInterfaces"
             ],
-            \\"resources\\": [
-              \\"*\\"
+            "resources": [
+              "*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4\\": {
-        \\"statement\\": [
+      "test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_alarm_query_0_161FA4E1\\": {
-        \\"alarm_actions\\": [
-          \\"arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic\\"
+  "resource": {
+    "aws_cloudwatch_metric_alarm": {
+      "test-synthetics_test-synthetics_synthetic_check_alarm_query_0_161FA4E1": {
+        "alarm_actions": [
+          "arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic"
         ],
-        \\"alarm_description\\": \\"Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name} canary success percentage has decreased below 66% in the last 15 minutes\\",
-        \\"alarm_name\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"CanaryName\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}\\"
+        "alarm_description": "Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name} canary success percentage has decreased below 66% in the last 15 minutes",
+        "alarm_name": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "CanaryName": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}"
         },
-        \\"evaluation_periods\\": 3,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 3,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"SuccessPercent\\",
-        \\"namespace\\": \\"CloudWatchSynthetics\\",
-        \\"ok_actions\\": [
-          \\"arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic\\"
+        "metric_name": "SuccessPercent",
+        "namespace": "CloudWatchSynthetics",
+        "ok_actions": [
+          "arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic"
         ],
-        \\"period\\": 300,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 66,
-        \\"treat_missing_data\\": \\"breaching\\"
+        "period": 300,
+        "statistic": "Average",
+        "threshold": 66,
+        "treat_missing_data": "breaching"
       },
-      \\"test-synthetics_test-synthetics_synthetic_check_alarm_uptime_0_47F383EB\\": {
-        \\"alarm_actions\\": [
-          \\"arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic\\"
+      "test-synthetics_test-synthetics_synthetic_check_alarm_uptime_0_47F383EB": {
+        "alarm_actions": [
+          "arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic"
         ],
-        \\"alarm_description\\": \\"Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name} canary success percentage has decreased below 66% in the last 15 minutes\\",
-        \\"alarm_name\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"CanaryName\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}\\"
+        "alarm_description": "Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name} canary success percentage has decreased below 66% in the last 15 minutes",
+        "alarm_name": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "CanaryName": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}"
         },
-        \\"evaluation_periods\\": 3,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 3,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"SuccessPercent\\",
-        \\"namespace\\": \\"CloudWatchSynthetics\\",
-        \\"ok_actions\\": [
-          \\"arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic\\"
+        "metric_name": "SuccessPercent",
+        "namespace": "CloudWatchSynthetics",
+        "ok_actions": [
+          "arn:aws:sns:us-east-1:123456789101:Test-Sns-Topic"
         ],
-        \\"period\\": 300,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 66,
-        \\"treat_missing_data\\": \\"breaching\\"
+        "period": 300,
+        "statistic": "Average",
+        "threshold": 66,
+        "treat_missing_data": "breaching"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7\\": {
-        \\"name\\": \\"pocket-acme-dev-synthetic-check-access\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_access_C1AC681E.json}\\"
+    "aws_iam_policy": {
+      "test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7": {
+        "name": "pocket-acme-dev-synthetic-check-access",
+        "policy": "\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_access_C1AC681E.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-synthetics_synthetic_check_role_B358E7A9\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4.json}\\",
-        \\"name\\": \\"pocket-acme-dev-synthetic-check\\"
+    "aws_iam_role": {
+      "test-synthetics_synthetic_check_role_B358E7A9": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4.json}",
+        "name": "pocket-acme-dev-synthetic-check"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_access_attach_4D7F0A0A\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "test-synthetics_test-synthetics_synthetic_check_access_attach_4D7F0A0A": {
+        "policy_arn": "\${aws_iam_policy.test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7.arn}",
+        "role": "\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96\\": {
-        \\"bucket\\": \\"pocket-acme-dev-synthetic-checks\\"
+    "aws_s3_bucket": {
+      "test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96": {
+        "bucket": "pocket-acme-dev-synthetic-checks"
       }
     },
-    \\"aws_s3_bucket_lifecycle_configuration\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_artifacts_lifecycle_4D55C3CA\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.id}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_lifecycle_configuration": {
+      "test-synthetics_test-synthetics_synthetic_check_artifacts_lifecycle_4D55C3CA": {
+        "bucket": "\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.id}",
+        "rule": [
           {
-            \\"expiration\\": {
-              \\"days\\": 30
+            "expiration": {
+              "days": 30
             },
-            \\"id\\": \\"30-day-retention\\",
-            \\"status\\": \\"Enabled\\"
+            "id": "30-day-retention",
+            "status": "Enabled"
           }
         ]
       }
     },
-    \\"aws_synthetics_canary\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3\\": {
-        \\"artifact_s3_location\\": \\"s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/\\",
-        \\"execution_role_arn\\": \\"\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}\\",
-        \\"handler\\": \\"synthetic.query\\",
-        \\"name\\": \\"acme-dev-query-0\\",
-        \\"run_config\\": {
-          \\"environment_variables\\": {
-            \\"GRAPHQL_ENDPOINT\\": \\"acme.getpocket.dev\\",
-            \\"GRAPHQL_JMESPATH\\": \\"errors[0].message\\",
-            \\"GRAPHQL_QUERY\\": \\"{\\\\\\"query\\\\\\": \\\\\\"query { someGraphQlQuery(arg1: \\\\\\\\\\\\\\"1\\\\\\\\\\\\\\", arg2: \\\\\\\\\\\\\\"1\\\\\\\\\\\\\\") {returnedAttr} }\\\\\\"}\\",
-            \\"GRAPHQL_RESPONSE\\": \\"Error - Not Found: A resource by that arg1 could not be found\\"
+    "aws_synthetics_canary": {
+      "test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3": {
+        "artifact_s3_location": "s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/",
+        "execution_role_arn": "\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}",
+        "handler": "synthetic.query",
+        "name": "acme-dev-query-0",
+        "run_config": {
+          "environment_variables": {
+            "GRAPHQL_ENDPOINT": "acme.getpocket.dev",
+            "GRAPHQL_JMESPATH": "errors[0].message",
+            "GRAPHQL_QUERY": "{\\"query\\": \\"query { someGraphQlQuery(arg1: \\\\\\"1\\\\\\", arg2: \\\\\\"1\\\\\\") {returnedAttr} }\\"}",
+            "GRAPHQL_RESPONSE": "Error - Not Found: A resource by that arg1 could not be found"
           },
-          \\"timeout_in_seconds\\": 180
+          "timeout_in_seconds": 180
         },
-        \\"runtime_version\\": \\"syn-nodejs-puppeteer-4.0\\",
-        \\"s3_bucket\\": \\"pocket-syntheticchecks-dev\\",
-        \\"s3_key\\": \\"aws-synthetic-dev.zip\\",
-        \\"schedule\\": {
-          \\"expression\\": \\"rate(5 minutes)\\"
+        "runtime_version": "syn-nodejs-puppeteer-4.0",
+        "s3_bucket": "pocket-syntheticchecks-dev",
+        "s3_key": "aws-synthetic-dev.zip",
+        "schedule": {
+          "expression": "rate(5 minutes)"
         },
-        \\"start_canary\\": true
+        "start_canary": true
       },
-      \\"test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479\\": {
-        \\"artifact_s3_location\\": \\"s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/\\",
-        \\"execution_role_arn\\": \\"\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}\\",
-        \\"handler\\": \\"synthetic.uptime\\",
-        \\"name\\": \\"acme-dev-uptime-0\\",
-        \\"run_config\\": {
-          \\"environment_variables\\": {
-            \\"UPTIME_BODY\\": \\"ok\\",
-            \\"UPTIME_URL\\": \\"acme.getpocket.dev/.well-known/apollo/server-health\\"
+      "test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479": {
+        "artifact_s3_location": "s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/",
+        "execution_role_arn": "\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}",
+        "handler": "synthetic.uptime",
+        "name": "acme-dev-uptime-0",
+        "run_config": {
+          "environment_variables": {
+            "UPTIME_BODY": "ok",
+            "UPTIME_URL": "acme.getpocket.dev/.well-known/apollo/server-health"
           },
-          \\"timeout_in_seconds\\": 180
+          "timeout_in_seconds": 180
         },
-        \\"runtime_version\\": \\"syn-nodejs-puppeteer-4.0\\",
-        \\"s3_bucket\\": \\"pocket-syntheticchecks-dev\\",
-        \\"s3_key\\": \\"aws-synthetic-dev.zip\\",
-        \\"schedule\\": {
-          \\"expression\\": \\"rate(5 minutes)\\"
+        "runtime_version": "syn-nodejs-puppeteer-4.0",
+        "s3_bucket": "pocket-syntheticchecks-dev",
+        "s3_key": "aws-synthetic-dev.zip",
+        "schedule": {
+          "expression": "rate(5 minutes)"
         },
-        \\"start_canary\\": true
+        "start_canary": true
       }
     }
   }
@@ -238,228 +238,228 @@ exports[`Pocket Cloudwatch Synthetics adds optional Alarms & Alarm Actions to Sy
 
 exports[`Pocket Cloudwatch Synthetics renders desired AWS Synthetic Checks 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_access_C1AC681E\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-synthetics_test-synthetics_synthetic_check_access_C1AC681E": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:PutObject\\",
-              \\"s3:GetObject\\"
+            "actions": [
+              "s3:PutObject",
+              "s3:GetObject"
             ],
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}/*\\"
+            "resources": [
+              "\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\"
+            "actions": [
+              "s3:GetObject"
             ],
-            \\"resources\\": [
-              \\"arn:aws:s3:::pocket-syntheticchecks-dev/*\\"
+            "resources": [
+              "arn:aws:s3:::pocket-syntheticchecks-dev/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetBucketLocation\\"
+            "actions": [
+              "s3:GetBucketLocation"
             ],
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}\\"
+            "resources": [
+              "\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.arn}"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:ListAllMyBuckets\\"
+            "actions": [
+              "s3:ListAllMyBuckets"
             ],
-            \\"resources\\": [
-              \\"*\\"
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"cloudwatch:PutMetricData\\"
+            "actions": [
+              "cloudwatch:PutMetricData"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEquals\\",
-                \\"values\\": [
-                  \\"CloudWatchSynthetics\\"
+                "test": "StringEquals",
+                "values": [
+                  "CloudWatchSynthetics"
                 ],
-                \\"variable\\": \\"cloudwatch:namespace\\"
+                "variable": "cloudwatch:namespace"
               }
             ],
-            \\"resources\\": [
-              \\"*\\"
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ec2:AttachNetworkInterface\\",
-              \\"ec2:CreateNetworkInterface\\",
-              \\"ec2:DeleteNetworkInterface\\",
-              \\"ec2:DescribeNetworkInterfaces\\"
+            "actions": [
+              "ec2:AttachNetworkInterface",
+              "ec2:CreateNetworkInterface",
+              "ec2:DeleteNetworkInterface",
+              "ec2:DescribeNetworkInterfaces"
             ],
-            \\"resources\\": [
-              \\"*\\"
+            "resources": [
+              "*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4\\": {
-        \\"statement\\": [
+      "test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_alarm_query_0_161FA4E1\\": {
-        \\"alarm_actions\\": [
+  "resource": {
+    "aws_cloudwatch_metric_alarm": {
+      "test-synthetics_test-synthetics_synthetic_check_alarm_query_0_161FA4E1": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name} canary success percentage has decreased below 66% in the last 15 minutes\\",
-        \\"alarm_name\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"CanaryName\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}\\"
+        "alarm_description": "Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name} canary success percentage has decreased below 66% in the last 15 minutes",
+        "alarm_name": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "CanaryName": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3.name}"
         },
-        \\"evaluation_periods\\": 3,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 3,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"SuccessPercent\\",
-        \\"namespace\\": \\"CloudWatchSynthetics\\",
-        \\"ok_actions\\": [
+        "metric_name": "SuccessPercent",
+        "namespace": "CloudWatchSynthetics",
+        "ok_actions": [
         ],
-        \\"period\\": 300,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 66,
-        \\"treat_missing_data\\": \\"breaching\\"
+        "period": 300,
+        "statistic": "Average",
+        "threshold": 66,
+        "treat_missing_data": "breaching"
       },
-      \\"test-synthetics_test-synthetics_synthetic_check_alarm_uptime_0_47F383EB\\": {
-        \\"alarm_actions\\": null,
-        \\"alarm_description\\": \\"Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name} canary success percentage has decreased below 66% in the last 15 minutes\\",
-        \\"alarm_name\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"CanaryName\\": \\"\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}\\"
+      "test-synthetics_test-synthetics_synthetic_check_alarm_uptime_0_47F383EB": {
+        "alarm_actions": null,
+        "alarm_description": "Alert when \${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name} canary success percentage has decreased below 66% in the last 15 minutes",
+        "alarm_name": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "CanaryName": "\${aws_synthetics_canary.test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479.name}"
         },
-        \\"evaluation_periods\\": 3,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 3,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"SuccessPercent\\",
-        \\"namespace\\": \\"CloudWatchSynthetics\\",
-        \\"ok_actions\\": null,
-        \\"period\\": 300,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 66,
-        \\"treat_missing_data\\": \\"breaching\\"
+        "metric_name": "SuccessPercent",
+        "namespace": "CloudWatchSynthetics",
+        "ok_actions": null,
+        "period": 300,
+        "statistic": "Average",
+        "threshold": 66,
+        "treat_missing_data": "breaching"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7\\": {
-        \\"name\\": \\"pocket-acme-dev-synthetic-check-access\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_access_C1AC681E.json}\\"
+    "aws_iam_policy": {
+      "test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7": {
+        "name": "pocket-acme-dev-synthetic-check-access",
+        "policy": "\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_access_C1AC681E.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-synthetics_synthetic_check_role_B358E7A9\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4.json}\\",
-        \\"name\\": \\"pocket-acme-dev-synthetic-check\\"
+    "aws_iam_role": {
+      "test-synthetics_synthetic_check_role_B358E7A9": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-synthetics_test-synthetics_synthetic_check_assume_9E375AF4.json}",
+        "name": "pocket-acme-dev-synthetic-check"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_access_attach_4D7F0A0A\\": {
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.id}\\"
+    "aws_iam_role_policy_attachment": {
+      "test-synthetics_test-synthetics_synthetic_check_access_attach_4D7F0A0A": {
+        "policy_arn": "\${aws_iam_policy.test-synthetics_test-synthetics_synthetic_check_access_policy_F0C0ABD7.arn}",
+        "role": "\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96\\": {
-        \\"bucket\\": \\"pocket-acme-dev-synthetic-checks\\"
+    "aws_s3_bucket": {
+      "test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96": {
+        "bucket": "pocket-acme-dev-synthetic-checks"
       }
     },
-    \\"aws_s3_bucket_lifecycle_configuration\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_artifacts_lifecycle_4D55C3CA\\": {
-        \\"bucket\\": \\"\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.id}\\",
-        \\"rule\\": [
+    "aws_s3_bucket_lifecycle_configuration": {
+      "test-synthetics_test-synthetics_synthetic_check_artifacts_lifecycle_4D55C3CA": {
+        "bucket": "\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.id}",
+        "rule": [
           {
-            \\"expiration\\": {
-              \\"days\\": 30
+            "expiration": {
+              "days": 30
             },
-            \\"id\\": \\"30-day-retention\\",
-            \\"status\\": \\"Enabled\\"
+            "id": "30-day-retention",
+            "status": "Enabled"
           }
         ]
       }
     },
-    \\"aws_synthetics_canary\\": {
-      \\"test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3\\": {
-        \\"artifact_s3_location\\": \\"s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/\\",
-        \\"execution_role_arn\\": \\"\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}\\",
-        \\"handler\\": \\"synthetic.query\\",
-        \\"name\\": \\"acme-dev-query-0\\",
-        \\"run_config\\": {
-          \\"environment_variables\\": {
-            \\"GRAPHQL_ENDPOINT\\": \\"acme.getpocket.dev\\",
-            \\"GRAPHQL_JMESPATH\\": \\"errors[0].message\\",
-            \\"GRAPHQL_QUERY\\": \\"{\\\\\\"query\\\\\\": \\\\\\"query { someGraphQlQuery(arg1: \\\\\\\\\\\\\\"1\\\\\\\\\\\\\\", arg2: \\\\\\\\\\\\\\"1\\\\\\\\\\\\\\") {returnedAttr} }\\\\\\"}\\",
-            \\"GRAPHQL_RESPONSE\\": \\"Error - Not Found: A resource by that arg1 could not be found\\"
+    "aws_synthetics_canary": {
+      "test-synthetics_test-synthetics_synthetic_check_query_0_ECB1B9B3": {
+        "artifact_s3_location": "s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/",
+        "execution_role_arn": "\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}",
+        "handler": "synthetic.query",
+        "name": "acme-dev-query-0",
+        "run_config": {
+          "environment_variables": {
+            "GRAPHQL_ENDPOINT": "acme.getpocket.dev",
+            "GRAPHQL_JMESPATH": "errors[0].message",
+            "GRAPHQL_QUERY": "{\\"query\\": \\"query { someGraphQlQuery(arg1: \\\\\\"1\\\\\\", arg2: \\\\\\"1\\\\\\") {returnedAttr} }\\"}",
+            "GRAPHQL_RESPONSE": "Error - Not Found: A resource by that arg1 could not be found"
           },
-          \\"timeout_in_seconds\\": 180
+          "timeout_in_seconds": 180
         },
-        \\"runtime_version\\": \\"syn-nodejs-puppeteer-4.0\\",
-        \\"s3_bucket\\": \\"pocket-syntheticchecks-dev\\",
-        \\"s3_key\\": \\"aws-synthetic-dev.zip\\",
-        \\"schedule\\": {
-          \\"expression\\": \\"rate(5 minutes)\\"
+        "runtime_version": "syn-nodejs-puppeteer-4.0",
+        "s3_bucket": "pocket-syntheticchecks-dev",
+        "s3_key": "aws-synthetic-dev.zip",
+        "schedule": {
+          "expression": "rate(5 minutes)"
         },
-        \\"start_canary\\": true
+        "start_canary": true
       },
-      \\"test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479\\": {
-        \\"artifact_s3_location\\": \\"s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/\\",
-        \\"execution_role_arn\\": \\"\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}\\",
-        \\"handler\\": \\"synthetic.uptime\\",
-        \\"name\\": \\"acme-dev-uptime-0\\",
-        \\"run_config\\": {
-          \\"environment_variables\\": {
-            \\"UPTIME_BODY\\": \\"ok\\",
-            \\"UPTIME_URL\\": \\"acme.getpocket.dev/.well-known/apollo/server-health\\"
+      "test-synthetics_test-synthetics_synthetic_check_uptime_0_2398A479": {
+        "artifact_s3_location": "s3://\${aws_s3_bucket.test-synthetics_test-synthetics_synthetic_check_artifacts_6B281C96.bucket}/",
+        "execution_role_arn": "\${aws_iam_role.test-synthetics_synthetic_check_role_B358E7A9.arn}",
+        "handler": "synthetic.uptime",
+        "name": "acme-dev-uptime-0",
+        "run_config": {
+          "environment_variables": {
+            "UPTIME_BODY": "ok",
+            "UPTIME_URL": "acme.getpocket.dev/.well-known/apollo/server-health"
           },
-          \\"timeout_in_seconds\\": 180
+          "timeout_in_seconds": 180
         },
-        \\"runtime_version\\": \\"syn-nodejs-puppeteer-4.0\\",
-        \\"s3_bucket\\": \\"pocket-syntheticchecks-dev\\",
-        \\"s3_key\\": \\"aws-synthetic-dev.zip\\",
-        \\"schedule\\": {
-          \\"expression\\": \\"rate(5 minutes)\\"
+        "runtime_version": "syn-nodejs-puppeteer-4.0",
+        "s3_bucket": "pocket-syntheticchecks-dev",
+        "s3_key": "aws-synthetic-dev.zip",
+        "schedule": {
+          "expression": "rate(5 minutes)"
         },
-        \\"start_canary\\": true
+        "start_canary": true
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketECSApplication.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSApplication.spec.ts.snap
@@ -2,334 +2,334 @@
 
 exports[`PocketECSApplication renders an Pocket App with logs and dashboard in a specified region 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"central region\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"central region\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -338,366 +338,366 @@ exports[`PocketECSApplication renders an Pocket App with logs and dashboard in a
 
 exports[`PocketECSApplication renders an application with autoscaling group and tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "propagate_tags": "SERVICE",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -706,334 +706,334 @@ exports[`PocketECSApplication renders an application with autoscaling group and 
 
 exports[`PocketECSApplication renders an application with custom task sizes 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"8675\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "8675",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"309\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "309",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -1042,366 +1042,366 @@ exports[`PocketECSApplication renders an application with custom task sizes 1`] 
 
 exports[`PocketECSApplication renders an application with default autoscaling group and tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "propagate_tags": "SERVICE",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         }
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"tags\\": {
-          \\"hobby\\": \\"bowling\\",
-          \\"name\\": \\"thedude\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "tags": {
+          "hobby": "bowling",
+          "name": "thedude"
         },
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -1410,334 +1410,334 @@ exports[`PocketECSApplication renders an application with default autoscaling gr
 
 exports[`PocketECSApplication renders an application with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[]",
+        "cpu": "512",
+        "depends_on": [
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }
@@ -1746,359 +1746,359 @@ exports[`PocketECSApplication renders an application with minimal config 1`] = `
 
 exports[`PocketECSApplication renders an application with modified container def protocol, cpu and memory reservation 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketApp_pocket_vpc_current_identity_06D87057\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketApp_pocket_vpc_current_identity_06D87057": {
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "identifiers": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketApp_pocket_vpc_secrets_manager_key_9FD2BC93": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketApp_pocket_vpc_current_region_8ED435E7\\": {
+    "aws_region": {
+      "testPocketApp_pocket_vpc_current_region_8ED435E7": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketApp_pocket_vpc_default_security_groups_40B4FC48\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketApp_pocket_vpc_default_security_groups_40B4FC48": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       },
-      \\"testPocketApp_pocket_vpc_internal_security_groups_12F7F666\\": {
-        \\"filter\\": [
+      "testPocketApp_pocket_vpc_internal_security_groups_12F7F666": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketApp_pocket_vpc_private_subnets_9D449563\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_public_subnets_B0B3A6AB\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketApp_pocket_vpc_vpc_ssm_param_235525D4\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketApp_pocket_vpc_public_subnet_ids_01F0B902\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketApp_pocket_vpc_C4E157E3\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketApp_pocket_vpc_private_subnets_9D449563": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketApp_pocket_vpc_public_subnets_B0B3A6AB": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketApp_pocket_vpc_vpc_ssm_param_235525D4": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_private_subnets_9D449563.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketApp_pocket_vpc_public_subnet_ids_01F0B902": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketApp_pocket_vpc_public_subnets_B0B3A6AB.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketApp_pocket_vpc_C4E157E3": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketApp_pocket_vpc_vpc_ssm_param_235525D4.value}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_appautoscaling_policy\\": {
-      \\"testPocketApp_autoscaling_scale_in_policy_A163A235\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+  "resource": {
+    "aws_appautoscaling_policy": {
+      "testPocketApp_autoscaling_scale_in_policy_A163A235": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleInPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleInPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_upper_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": -1
+              "metric_interval_upper_bound": "0",
+              "scaling_adjustment": -1
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       },
-      \\"testPocketApp_autoscaling_scale_out_policy_075BFAC4\\": {
-        \\"depends_on\\": [
-          \\"aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1\\"
+      "testPocketApp_autoscaling_scale_out_policy_075BFAC4": {
+        "depends_on": [
+          "aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1"
         ],
-        \\"name\\": \\"testapp-ScaleOutPolicy\\",
-        \\"policy_type\\": \\"StepScaling\\",
-        \\"resource_id\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}\\",
-        \\"scalable_dimension\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}\\",
-        \\"service_namespace\\": \\"\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}\\",
-        \\"step_scaling_policy_configuration\\": {
-          \\"adjustment_type\\": \\"ChangeInCapacity\\",
-          \\"cooldown\\": 60,
-          \\"metric_aggregation_type\\": \\"Average\\",
-          \\"step_adjustment\\": [
+        "name": "testapp-ScaleOutPolicy",
+        "policy_type": "StepScaling",
+        "resource_id": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.resource_id}",
+        "scalable_dimension": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.scalable_dimension}",
+        "service_namespace": "\${aws_appautoscaling_target.testPocketApp_autoscaling_autoscaling_target_505E4EA1.service_namespace}",
+        "step_scaling_policy_configuration": {
+          "adjustment_type": "ChangeInCapacity",
+          "cooldown": 60,
+          "metric_aggregation_type": "Average",
+          "step_adjustment": [
             {
-              \\"metric_interval_lower_bound\\": \\"0\\",
-              \\"scaling_adjustment\\": 2
+              "metric_interval_lower_bound": "0",
+              "scaling_adjustment": 2
             }
           ]
         },
-        \\"target_tracking_scaling_policy_configuration\\": null
+        "target_tracking_scaling_policy_configuration": null
       }
     },
-    \\"aws_appautoscaling_target\\": {
-      \\"testPocketApp_autoscaling_autoscaling_target_505E4EA1\\": {
-        \\"max_capacity\\": 2,
-        \\"min_capacity\\": 1,
-        \\"resource_id\\": \\"service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",
-        \\"scalable_dimension\\": \\"ecs:service:DesiredCount\\",
-        \\"service_namespace\\": \\"ecs\\"
+    "aws_appautoscaling_target": {
+      "testPocketApp_autoscaling_autoscaling_target_505E4EA1": {
+        "max_capacity": 2,
+        "min_capacity": 1,
+        "resource_id": "service/\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}/\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}",
+        "scalable_dimension": "ecs:service:DesiredCount",
+        "service_namespace": "ecs"
       }
     },
-    \\"aws_cloudwatch_dashboard\\": {
-      \\"testPocketApp_cloudwatch-dashboard_26E9F70C\\": {
-        \\"dashboard_body\\": \\"{\\\\\\"widgets\\\\\\":[{\\\\\\"type\\\\\\":\\\\\\"metric\\\\\\",\\\\\\"x\\\\\\":0,\\\\\\"y\\\\\\":6,\\\\\\"width\\\\\\":12,\\\\\\"height\\\\\\":6,\\\\\\"properties\\\\\\":{\\\\\\"metrics\\\\\\":[[\\\\\\"ECS/ContainerInsights\\\\\\",\\\\\\"RunningTaskCount\\\\\\",\\\\\\"ServiceName\\\\\\",\\\\\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\\\\\",\\\\\\"ClusterName\\\\\\",\\\\\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\\\\\",{\\\\\\"yAxis\\\\\\":\\\\\\"right\\\\\\",\\\\\\"color\\\\\\":\\\\\\"#c49c94\\\\\\"}],[\\\\\\"AWS/ECS\\\\\\",\\\\\\"CPUUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#f7b6d2\\\\\\"}],[\\\\\\".\\\\\\",\\\\\\"MemoryUtilization\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",\\\\\\".\\\\\\",{\\\\\\"color\\\\\\":\\\\\\"#c7c7c7\\\\\\"}]],\\\\\\"view\\\\\\":\\\\\\"timeSeries\\\\\\",\\\\\\"stacked\\\\\\":false,\\\\\\"region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"stat\\\\\\":\\\\\\"Average\\\\\\",\\\\\\"period\\\\\\":60,\\\\\\"annotations\\\\\\":{\\\\\\"horizontal\\\\\\":[{\\\\\\"color\\\\\\":\\\\\\"#e377c2\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale out\\\\\\",\\\\\\"value\\\\\\":45},{\\\\\\"color\\\\\\":\\\\\\"#c5b0d5\\\\\\",\\\\\\"label\\\\\\":\\\\\\"CPU scale in\\\\\\",\\\\\\"value\\\\\\":30}]},\\\\\\"title\\\\\\":\\\\\\"Service Load\\\\\\"}}]}\\",
-        \\"dashboard_name\\": \\"testapp\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"dashboard_body\\"
+    "aws_cloudwatch_dashboard": {
+      "testPocketApp_cloudwatch-dashboard_26E9F70C": {
+        "dashboard_body": "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"x\\":0,\\"y\\":6,\\"width\\":12,\\"height\\":6,\\"properties\\":{\\"metrics\\":[[\\"ECS/ContainerInsights\\",\\"RunningTaskCount\\",\\"ServiceName\\",\\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\",\\"ClusterName\\",\\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",{\\"yAxis\\":\\"right\\",\\"color\\":\\"#c49c94\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#f7b6d2\\"}],[\\".\\",\\"MemoryUtilization\\",\\".\\",\\".\\",\\".\\",\\".\\",{\\"color\\":\\"#c7c7c7\\"}]],\\"view\\":\\"timeSeries\\",\\"stacked\\":false,\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Average\\",\\"period\\":60,\\"annotations\\":{\\"horizontal\\":[{\\"color\\":\\"#e377c2\\",\\"label\\":\\"CPU scale out\\",\\"value\\":45},{\\"color\\":\\"#c5b0d5\\",\\"label\\":\\"CPU scale in\\",\\"value\\":30}]},\\"title\\":\\"Service Load\\"}}]}",
+        "dashboard_name": "testapp",
+        "lifecycle": {
+          "ignore_changes": [
+            "dashboard_body"
           ]
         }
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"testPocketApp_ecs_service_ecs-xray-daemon_55253A74\\": {
-        \\"name_prefix\\": \\"/ecs/testapp/xray-daemon\\",
-        \\"retention_in_days\\": 30
+    "aws_cloudwatch_log_group": {
+      "testPocketApp_ecs_service_ecs-xray-daemon_55253A74": {
+        "name_prefix": "/ecs/testapp/xray-daemon",
+        "retention_in_days": 30
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"testPocketApp_autoscaling_scale_in_alarm_69B5F00D\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}\\"
+    "aws_cloudwatch_metric_alarm": {
+      "testPocketApp_autoscaling_scale_in_alarm_69B5F00D": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_in_policy_A163A235.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to reduce capacity if container CPU is low\\",
-        \\"alarm_name\\": \\"testapp Service Low CPU\\",
-        \\"comparison_operator\\": \\"LessThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to reduce capacity if container CPU is low",
+        "alarm_name": "testapp Service Low CPU",
+        "comparison_operator": "LessThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 30,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 30,
+        "treat_missing_data": "notBreaching"
       },
-      \\"testPocketApp_autoscaling_scale_out_alarm_4313FBE9\\": {
-        \\"alarm_actions\\": [
-          \\"\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}\\"
+      "testPocketApp_autoscaling_scale_out_alarm_4313FBE9": {
+        "alarm_actions": [
+          "\${aws_appautoscaling_policy.testPocketApp_autoscaling_scale_out_policy_075BFAC4.arn}"
         ],
-        \\"alarm_description\\": \\"Alarm to add capacity if container CPU is high\\",
-        \\"alarm_name\\": \\"testapp Service High CPU\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"dimensions\\": {
-          \\"ClusterName\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}\\",
-          \\"ServiceName\\": \\"\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}\\"
+        "alarm_description": "Alarm to add capacity if container CPU is high",
+        "alarm_name": "testapp Service High CPU",
+        "comparison_operator": "GreaterThanThreshold",
+        "dimensions": {
+          "ClusterName": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.name}",
+          "ServiceName": "\${aws_ecs_service.testPocketApp_ecs_service_ecs-service_182DEA4C.name}"
         },
-        \\"evaluation_periods\\": 2,
-        \\"metric_name\\": \\"CPUUtilization\\",
-        \\"namespace\\": \\"AWS/ECS\\",
-        \\"period\\": 60,
-        \\"statistic\\": \\"Average\\",
-        \\"threshold\\": 45,
-        \\"treat_missing_data\\": \\"notBreaching\\"
+        "evaluation_periods": 2,
+        "metric_name": "CPUUtilization",
+        "namespace": "AWS/ECS",
+        "period": 60,
+        "statistic": "Average",
+        "threshold": 45,
+        "treat_missing_data": "notBreaching"
       }
     },
-    \\"aws_ecr_lifecycle_policy\\": {
-      \\"testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo-lifecyclepolicy_B1867100\\": {
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\"
+    "aws_ecr_lifecycle_policy": {
+      "testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo-lifecyclepolicy_B1867100": {
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C"
         ],
-        \\"policy\\": \\"{\\\\\\"rules\\\\\\":[{\\\\\\"rulePriority\\\\\\":1,\\\\\\"description\\\\\\":\\\\\\"expire old images\\\\\\",\\\\\\"selection\\\\\\":{\\\\\\"tagStatus\\\\\\":\\\\\\"any\\\\\\",\\\\\\"countType\\\\\\":\\\\\\"imageCountMoreThan\\\\\\",\\\\\\"countNumber\\\\\\":800},\\\\\\"action\\\\\\":{\\\\\\"type\\\\\\":\\\\\\"expire\\\\\\"}}]}\\",
-        \\"repository\\": \\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.name}\\"
+        "policy": "{\\"rules\\":[{\\"rulePriority\\":1,\\"description\\":\\"expire old images\\",\\"selection\\":{\\"tagStatus\\":\\"any\\",\\"countType\\":\\"imageCountMoreThan\\",\\"countNumber\\":800},\\"action\\":{\\"type\\":\\"expire\\"}}]}",
+        "repository": "\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.name}"
       }
     },
-    \\"aws_ecr_repository\\": {
-      \\"testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\": {
-        \\"image_scanning_configuration\\": {
-          \\"scan_on_push\\": true
+    "aws_ecr_repository": {
+      "testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C": {
+        "image_scanning_configuration": {
+          "scan_on_push": true
         },
-        \\"name\\": \\"testapp-xray-daemon\\"
+        "name": "testapp-xray-daemon"
       }
     },
-    \\"aws_ecs_cluster\\": {
-      \\"testPocketApp_ecs_cluster_C3960066\\": {
-        \\"name\\": \\"testapp\\",
-        \\"setting\\": [
+    "aws_ecs_cluster": {
+      "testPocketApp_ecs_cluster_C3960066": {
+        "name": "testapp",
+        "setting": [
           {
-            \\"name\\": \\"containerInsights\\",
-            \\"value\\": \\"enabled\\"
+            "name": "containerInsights",
+            "value": "enabled"
           }
         ]
       }
     },
-    \\"aws_ecs_service\\": {
-      \\"testPocketApp_ecs_service_ecs-service_182DEA4C\\": {
-        \\"cluster\\": \\"\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\"
+    "aws_ecs_service": {
+      "testPocketApp_ecs_service_ecs-service_182DEA4C": {
+        "cluster": "\${aws_ecs_cluster.testPocketApp_ecs_cluster_C3960066.arn}",
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C"
         ],
-        \\"deployment_controller\\": {
-          \\"type\\": \\"ECS\\"
+        "deployment_controller": {
+          "type": "ECS"
         },
-        \\"deployment_maximum_percent\\": 200,
-        \\"deployment_minimum_healthy_percent\\": 100,
-        \\"desired_count\\": 2,
-        \\"launch_type\\": \\"FARGATE\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"desired_count\\",
-            \\"load_balancer\\"
+        "deployment_maximum_percent": 200,
+        "deployment_minimum_healthy_percent": 100,
+        "desired_count": 2,
+        "launch_type": "FARGATE",
+        "lifecycle": {
+          "ignore_changes": [
+            "desired_count",
+            "load_balancer"
           ]
         },
-        \\"load_balancer\\": [
+        "load_balancer": [
         ],
-        \\"name\\": \\"testapp\\",
-        \\"network_configuration\\": {
-          \\"security_groups\\": [
-            \\"\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}\\"
+        "name": "testapp",
+        "network_configuration": {
+          "security_groups": [
+            "\${aws_security_group.testPocketApp_ecs_service_ecs_security_group_9C016FA8.id}"
           ],
-          \\"subnets\\": \\"\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}\\"
+          "subnets": "\${data.aws_subnets.testPocketApp_pocket_vpc_private_subnet_ids_EB1E3A65.ids}"
         },
-        \\"propagate_tags\\": \\"SERVICE\\",
-        \\"task_definition\\": \\"\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}\\"
+        "propagate_tags": "SERVICE",
+        "task_definition": "\${aws_ecs_task_definition.testPocketApp_ecs_service_ecs-task_A7E74E45.arn}"
       }
     },
-    \\"aws_ecs_task_definition\\": {
-      \\"testPocketApp_ecs_service_ecs-task_A7E74E45\\": {
-        \\"container_definitions\\": \\"[{\\\\\\"dnsSearchDomains\\\\\\":null,\\\\\\"environmentFiles\\\\\\":null,\\\\\\"logConfiguration\\\\\\":{\\\\\\"logDriver\\\\\\":\\\\\\"awslogs\\\\\\",\\\\\\"secretOptions\\\\\\":[],\\\\\\"options\\\\\\":{\\\\\\"awslogs-group\\\\\\":\\\\\\"\${aws_cloudwatch_log_group.testPocketApp_ecs_service_ecs-xray-daemon_55253A74.name}\\\\\\",\\\\\\"awslogs-region\\\\\\":\\\\\\"us-east-1\\\\\\",\\\\\\"awslogs-stream-prefix\\\\\\":\\\\\\"ecs\\\\\\"}},\\\\\\"entryPoint\\\\\\":null,\\\\\\"portMappings\\\\\\":[{\\\\\\"hostPort\\\\\\":0,\\\\\\"containerPort\\\\\\":2000,\\\\\\"protocol\\\\\\":\\\\\\"udp\\\\\\"}],\\\\\\"linuxParameters\\\\\\":null,\\\\\\"cpu\\\\\\":10,\\\\\\"environment\\\\\\":[],\\\\\\"resourceRequirements\\\\\\":null,\\\\\\"ulimits\\\\\\":null,\\\\\\"repositoryCredentials\\\\\\":null,\\\\\\"dnsServers\\\\\\":null,\\\\\\"mountPoints\\\\\\":[],\\\\\\"workingDirectory\\\\\\":null,\\\\\\"secrets\\\\\\":null,\\\\\\"dockerSecurityOptions\\\\\\":null,\\\\\\"memory\\\\\\":null,\\\\\\"memoryReservation\\\\\\":50,\\\\\\"volumesFrom\\\\\\":[],\\\\\\"stopTimeout\\\\\\":null,\\\\\\"image\\\\\\":\\\\\\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.repository_url}:latest\\\\\\",\\\\\\"startTimeout\\\\\\":null,\\\\\\"firelensConfiguration\\\\\\":null,\\\\\\"dependsOn\\\\\\":null,\\\\\\"disableNetworking\\\\\\":null,\\\\\\"interactive\\\\\\":null,\\\\\\"healthCheck\\\\\\":null,\\\\\\"essential\\\\\\":true,\\\\\\"links\\\\\\":null,\\\\\\"hostname\\\\\\":null,\\\\\\"extraHosts\\\\\\":null,\\\\\\"pseudoTerminal\\\\\\":null,\\\\\\"user\\\\\\":null,\\\\\\"readonlyRootFilesystem\\\\\\":false,\\\\\\"dockerLabels\\\\\\":null,\\\\\\"systemControls\\\\\\":null,\\\\\\"privileged\\\\\\":null,\\\\\\"name\\\\\\":\\\\\\"xray-daemon\\\\\\"}]\\",
-        \\"cpu\\": \\"512\\",
-        \\"depends_on\\": [
-          \\"aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C\\"
+    "aws_ecs_task_definition": {
+      "testPocketApp_ecs_service_ecs-task_A7E74E45": {
+        "container_definitions": "[{\\"dnsSearchDomains\\":null,\\"environmentFiles\\":null,\\"logConfiguration\\":{\\"logDriver\\":\\"awslogs\\",\\"secretOptions\\":[],\\"options\\":{\\"awslogs-group\\":\\"\${aws_cloudwatch_log_group.testPocketApp_ecs_service_ecs-xray-daemon_55253A74.name}\\",\\"awslogs-region\\":\\"us-east-1\\",\\"awslogs-stream-prefix\\":\\"ecs\\"}},\\"entryPoint\\":null,\\"portMappings\\":[{\\"hostPort\\":0,\\"containerPort\\":2000,\\"protocol\\":\\"udp\\"}],\\"linuxParameters\\":null,\\"cpu\\":10,\\"environment\\":[],\\"resourceRequirements\\":null,\\"ulimits\\":null,\\"repositoryCredentials\\":null,\\"dnsServers\\":null,\\"mountPoints\\":[],\\"workingDirectory\\":null,\\"secrets\\":null,\\"dockerSecurityOptions\\":null,\\"memory\\":null,\\"memoryReservation\\":50,\\"volumesFrom\\":[],\\"stopTimeout\\":null,\\"image\\":\\"\${aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C.repository_url}:latest\\",\\"startTimeout\\":null,\\"firelensConfiguration\\":null,\\"dependsOn\\":null,\\"disableNetworking\\":null,\\"interactive\\":null,\\"healthCheck\\":null,\\"essential\\":true,\\"links\\":null,\\"hostname\\":null,\\"extraHosts\\":null,\\"pseudoTerminal\\":null,\\"user\\":null,\\"readonlyRootFilesystem\\":false,\\"dockerLabels\\":null,\\"systemControls\\":null,\\"privileged\\":null,\\"name\\":\\"xray-daemon\\"}]",
+        "cpu": "512",
+        "depends_on": [
+          "aws_ecr_repository.testPocketApp_ecs_service_ecr-xray-daemon_ecr-repo_9028CD2C"
         ],
-        \\"execution_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}\\",
-        \\"family\\": \\"testapp\\",
-        \\"memory\\": \\"2048\\",
-        \\"network_mode\\": \\"awsvpc\\",
-        \\"requires_compatibilities\\": [
-          \\"FARGATE\\"
+        "execution_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C.arn}",
+        "family": "testapp",
+        "memory": "2048",
+        "network_mode": "awsvpc",
+        "requires_compatibilities": [
+          "FARGATE"
         ],
-        \\"task_role_arn\\": \\"\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}\\",
-        \\"volume\\": [
+        "task_role_arn": "\${aws_iam_role.testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963.arn}",
+        "volume": [
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskExecutionRole\\"
+    "aws_iam_role": {
+      "testPocketApp_ecs_service_ecs-iam_ecs-execution-role_EB461A0C": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskExecutionRole"
       },
-      \\"testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}\\",
-        \\"name\\": \\"testapp-TaskRole\\"
+      "testPocketApp_ecs_service_ecs-iam_ecs-task-role_7DB93963": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.testPocketApp_ecs_service_ecs-iam_ecs-task-assume_ABB81680.json}",
+        "name": "testapp-TaskRole"
       }
     },
-    \\"aws_security_group\\": {
-      \\"testPocketApp_ecs_service_ecs_security_group_9C016FA8\\": {
-        \\"description\\": \\"Internal ECS Security Group (Managed by Terraform)\\",
-        \\"egress\\": [
+    "aws_security_group": {
+      "testPocketApp_ecs_service_ecs_security_group_9C016FA8": {
+        "description": "Internal ECS Security Group (Managed by Terraform)",
+        "egress": [
           {
-            \\"cidr_blocks\\": [
-              \\"0.0.0.0/0\\"
+            "cidr_blocks": [
+              "0.0.0.0/0"
             ],
-            \\"description\\": \\"required\\",
-            \\"from_port\\": 0,
-            \\"ipv6_cidr_blocks\\": [
+            "description": "required",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [
             ],
-            \\"prefix_list_ids\\": [
+            "prefix_list_ids": [
             ],
-            \\"protocol\\": \\"-1\\",
-            \\"security_groups\\": [
+            "protocol": "-1",
+            "security_groups": [
             ],
-            \\"self\\": null,
-            \\"to_port\\": 0
+            "self": null,
+            "to_port": 0
           }
         ],
-        \\"ingress\\": [
+        "ingress": [
         ],
-        \\"lifecycle\\": {
-          \\"create_before_destroy\\": true
+        "lifecycle": {
+          "create_before_destroy": true
         },
-        \\"name_prefix\\": \\"testapp-ECSSecurityGroup\\",
-        \\"vpc_id\\": \\"\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}\\"
+        "name_prefix": "testapp-ECSSecurityGroup",
+        "vpc_id": "\${data.aws_vpc.testPocketApp_pocket_vpc_C4E157E3.id}"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketECSCodePipeline.spec.ts.snap
@@ -2,216 +2,216 @@
 
 exports[`renders a Pocket ECS Codepipeline template 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -220,249 +220,249 @@ exports[`renders a Pocket ECS Codepipeline template 1`] = `
 
 exports[`renders a Pocket ECS Codepipeline template with custom steps 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"projectName\\": \\"Test-Env-MyBuild\\"
+                "category": "Deploy",
+                "configuration": {
+                  "projectName": "Test-Env-MyBuild"
                 },
-                \\"name\\": \\"MyBuild\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "name": "MyBuild",
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Custom_PreDeploy_Stage\\"
+            "name": "Custom_PreDeploy_Stage"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"ExecutionNamePrefix\\": \\"CodePipelineDeploy\\",
-                  \\"stateMachineArn\\": \\"myStateMachineArn123\\"
+                "category": "Deploy",
+                "configuration": {
+                  "ExecutionNamePrefix": "CodePipelineDeploy",
+                  "stateMachineArn": "myStateMachineArn123"
                 },
-                \\"name\\": \\"Custom_Action\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"StepFunctions\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "name": "Custom_Action",
+                "owner": "AWS",
+                "provider": "StepFunctions",
+                "run_order": 1,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Custom_PostDeploy_Stage\\"
+            "name": "Custom_PostDeploy_Stage"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -471,221 +471,221 @@ exports[`renders a Pocket ECS Codepipeline template with custom steps 1`] = `
 
 exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ],
-        \\"tags\\": {
-          \\"yup\\": \\"a tag\\"
+        "tags": {
+          "yup": "a tag"
         }
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true,
-        \\"tags\\": {
-          \\"yup\\": \\"a tag\\"
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true,
+        "tags": {
+          "yup": "a tag"
         }
       }
     }
@@ -695,216 +695,216 @@ exports[`renders a Pocket ECS Codepipeline template with tags 1`] = `
 
 exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy app name 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:TestAppName\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:TestAppName/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:TestAppName",
+              "arn:aws:codedeploy:*:*:deploymentgroup:TestAppName/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"TestAppName\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "TestAppName",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -913,216 +913,216 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
 
 exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy deployment group name 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/TestDeploymentGroupName\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/TestDeploymentGroupName",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"TestDeploymentGroupName\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "TestDeploymentGroupName",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -1131,216 +1131,216 @@ exports[`renders a Pocket ECS Codepipeline template with the provided CodeDeploy
 
 exports[`renders a Pocket ECS Codepipeline template with the provided appspec path 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"testappspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "testappspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -1349,216 +1349,216 @@ exports[`renders a Pocket ECS Codepipeline template with the provided appspec pa
 
 exports[`renders a Pocket ECS Codepipeline template with the provided artifact bucket prefix 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"my-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "my-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -1567,216 +1567,216 @@ exports[`renders a Pocket ECS Codepipeline template with the provided artifact b
 
 exports[`renders a Pocket ECS Codepipeline template with the provided code build project name 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/TestBuildName*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/TestBuildName*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"TestBuildName\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "TestBuildName"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"taskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "taskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }
@@ -1785,216 +1785,216 @@ exports[`renders a Pocket ECS Codepipeline template with the provided code build
 
 exports[`renders a Pocket ECS Codepipeline template with the provided taskdef path 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_iam_policy_document\\": {
-      \\"test-codepipeline_codepipeline-assume-role-policy_AB972C21\\": {
-        \\"statement\\": [
+  "data": {
+    "aws_iam_policy_document": {
+      "test-codepipeline_codepipeline-assume-role-policy_AB972C21": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codepipeline.amazonaws.com\\"
+                "identifiers": [
+                  "codepipeline.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ]
       },
-      \\"test-codepipeline_codepipeline-role-policy-document_DD4EB3DB\\": {
-        \\"statement\\": [
+      "test-codepipeline_codepipeline-role-policy-document_DD4EB3DB": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"codestar-connections:UseConnection\\"
+            "actions": [
+              "codestar-connections:UseConnection"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:codestart-connection:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:codestart-connection:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codebuild:BatchGetBuilds\\",
-              \\"codebuild:StartBuild\\",
-              \\"codebuild:BatchGetBuildBatches\\",
-              \\"codebuild:StartBuildBatch\\"
+            "actions": [
+              "codebuild:BatchGetBuilds",
+              "codebuild:StartBuild",
+              "codebuild:BatchGetBuildBatches",
+              "codebuild:StartBuildBatch"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codebuild:*:*:project/Test-Env*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codebuild:*:*:project/Test-Env*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"codedeploy:CreateDeployment\\",
-              \\"codedeploy:GetApplication\\",
-              \\"codedeploy:GetApplicationRevision\\",
-              \\"codedeploy:GetDeployment\\",
-              \\"codedeploy:RegisterApplicationRevision\\",
-              \\"codedeploy:GetDeploymentConfig\\"
+            "actions": [
+              "codedeploy:CreateDeployment",
+              "codedeploy:GetApplication",
+              "codedeploy:GetApplicationRevision",
+              "codedeploy:GetDeployment",
+              "codedeploy:RegisterApplicationRevision",
+              "codedeploy:GetDeploymentConfig"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:codedeploy:*:*:application:Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS\\",
-              \\"arn:aws:codedeploy:*:*:deploymentconfig:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:codedeploy:*:*:application:Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentgroup:Test-Env-ECS/Test-Env-ECS",
+              "arn:aws:codedeploy:*:*:deploymentconfig:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"s3:GetObject\\",
-              \\"s3:GetObjectVersion\\",
-              \\"s3:GetBucketVersioning\\",
-              \\"s3:PutObjectAcl\\",
-              \\"s3:PutObject\\"
+            "actions": [
+              "s3:GetObject",
+              "s3:GetObjectVersion",
+              "s3:GetBucketVersioning",
+              "s3:PutObjectAcl",
+              "s3:PutObject"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}\\",
-              \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}",
+              "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.arn}/*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"iam:PassRole\\"
+            "actions": [
+              "iam:PassRole"
             ],
-            \\"condition\\": [
+            "condition": [
               {
-                \\"test\\": \\"StringEqualsIfExists\\",
-                \\"values\\": [
-                  \\"ecs-tasks.amazonaws.com\\"
+                "test": "StringEqualsIfExists",
+                "values": [
+                  "ecs-tasks.amazonaws.com"
                 ],
-                \\"variable\\": \\"iam:PassedToService\\"
+                "variable": "iam:PassedToService"
               }
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ecs:RegisterTaskDefinition\\"
+            "actions": [
+              "ecs:RegisterTaskDefinition"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ]
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"test-codepipeline_kms_s3_alias_6C922DC1\\": {
-        \\"name\\": \\"alias/aws/s3\\"
+    "aws_kms_alias": {
+      "test-codepipeline_kms_s3_alias_6C922DC1": {
+        "name": "alias/aws/s3"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_codepipeline\\": {
-      \\"test-codepipeline_367BF1E2\\": {
-        \\"artifact_store\\": [
+  "resource": {
+    "aws_codepipeline": {
+      "test-codepipeline_367BF1E2": {
+        "artifact_store": [
           {
-            \\"encryption_key\\": {
-              \\"id\\": \\"\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}\\",
-              \\"type\\": \\"KMS\\"
+            "encryption_key": {
+              "id": "\${data.aws_kms_alias.test-codepipeline_kms_s3_alias_6C922DC1.arn}",
+              "type": "KMS"
             },
-            \\"location\\": \\"\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}\\",
-            \\"type\\": \\"S3\\"
+            "location": "\${aws_s3_bucket.test-codepipeline_codepipeline-bucket_D4671464.bucket}",
+            "type": "S3"
           }
         ],
-        \\"name\\": \\"Test-Env-CodePipeline\\",
-        \\"role_arn\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}\\",
-        \\"stage\\": [
+        "name": "Test-Env-CodePipeline",
+        "role_arn": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.arn}",
+        "stage": [
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Source\\",
-                \\"configuration\\": {
-                  \\"BranchName\\": \\"test\\",
-                  \\"ConnectionArn\\": \\"arn:codestart-connection:*\\",
-                  \\"DetectChanges\\": \\"false\\",
-                  \\"FullRepositoryId\\": \\"string\\"
+                "category": "Source",
+                "configuration": {
+                  "BranchName": "test",
+                  "ConnectionArn": "arn:codestart-connection:*",
+                  "DetectChanges": "false",
+                  "FullRepositoryId": "string"
                 },
-                \\"name\\": \\"GitHub_Checkout\\",
-                \\"namespace\\": \\"SourceVariables\\",
-                \\"output_artifacts\\": [
-                  \\"SourceOutput\\"
+                "name": "GitHub_Checkout",
+                "namespace": "SourceVariables",
+                "output_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeStarSourceConnection\\",
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Source\\"
+            "name": "Source"
           },
           {
-            \\"action\\": [
+            "action": [
               {
-                \\"category\\": \\"Build\\",
-                \\"configuration\\": {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\"name\\\\\\":\\\\\\"GIT_BRANCH\\\\\\",\\\\\\"value\\\\\\":\\\\\\"#{SourceVariables.BranchName}\\\\\\"}]\\",
-                  \\"ProjectName\\": \\"Test-Env\\"
+                "category": "Build",
+                "configuration": {
+                  "EnvironmentVariables": "[{\\"name\\":\\"GIT_BRANCH\\",\\"value\\":\\"#{SourceVariables.BranchName}\\"}]",
+                  "ProjectName": "Test-Env"
                 },
-                \\"input_artifacts\\": [
-                  \\"SourceOutput\\"
+                "input_artifacts": [
+                  "SourceOutput"
                 ],
-                \\"name\\": \\"Deploy_CDK\\",
-                \\"output_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "name": "Deploy_CDK",
+                "output_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeBuild\\",
-                \\"run_order\\": 1,
-                \\"version\\": \\"1\\"
+                "owner": "AWS",
+                "provider": "CodeBuild",
+                "run_order": 1,
+                "version": "1"
               },
               {
-                \\"category\\": \\"Deploy\\",
-                \\"configuration\\": {
-                  \\"AppSpecTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"AppSpecTemplatePath\\": \\"appspec.json\\",
-                  \\"ApplicationName\\": \\"Test-Env-ECS\\",
-                  \\"DeploymentGroupName\\": \\"Test-Env-ECS\\",
-                  \\"TaskDefinitionTemplateArtifact\\": \\"CodeBuildOutput\\",
-                  \\"TaskDefinitionTemplatePath\\": \\"testtaskdef.json\\"
+                "category": "Deploy",
+                "configuration": {
+                  "AppSpecTemplateArtifact": "CodeBuildOutput",
+                  "AppSpecTemplatePath": "appspec.json",
+                  "ApplicationName": "Test-Env-ECS",
+                  "DeploymentGroupName": "Test-Env-ECS",
+                  "TaskDefinitionTemplateArtifact": "CodeBuildOutput",
+                  "TaskDefinitionTemplatePath": "testtaskdef.json"
                 },
-                \\"input_artifacts\\": [
-                  \\"CodeBuildOutput\\"
+                "input_artifacts": [
+                  "CodeBuildOutput"
                 ],
-                \\"name\\": \\"Deploy_ECS\\",
-                \\"owner\\": \\"AWS\\",
-                \\"provider\\": \\"CodeDeployToECS\\",
-                \\"run_order\\": 2,
-                \\"version\\": \\"1\\"
+                "name": "Deploy_ECS",
+                "owner": "AWS",
+                "provider": "CodeDeployToECS",
+                "run_order": 2,
+                "version": "1"
               }
             ],
-            \\"name\\": \\"Deploy\\"
+            "name": "Deploy"
           }
         ]
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-codepipeline_codepipeline-role_4D3D2364\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}\\",
-        \\"name\\": \\"Test-Env-CodePipelineRole\\"
+    "aws_iam_role": {
+      "test-codepipeline_codepipeline-role_4D3D2364": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-assume-role-policy_AB972C21.json}",
+        "name": "Test-Env-CodePipelineRole"
       }
     },
-    \\"aws_iam_role_policy\\": {
-      \\"test-codepipeline_codepipeline-role-policy_76FC5FBB\\": {
-        \\"name\\": \\"Test-Env-CodePipeline-Role-Policy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}\\",
-        \\"role\\": \\"\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}\\"
+    "aws_iam_role_policy": {
+      "test-codepipeline_codepipeline-role-policy_76FC5FBB": {
+        "name": "Test-Env-CodePipeline-Role-Policy",
+        "policy": "\${data.aws_iam_policy_document.test-codepipeline_codepipeline-role-policy-document_DD4EB3DB.json}",
+        "role": "\${aws_iam_role.test-codepipeline_codepipeline-role_4D3D2364.id}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-codepipeline_codepipeline-bucket_D4671464\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-codepipeline_codepipeline-bucket_D4671464": {
+        "acl": "private",
+        "bucket": "pocket-codepipeline-e7e6d80d49c8787d2f7a7aca123082dd",
+        "force_destroy": true
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeRuleWithMultipleTargets.spec.ts.snap
@@ -2,179 +2,179 @@
 
 exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and multiple targets 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\": {
-        \\"description\\": \\"Test description\\",
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B": {
+        "description": "Test description",
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
+        "name": "test-event-bridge-rule-multiple-targets-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F\\": {
-        \\"arn\\": \\"lambda.arn\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F": {
+        "arn": "lambda.arn",
+        "dead_letter_config": {
         },
-        \\"depends_on\\": [
-          \\"aws_lambda_alias.test-lambda_alias_CCFDFCE9\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\"
+        "depends_on": [
+          "aws_lambda_alias.test-lambda_alias_CCFDFCE9",
+          "aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B"
         ],
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
-        \\"target_id\\": \\"test-lambda-id\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}",
+        "target_id": "test-lambda-id"
       },
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF\\": {
-        \\"arn\\": \\"\${aws_sqs_queue.test-queue.arn}\\",
-        \\"dead_letter_config\\": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF": {
+        "arn": "\${aws_sqs_queue.test-queue.arn}",
+        "dead_letter_config": {
         },
-        \\"depends_on\\": [
-          \\"aws_sqs_queue.test-queue\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\"
+        "depends_on": [
+          "aws_sqs_queue.test-queue",
+          "aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B"
         ],
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
-        \\"target_id\\": \\"test-sqs-id\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}",
+        "target_id": "test-sqs-id"
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"test-queue\\": {
-        \\"name\\": \\"Test-SQS-Queue\\"
+    "aws_sqs_queue": {
+      "test-queue": {
+        "name": "Test-SQS-Queue"
       }
     }
   }
@@ -183,33 +183,33 @@ exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and mu
 
 exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and pre-existing targets 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\": {
-        \\"description\\": \\"Test description\\",
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B": {
+        "description": "Test description",
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
+        "name": "test-event-bridge-rule-multiple-targets-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F\\": {
-        \\"arn\\": \\"lambda.arn\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F": {
+        "arn": "lambda.arn",
+        "dead_letter_config": {
         },
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
-        \\"target_id\\": \\"test-lambda-id\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}",
+        "target_id": "test-lambda-id"
       },
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF\\": {
-        \\"arn\\": \\"testSqs.arn\\",
-        \\"dead_letter_config\\": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF": {
+        "arn": "testSqs.arn",
+        "dead_letter_config": {
         },
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
-        \\"target_id\\": \\"test-sqs-id\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}",
+        "target_id": "test-sqs-id"
       }
     }
   }
@@ -218,34 +218,34 @@ exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge and pr
 
 exports[`PocketEventBridgeRuleWithMultipleTargets renders an event bridge rule with prevent destroy flag 1`] = `
 "{
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B\\": {
-        \\"description\\": \\"Test description\\",
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
-          \\"prevent_destroy\\": true
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B": {
+        "description": "Test description",
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
+          "prevent_destroy": true
         },
-        \\"name\\": \\"test-event-bridge-rule-multiple-targets-Rule\\"
+        "name": "test-event-bridge-rule-multiple-targets-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F\\": {
-        \\"arn\\": \\"lambda.arn\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-lambda-id_DE65E71F": {
+        "arn": "lambda.arn",
+        "dead_letter_config": {
         },
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
-        \\"target_id\\": \\"test-lambda-id\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}",
+        "target_id": "test-lambda-id"
       },
-      \\"test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF\\": {
-        \\"arn\\": \\"testSqs.arn\\",
-        \\"dead_letter_config\\": {
+      "test-event-bridge-for-multiple-targets-1_event-bridge-rule_event-bridge-target-test-sqs-id_2DE721FF": {
+        "arn": "testSqs.arn",
+        "dead_letter_config": {
         },
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}\\",
-        \\"target_id\\": \\"test-sqs-id\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-for-multiple-targets-1_event-bridge-rule_1CCF9D7B.name}",
+        "target_id": "test-sqs-id"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketEventBridgeWithLambdaTarget.spec.ts.snap
@@ -2,174 +2,174 @@
 
 exports[`renders an event bridge and lambda target with event bus name 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-event-bridge-lambda_lambda-default-file_57164BB7\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-event-bridge-lambda_lambda-default-file_57164BB7": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-event-bridge-lambda_assume-policy-document_59E97C0B\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-event-bridge-lambda_assume-policy-document_59E97C0B": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-event-bridge-lambda_execution-policy-document_0A3C0E28\\": {
-        \\"statement\\": [
+      "test-event-bridge-lambda_execution-policy-document_0A3C0E28": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-lambda_event-bridge-rule_529FF7C2\\": {
-        \\"event_bus_name\\": \\"test-bus\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-lambda_event-bridge-rule_529FF7C2": {
+        "event_bus_name": "test-bus",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"test-event-bridge-lambda-Rule\\"
+        "name": "test-event-bridge-lambda-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-lambda_event-bridge-rule_event-bridge-target-lambda_30D0509D\\": {
-        \\"arn\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-lambda_event-bridge-rule_event-bridge-target-lambda_30D0509D": {
+        "arn": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}",
+        "dead_letter_config": {
         },
-        \\"depends_on\\": [
-          \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+        "depends_on": [
+          "aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC",
+          "aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2"
         ],
-        \\"event_bus_name\\": \\"test-bus\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}\\",
-        \\"target_id\\": \\"lambda\\"
+        "event_bus_name": "test-bus",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}",
+        "target_id": "lambda"
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-event-bridge-lambda_log-group_CF4CF8D4\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
+    "aws_cloudwatch_log_group": {
+      "test-event-bridge-lambda_log-group_CF4CF8D4": {
+        "depends_on": [
+          "aws_lambda_function.test-event-bridge-lambda_65C2E1CE"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-event-bridge-lambda_execution-policy_F6422B9B\\": {
-        \\"name\\": \\"test-event-bridge-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-event-bridge-lambda_execution-policy-document_0A3C0E28.json}\\"
+    "aws_iam_policy": {
+      "test-event-bridge-lambda_execution-policy_F6422B9B": {
+        "name": "test-event-bridge-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-event-bridge-lambda_execution-policy-document_0A3C0E28.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-event-bridge-lambda_execution-role_7936A26A\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-event-bridge-lambda_assume-policy-document_59E97C0B.json}\\",
-        \\"name\\": \\"test-event-bridge-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-event-bridge-lambda_execution-role_7936A26A": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-event-bridge-lambda_assume-policy-document_59E97C0B.json}",
+        "name": "test-event-bridge-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-event-bridge-lambda_execution-role-policy-attachment_2614BB3C\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A\\",
-          \\"aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B\\"
+    "aws_iam_role_policy_attachment": {
+      "test-event-bridge-lambda_execution-role-policy-attachment_2614BB3C": {
+        "depends_on": [
+          "aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A",
+          "aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B.arn}",
+        "role": "\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-event-bridge-lambda_alias_2EC274FC\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
+    "aws_lambda_alias": {
+      "test-event-bridge-lambda_alias_2EC274FC": {
+        "depends_on": [
+          "aws_lambda_function.test-event-bridge-lambda_65C2E1CE"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-event-bridge-lambda_65C2E1CE\\": {
-        \\"filename\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_path}\\",
-        \\"function_name\\": \\"test-event-bridge-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-event-bridge-lambda_65C2E1CE": {
+        "filename": "\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_path}",
+        "function_name": "test-event-bridge-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_lambda_permission\\": {
-      \\"test-event-bridge-lambda_lambda-permission_D900B300\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"depends_on\\": [
-          \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+    "aws_lambda_permission": {
+      "test-event-bridge-lambda_lambda-permission_D900B300": {
+        "action": "lambda:InvokeFunction",
+        "depends_on": [
+          "aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC",
+          "aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2"
         ],
-        \\"function_name\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
-        \\"principal\\": \\"events.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\",
-        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.arn}\\"
+        "function_name": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}",
+        "principal": "events.amazonaws.com",
+        "qualifier": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}",
+        "source_arn": "\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.arn}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-event-bridge-lambda_code-bucket_3703E73B\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-event-bridge-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-event-bridge-lambda_code-bucket_3703E73B": {
+        "acl": "private",
+        "bucket": "pocket-test-event-bridge-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-event-bridge-lambda_code-bucket-public-access-block_A1A4EF9D\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-event-bridge-lambda_code-bucket-public-access-block_A1A4EF9D": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}"
       }
     }
   }
@@ -178,175 +178,175 @@ exports[`renders an event bridge and lambda target with event bus name 1`] = `
 
 exports[`renders an event bridge and lambda target with rule description 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-event-bridge-lambda_lambda-default-file_57164BB7\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-event-bridge-lambda_lambda-default-file_57164BB7": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-event-bridge-lambda_assume-policy-document_59E97C0B\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-event-bridge-lambda_assume-policy-document_59E97C0B": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-event-bridge-lambda_execution-policy-document_0A3C0E28\\": {
-        \\"statement\\": [
+      "test-event-bridge-lambda_execution-policy-document_0A3C0E28": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_event_rule\\": {
-      \\"test-event-bridge-lambda_event-bridge-rule_529FF7C2\\": {
-        \\"description\\": \\"Test description\\",
-        \\"event_bus_name\\": \\"default\\",
-        \\"event_pattern\\": \\"{\\\\\\"source\\\\\\":[\\\\\\"aws.states\\\\\\"],\\\\\\"detail-type\\\\\\":[\\\\\\"Step Functions Execution Status Change\\\\\\"]}\\",
-        \\"lifecycle\\": {
+  "resource": {
+    "aws_cloudwatch_event_rule": {
+      "test-event-bridge-lambda_event-bridge-rule_529FF7C2": {
+        "description": "Test description",
+        "event_bus_name": "default",
+        "event_pattern": "{\\"source\\":[\\"aws.states\\"],\\"detail-type\\":[\\"Step Functions Execution Status Change\\"]}",
+        "lifecycle": {
         },
-        \\"name\\": \\"test-event-bridge-lambda-Rule\\"
+        "name": "test-event-bridge-lambda-Rule"
       }
     },
-    \\"aws_cloudwatch_event_target\\": {
-      \\"test-event-bridge-lambda_event-bridge-rule_event-bridge-target-lambda_30D0509D\\": {
-        \\"arn\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}\\",
-        \\"dead_letter_config\\": {
+    "aws_cloudwatch_event_target": {
+      "test-event-bridge-lambda_event-bridge-rule_event-bridge-target-lambda_30D0509D": {
+        "arn": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.arn}",
+        "dead_letter_config": {
         },
-        \\"depends_on\\": [
-          \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+        "depends_on": [
+          "aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC",
+          "aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2"
         ],
-        \\"event_bus_name\\": \\"default\\",
-        \\"rule\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}\\",
-        \\"target_id\\": \\"lambda\\"
+        "event_bus_name": "default",
+        "rule": "\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.name}",
+        "target_id": "lambda"
       }
     },
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-event-bridge-lambda_log-group_CF4CF8D4\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
+    "aws_cloudwatch_log_group": {
+      "test-event-bridge-lambda_log-group_CF4CF8D4": {
+        "depends_on": [
+          "aws_lambda_function.test-event-bridge-lambda_65C2E1CE"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-event-bridge-lambda_execution-policy_F6422B9B\\": {
-        \\"name\\": \\"test-event-bridge-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-event-bridge-lambda_execution-policy-document_0A3C0E28.json}\\"
+    "aws_iam_policy": {
+      "test-event-bridge-lambda_execution-policy_F6422B9B": {
+        "name": "test-event-bridge-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-event-bridge-lambda_execution-policy-document_0A3C0E28.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-event-bridge-lambda_execution-role_7936A26A\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-event-bridge-lambda_assume-policy-document_59E97C0B.json}\\",
-        \\"name\\": \\"test-event-bridge-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-event-bridge-lambda_execution-role_7936A26A": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-event-bridge-lambda_assume-policy-document_59E97C0B.json}",
+        "name": "test-event-bridge-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-event-bridge-lambda_execution-role-policy-attachment_2614BB3C\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A\\",
-          \\"aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B\\"
+    "aws_iam_role_policy_attachment": {
+      "test-event-bridge-lambda_execution-role-policy-attachment_2614BB3C": {
+        "depends_on": [
+          "aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A",
+          "aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-event-bridge-lambda_execution-policy_F6422B9B.arn}",
+        "role": "\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-event-bridge-lambda_alias_2EC274FC\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-event-bridge-lambda_65C2E1CE\\"
+    "aws_lambda_alias": {
+      "test-event-bridge-lambda_alias_2EC274FC": {
+        "depends_on": [
+          "aws_lambda_function.test-event-bridge-lambda_65C2E1CE"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-event-bridge-lambda_65C2E1CE.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-event-bridge-lambda_65C2E1CE.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-event-bridge-lambda_65C2E1CE\\": {
-        \\"filename\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_path}\\",
-        \\"function_name\\": \\"test-event-bridge-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-event-bridge-lambda_65C2E1CE": {
+        "filename": "\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_path}",
+        "function_name": "test-event-bridge-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-event-bridge-lambda_execution-role_7936A26A.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-event-bridge-lambda_lambda-default-file_57164BB7.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_lambda_permission\\": {
-      \\"test-event-bridge-lambda_lambda-permission_D900B300\\": {
-        \\"action\\": \\"lambda:InvokeFunction\\",
-        \\"depends_on\\": [
-          \\"aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC\\",
-          \\"aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2\\"
+    "aws_lambda_permission": {
+      "test-event-bridge-lambda_lambda-permission_D900B300": {
+        "action": "lambda:InvokeFunction",
+        "depends_on": [
+          "aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC",
+          "aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2"
         ],
-        \\"function_name\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}\\",
-        \\"principal\\": \\"events.amazonaws.com\\",
-        \\"qualifier\\": \\"\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}\\",
-        \\"source_arn\\": \\"\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.arn}\\"
+        "function_name": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.function_name}",
+        "principal": "events.amazonaws.com",
+        "qualifier": "\${aws_lambda_alias.test-event-bridge-lambda_alias_2EC274FC.name}",
+        "source_arn": "\${aws_cloudwatch_event_rule.test-event-bridge-lambda_event-bridge-rule_529FF7C2.arn}"
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-event-bridge-lambda_code-bucket_3703E73B\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-event-bridge-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-event-bridge-lambda_code-bucket_3703E73B": {
+        "acl": "private",
+        "bucket": "pocket-test-event-bridge-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-event-bridge-lambda_code-bucket-public-access-block_A1A4EF9D\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-event-bridge-lambda_code-bucket-public-access-block_A1A4EF9D": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-event-bridge-lambda_code-bucket_3703E73B.id}"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketPagerDuty.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketPagerDuty.spec.ts.snap
@@ -2,111 +2,111 @@
 
 exports[`renders a Pocket PagerDuty for critical and non-critical actions 1`] = `
 "{
-  \\"data\\": {
-    \\"pagerduty_vendor\\": {
-      \\"test-pagerduty_cloudwatch_8824B7B3\\": {
-        \\"name\\": \\"Cloudwatch\\"
+  "data": {
+    "pagerduty_vendor": {
+      "test-pagerduty_cloudwatch_8824B7B3": {
+        "name": "Cloudwatch"
       },
-      \\"test-pagerduty_sentry_896D6C2C\\": {
-        \\"name\\": \\"Sentry\\"
+      "test-pagerduty_sentry_896D6C2C": {
+        "name": "Sentry"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"test-pagerduty_alarm-critical-topic_5B8FEE8D\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Critical\\",
-        \\"tags\\": {
+  "resource": {
+    "aws_sns_topic": {
+      "test-pagerduty_alarm-critical-topic_5B8FEE8D": {
+        "name": "Test-Env-Infrastructure-Alarm-Critical",
+        "tags": {
         }
       },
-      \\"test-pagerduty_alarm-non-critical-topic_3FD65796\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Non-Critical\\",
-        \\"tags\\": {
+      "test-pagerduty_alarm-non-critical-topic_3FD65796": {
+        "name": "Test-Env-Infrastructure-Alarm-Non-Critical",
+        "tags": {
         }
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"test-pagerduty_alarm-critical-subscription_ABC78F4F\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\"
+    "aws_sns_topic_subscription": {
+      "test-pagerduty_alarm-critical-subscription_ABC78F4F": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}"
       },
-      \\"test-pagerduty_alarm-non-critical-subscription_D80993D9\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\"
+      "test-pagerduty_alarm-non-critical-subscription_D80993D9": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}"
       }
     },
-    \\"pagerduty_service\\": {
-      \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Critical\\",
-        \\"escalation_policy\\": \\"critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"high\\"
+    "pagerduty_service": {
+      "test-pagerduty_pagerduty-critical_3EB714BD": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Critical",
+        "escalation_policy": "critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "high"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
+        "name": "Test-Env-PagerDuty-Critical"
       },
-      \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Non-Critical\\",
-        \\"escalation_policy\\": \\"non-critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"low\\"
+      "test-pagerduty_pagerduty-non-critical_BBC21A2B": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Non-Critical",
+        "escalation_policy": "non-critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "low"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Non-Critical\\"
+        "name": "Test-Env-PagerDuty-Non-Critical"
       }
     },
-    \\"pagerduty_service_integration\\": {
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+    "pagerduty_service_integration": {
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       }
     }
   }
@@ -115,111 +115,111 @@ exports[`renders a Pocket PagerDuty for critical and non-critical actions 1`] = 
 
 exports[`renders a Pocket PagerDuty with custom acknowledgement timeout 1`] = `
 "{
-  \\"data\\": {
-    \\"pagerduty_vendor\\": {
-      \\"test-pagerduty_cloudwatch_8824B7B3\\": {
-        \\"name\\": \\"Cloudwatch\\"
+  "data": {
+    "pagerduty_vendor": {
+      "test-pagerduty_cloudwatch_8824B7B3": {
+        "name": "Cloudwatch"
       },
-      \\"test-pagerduty_sentry_896D6C2C\\": {
-        \\"name\\": \\"Sentry\\"
+      "test-pagerduty_sentry_896D6C2C": {
+        "name": "Sentry"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"test-pagerduty_alarm-critical-topic_5B8FEE8D\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Critical\\",
-        \\"tags\\": {
+  "resource": {
+    "aws_sns_topic": {
+      "test-pagerduty_alarm-critical-topic_5B8FEE8D": {
+        "name": "Test-Env-Infrastructure-Alarm-Critical",
+        "tags": {
         }
       },
-      \\"test-pagerduty_alarm-non-critical-topic_3FD65796\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Non-Critical\\",
-        \\"tags\\": {
+      "test-pagerduty_alarm-non-critical-topic_3FD65796": {
+        "name": "Test-Env-Infrastructure-Alarm-Non-Critical",
+        "tags": {
         }
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"test-pagerduty_alarm-critical-subscription_ABC78F4F\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\"
+    "aws_sns_topic_subscription": {
+      "test-pagerduty_alarm-critical-subscription_ABC78F4F": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}"
       },
-      \\"test-pagerduty_alarm-non-critical-subscription_D80993D9\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\"
+      "test-pagerduty_alarm-non-critical-subscription_D80993D9": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}"
       }
     },
-    \\"pagerduty_service\\": {
-      \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"100\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Critical\\",
-        \\"escalation_policy\\": \\"critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"high\\"
+    "pagerduty_service": {
+      "test-pagerduty_pagerduty-critical_3EB714BD": {
+        "acknowledgement_timeout": "100",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Critical",
+        "escalation_policy": "critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "high"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
+        "name": "Test-Env-PagerDuty-Critical"
       },
-      \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"100\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Non-Critical\\",
-        \\"escalation_policy\\": \\"non-critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"low\\"
+      "test-pagerduty_pagerduty-non-critical_BBC21A2B": {
+        "acknowledgement_timeout": "100",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Non-Critical",
+        "escalation_policy": "non-critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "low"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Non-Critical\\"
+        "name": "Test-Env-PagerDuty-Non-Critical"
       }
     },
-    \\"pagerduty_service_integration\\": {
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+    "pagerduty_service_integration": {
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       }
     }
   }
@@ -228,111 +228,111 @@ exports[`renders a Pocket PagerDuty with custom acknowledgement timeout 1`] = `
 
 exports[`renders a Pocket PagerDuty with custom auto resolve timeout 1`] = `
 "{
-  \\"data\\": {
-    \\"pagerduty_vendor\\": {
-      \\"test-pagerduty_cloudwatch_8824B7B3\\": {
-        \\"name\\": \\"Cloudwatch\\"
+  "data": {
+    "pagerduty_vendor": {
+      "test-pagerduty_cloudwatch_8824B7B3": {
+        "name": "Cloudwatch"
       },
-      \\"test-pagerduty_sentry_896D6C2C\\": {
-        \\"name\\": \\"Sentry\\"
+      "test-pagerduty_sentry_896D6C2C": {
+        "name": "Sentry"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"test-pagerduty_alarm-critical-topic_5B8FEE8D\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Critical\\",
-        \\"tags\\": {
+  "resource": {
+    "aws_sns_topic": {
+      "test-pagerduty_alarm-critical-topic_5B8FEE8D": {
+        "name": "Test-Env-Infrastructure-Alarm-Critical",
+        "tags": {
         }
       },
-      \\"test-pagerduty_alarm-non-critical-topic_3FD65796\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Non-Critical\\",
-        \\"tags\\": {
+      "test-pagerduty_alarm-non-critical-topic_3FD65796": {
+        "name": "Test-Env-Infrastructure-Alarm-Non-Critical",
+        "tags": {
         }
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"test-pagerduty_alarm-critical-subscription_ABC78F4F\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\"
+    "aws_sns_topic_subscription": {
+      "test-pagerduty_alarm-critical-subscription_ABC78F4F": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}"
       },
-      \\"test-pagerduty_alarm-non-critical-subscription_D80993D9\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\"
+      "test-pagerduty_alarm-non-critical-subscription_D80993D9": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}"
       }
     },
-    \\"pagerduty_service\\": {
-      \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"4\\",
-        \\"description\\": \\"PagerDuty Critical\\",
-        \\"escalation_policy\\": \\"critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"high\\"
+    "pagerduty_service": {
+      "test-pagerduty_pagerduty-critical_3EB714BD": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "4",
+        "description": "PagerDuty Critical",
+        "escalation_policy": "critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "high"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
+        "name": "Test-Env-PagerDuty-Critical"
       },
-      \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"4\\",
-        \\"description\\": \\"PagerDuty Non-Critical\\",
-        \\"escalation_policy\\": \\"non-critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"low\\"
+      "test-pagerduty_pagerduty-non-critical_BBC21A2B": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "4",
+        "description": "PagerDuty Non-Critical",
+        "escalation_policy": "non-critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "low"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Non-Critical\\"
+        "name": "Test-Env-PagerDuty-Non-Critical"
       }
     },
-    \\"pagerduty_service_integration\\": {
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+    "pagerduty_service_integration": {
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       }
     }
   }
@@ -341,111 +341,111 @@ exports[`renders a Pocket PagerDuty with custom auto resolve timeout 1`] = `
 
 exports[`renders a Pocket PagerDuty with custom sns topic subscription confirmation timeout in minutes 1`] = `
 "{
-  \\"data\\": {
-    \\"pagerduty_vendor\\": {
-      \\"test-pagerduty_cloudwatch_8824B7B3\\": {
-        \\"name\\": \\"Cloudwatch\\"
+  "data": {
+    "pagerduty_vendor": {
+      "test-pagerduty_cloudwatch_8824B7B3": {
+        "name": "Cloudwatch"
       },
-      \\"test-pagerduty_sentry_896D6C2C\\": {
-        \\"name\\": \\"Sentry\\"
+      "test-pagerduty_sentry_896D6C2C": {
+        "name": "Sentry"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"test-pagerduty_alarm-critical-topic_5B8FEE8D\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Critical\\",
-        \\"tags\\": {
+  "resource": {
+    "aws_sns_topic": {
+      "test-pagerduty_alarm-critical-topic_5B8FEE8D": {
+        "name": "Test-Env-Infrastructure-Alarm-Critical",
+        "tags": {
         }
       },
-      \\"test-pagerduty_alarm-non-critical-topic_3FD65796\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Non-Critical\\",
-        \\"tags\\": {
+      "test-pagerduty_alarm-non-critical-topic_3FD65796": {
+        "name": "Test-Env-Infrastructure-Alarm-Non-Critical",
+        "tags": {
         }
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"test-pagerduty_alarm-critical-subscription_ABC78F4F\\": {
-        \\"confirmation_timeout_in_minutes\\": 10,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\"
+    "aws_sns_topic_subscription": {
+      "test-pagerduty_alarm-critical-subscription_ABC78F4F": {
+        "confirmation_timeout_in_minutes": 10,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}"
       },
-      \\"test-pagerduty_alarm-non-critical-subscription_D80993D9\\": {
-        \\"confirmation_timeout_in_minutes\\": 10,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\"
+      "test-pagerduty_alarm-non-critical-subscription_D80993D9": {
+        "confirmation_timeout_in_minutes": 10,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}"
       }
     },
-    \\"pagerduty_service\\": {
-      \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Critical\\",
-        \\"escalation_policy\\": \\"critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"high\\"
+    "pagerduty_service": {
+      "test-pagerduty_pagerduty-critical_3EB714BD": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Critical",
+        "escalation_policy": "critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "high"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
+        "name": "Test-Env-PagerDuty-Critical"
       },
-      \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Non-Critical\\",
-        \\"escalation_policy\\": \\"non-critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"low\\"
+      "test-pagerduty_pagerduty-non-critical_BBC21A2B": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Non-Critical",
+        "escalation_policy": "non-critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "low"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Non-Critical\\"
+        "name": "Test-Env-PagerDuty-Non-Critical"
       }
     },
-    \\"pagerduty_service_integration\\": {
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+    "pagerduty_service_integration": {
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       }
     }
   }
@@ -454,113 +454,113 @@ exports[`renders a Pocket PagerDuty with custom sns topic subscription confirmat
 
 exports[`renders a Pocket PagerDuty with sns topic tags 1`] = `
 "{
-  \\"data\\": {
-    \\"pagerduty_vendor\\": {
-      \\"test-pagerduty_cloudwatch_8824B7B3\\": {
-        \\"name\\": \\"Cloudwatch\\"
+  "data": {
+    "pagerduty_vendor": {
+      "test-pagerduty_cloudwatch_8824B7B3": {
+        "name": "Cloudwatch"
       },
-      \\"test-pagerduty_sentry_896D6C2C\\": {
-        \\"name\\": \\"Sentry\\"
+      "test-pagerduty_sentry_896D6C2C": {
+        "name": "Sentry"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_sns_topic\\": {
-      \\"test-pagerduty_alarm-critical-topic_5B8FEE8D\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Critical\\",
-        \\"tags\\": {
-          \\"Test\\": \\"Topic\\"
+  "resource": {
+    "aws_sns_topic": {
+      "test-pagerduty_alarm-critical-topic_5B8FEE8D": {
+        "name": "Test-Env-Infrastructure-Alarm-Critical",
+        "tags": {
+          "Test": "Topic"
         }
       },
-      \\"test-pagerduty_alarm-non-critical-topic_3FD65796\\": {
-        \\"name\\": \\"Test-Env-Infrastructure-Alarm-Non-Critical\\",
-        \\"tags\\": {
-          \\"Test\\": \\"Topic\\"
+      "test-pagerduty_alarm-non-critical-topic_3FD65796": {
+        "name": "Test-Env-Infrastructure-Alarm-Non-Critical",
+        "tags": {
+          "Test": "Topic"
         }
       }
     },
-    \\"aws_sns_topic_subscription\\": {
-      \\"test-pagerduty_alarm-critical-subscription_ABC78F4F\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\"
+    "aws_sns_topic_subscription": {
+      "test-pagerduty_alarm-critical-subscription_ABC78F4F": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-critical-topic_5B8FEE8D.arn}"
       },
-      \\"test-pagerduty_alarm-non-critical-subscription_D80993D9\\": {
-        \\"confirmation_timeout_in_minutes\\": 2,
-        \\"depends_on\\": [
-          \\"aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796\\",
-          \\"pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\"
+      "test-pagerduty_alarm-non-critical-subscription_D80993D9": {
+        "confirmation_timeout_in_minutes": 2,
+        "depends_on": [
+          "aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796",
+          "pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A"
         ],
-        \\"endpoint\\": \\"https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue\\",
-        \\"endpoint_auto_confirms\\": true,
-        \\"protocol\\": \\"https\\",
-        \\"topic_arn\\": \\"\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}\\"
+        "endpoint": "https://events.pagerduty.com/integration/\${pagerduty_service_integration.test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A.integration_key}/enqueue",
+        "endpoint_auto_confirms": true,
+        "protocol": "https",
+        "topic_arn": "\${aws_sns_topic.test-pagerduty_alarm-non-critical-topic_3FD65796.arn}"
       }
     },
-    \\"pagerduty_service\\": {
-      \\"test-pagerduty_pagerduty-critical_3EB714BD\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Critical\\",
-        \\"escalation_policy\\": \\"critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"high\\"
+    "pagerduty_service": {
+      "test-pagerduty_pagerduty-critical_3EB714BD": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Critical",
+        "escalation_policy": "critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "high"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Critical\\"
+        "name": "Test-Env-PagerDuty-Critical"
       },
-      \\"test-pagerduty_pagerduty-non-critical_BBC21A2B\\": {
-        \\"acknowledgement_timeout\\": \\"1800\\",
-        \\"alert_creation\\": \\"create_incidents\\",
-        \\"auto_resolve_timeout\\": \\"14400\\",
-        \\"description\\": \\"PagerDuty Non-Critical\\",
-        \\"escalation_policy\\": \\"non-critical-id\\",
-        \\"incident_urgency_rule\\": {
-          \\"type\\": \\"constant\\",
-          \\"urgency\\": \\"low\\"
+      "test-pagerduty_pagerduty-non-critical_BBC21A2B": {
+        "acknowledgement_timeout": "1800",
+        "alert_creation": "create_incidents",
+        "auto_resolve_timeout": "14400",
+        "description": "PagerDuty Non-Critical",
+        "escalation_policy": "non-critical-id",
+        "incident_urgency_rule": {
+          "type": "constant",
+          "urgency": "low"
         },
-        \\"name\\": \\"Test-Env-PagerDuty-Non-Critical\\"
+        "name": "Test-Env-PagerDuty-Non-Critical"
       }
     },
-    \\"pagerduty_service_integration\\": {
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+    "pagerduty_service_integration": {
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-critical_29FC10B0": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_cloudwatch_8824B7B3-non-critical_496C437A": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_cloudwatch_8824B7B3.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-critical_B5B900DE": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-critical_3EB714BD.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       },
-      \\"test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD\\": {
-        \\"depends_on\\": [
-          \\"pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B\\"
+      "test-pagerduty_test-pagerduty_sentry_896D6C2C-non-critical_15A9D0BD": {
+        "depends_on": [
+          "pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B"
         ],
-        \\"name\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}\\",
-        \\"service\\": \\"\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}\\",
-        \\"vendor\\": \\"\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}\\"
+        "name": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.name}",
+        "service": "\${pagerduty_service.test-pagerduty_pagerduty-non-critical_BBC21A2B.id}",
+        "vendor": "\${data.pagerduty_vendor.test-pagerduty_sentry_896D6C2C.id}"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSQSWithLambdaTarget.spec.ts.snap
@@ -2,181 +2,181 @@
 
 exports[`renders a lambda triggered by an existing sqs queue 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-sqs-lambda_lambda-default-file_52E1CC8A\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-sqs-lambda_lambda-default-file_52E1CC8A": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-sqs-lambda_assume-policy-document_98DE5C4D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-sqs-lambda_assume-policy-document_98DE5C4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-sqs-lambda_execution-policy-document_2C5F0106\\": {
-        \\"statement\\": [
+      "test-sqs-lambda_execution-policy-document_2C5F0106": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-sqs-lambda_lambda_sqs_policy_3C63A136\\": {
-        \\"statement\\": [
+      "test-sqs-lambda_lambda_sqs_policy_3C63A136": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\",
-              \\"sqs:ReceiveMessage\\",
-              \\"sqs:DeleteMessage\\",
-              \\"sqs:GetQueueAttributes\\",
-              \\"sqs:ChangeMessageVisibility\\"
+            "actions": [
+              "sqs:SendMessage",
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+              "sqs:ChangeMessageVisibility"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${data.aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_D097423A.arn}\\"
+            "effect": "Allow",
+            "resources": [
+              "\${data.aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_D097423A.arn}"
             ]
           }
         ]
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"test-sqs-lambda_lambda_sqs_queue_D097423A\\": {
-        \\"name\\": \\"my-existing-sqs\\"
+    "aws_sqs_queue": {
+      "test-sqs-lambda_lambda_sqs_queue_D097423A": {
+        "name": "my-existing-sqs"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-sqs-lambda_log-group_F69AB78F\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-sqs-lambda_log-group_F69AB78F": {
+        "depends_on": [
+          "aws_lambda_function.test-sqs-lambda_C2DB9DC9"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-sqs-lambda_execution-policy_ED32F1C0\\": {
-        \\"name\\": \\"test-sqs-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}\\"
+    "aws_iam_policy": {
+      "test-sqs-lambda_execution-policy_ED32F1C0": {
+        "name": "test-sqs-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}"
       },
-      \\"test-sqs-lambda_sqs-policy_E98CC69F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\"
+      "test-sqs-lambda_sqs-policy_E98CC69F": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9"
         ],
-        \\"name\\": \\"test-sqs-lambda-LambdaSQSPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}\\"
+        "name": "test-sqs-lambda-LambdaSQSPolicy",
+        "policy": "\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-sqs-lambda_execution-role_7323CCD9\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}\\",
-        \\"name\\": \\"test-sqs-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-sqs-lambda_execution-role_7323CCD9": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}",
+        "name": "test-sqs-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-sqs-lambda_execution-role-policy-attachment_45759A7F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
-          \\"aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0\\"
+    "aws_iam_role_policy_attachment": {
+      "test-sqs-lambda_execution-role-policy-attachment_45759A7F": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9",
+          "aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}",
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}"
       },
-      \\"test-sqs-lambda_execution-role-policy-attachment_CA21C309\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
-          \\"aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F\\"
+      "test-sqs-lambda_execution-role-policy-attachment_CA21C309": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9",
+          "aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}",
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-sqs-lambda_alias_2C2A09A2\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+    "aws_lambda_alias": {
+      "test-sqs-lambda_alias_2C2A09A2": {
+        "depends_on": [
+          "aws_lambda_function.test-sqs-lambda_C2DB9DC9"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_event_source_mapping\\": {
-      \\"test-sqs-lambda_lambda_event_source_mapping_C60D5FF2\\": {
-        \\"event_source_arn\\": \\"\${data.aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_D097423A.arn}\\",
-        \\"function_name\\": \\"\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}\\"
+    "aws_lambda_event_source_mapping": {
+      "test-sqs-lambda_lambda_event_source_mapping_C60D5FF2": {
+        "event_source_arn": "\${data.aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_D097423A.arn}",
+        "function_name": "\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-sqs-lambda_C2DB9DC9\\": {
-        \\"filename\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}\\",
-        \\"function_name\\": \\"test-sqs-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-sqs-lambda_C2DB9DC9": {
+        "filename": "\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}",
+        "function_name": "test-sqs-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-sqs-lambda_code-bucket_34D549A2\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-sqs-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-sqs-lambda_code-bucket_34D549A2": {
+        "acl": "private",
+        "bucket": "pocket-test-sqs-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-sqs-lambda_code-bucket-public-access-block_942034EC\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-sqs-lambda_code-bucket-public-access-block_942034EC": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}"
       }
     }
   }
@@ -185,182 +185,182 @@ exports[`renders a lambda triggered by an existing sqs queue 1`] = `
 
 exports[`renders a plain sqs queue and lambda target 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-sqs-lambda_lambda-default-file_52E1CC8A\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-sqs-lambda_lambda-default-file_52E1CC8A": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-sqs-lambda_assume-policy-document_98DE5C4D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-sqs-lambda_assume-policy-document_98DE5C4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-sqs-lambda_execution-policy-document_2C5F0106\\": {
-        \\"statement\\": [
+      "test-sqs-lambda_execution-policy-document_2C5F0106": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-sqs-lambda_lambda_sqs_policy_3C63A136\\": {
-        \\"statement\\": [
+      "test-sqs-lambda_lambda_sqs_policy_3C63A136": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\",
-              \\"sqs:ReceiveMessage\\",
-              \\"sqs:DeleteMessage\\",
-              \\"sqs:GetQueueAttributes\\",
-              \\"sqs:ChangeMessageVisibility\\"
+            "actions": [
+              "sqs:SendMessage",
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+              "sqs:ChangeMessageVisibility"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-sqs-lambda_log-group_F69AB78F\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-sqs-lambda_log-group_F69AB78F": {
+        "depends_on": [
+          "aws_lambda_function.test-sqs-lambda_C2DB9DC9"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-sqs-lambda_execution-policy_ED32F1C0\\": {
-        \\"name\\": \\"test-sqs-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}\\"
+    "aws_iam_policy": {
+      "test-sqs-lambda_execution-policy_ED32F1C0": {
+        "name": "test-sqs-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}"
       },
-      \\"test-sqs-lambda_sqs-policy_E98CC69F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\"
+      "test-sqs-lambda_sqs-policy_E98CC69F": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9"
         ],
-        \\"name\\": \\"test-sqs-lambda-LambdaSQSPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}\\"
+        "name": "test-sqs-lambda-LambdaSQSPolicy",
+        "policy": "\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-sqs-lambda_execution-role_7323CCD9\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}\\",
-        \\"name\\": \\"test-sqs-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-sqs-lambda_execution-role_7323CCD9": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}",
+        "name": "test-sqs-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-sqs-lambda_execution-role-policy-attachment_45759A7F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
-          \\"aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0\\"
+    "aws_iam_role_policy_attachment": {
+      "test-sqs-lambda_execution-role-policy-attachment_45759A7F": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9",
+          "aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}",
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}"
       },
-      \\"test-sqs-lambda_execution-role-policy-attachment_CA21C309\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
-          \\"aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F\\"
+      "test-sqs-lambda_execution-role-policy-attachment_CA21C309": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9",
+          "aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}",
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-sqs-lambda_alias_2C2A09A2\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+    "aws_lambda_alias": {
+      "test-sqs-lambda_alias_2C2A09A2": {
+        "depends_on": [
+          "aws_lambda_function.test-sqs-lambda_C2DB9DC9"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_event_source_mapping\\": {
-      \\"test-sqs-lambda_lambda_event_source_mapping_C60D5FF2\\": {
-        \\"event_source_arn\\": \\"\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}\\",
-        \\"function_name\\": \\"\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}\\"
+    "aws_lambda_event_source_mapping": {
+      "test-sqs-lambda_lambda_event_source_mapping_C60D5FF2": {
+        "event_source_arn": "\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}",
+        "function_name": "\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-sqs-lambda_C2DB9DC9\\": {
-        \\"filename\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}\\",
-        \\"function_name\\": \\"test-sqs-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-sqs-lambda_C2DB9DC9": {
+        "filename": "\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}",
+        "function_name": "test-sqs-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-sqs-lambda_code-bucket_34D549A2\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-sqs-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-sqs-lambda_code-bucket_34D549A2": {
+        "acl": "private",
+        "bucket": "pocket-test-sqs-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-sqs-lambda_code-bucket-public-access-block_942034EC\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-sqs-lambda_code-bucket-public-access-block_942034EC": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"test-sqs-lambda_lambda_sqs_queue_7C6D24B3\\": {
-        \\"fifo_queue\\": false,
-        \\"name\\": \\"test-sqs-lambda-Queue\\"
+    "aws_sqs_queue": {
+      "test-sqs-lambda_lambda_sqs_queue_7C6D24B3": {
+        "fifo_queue": false,
+        "name": "test-sqs-lambda-Queue"
       }
     }
   }
@@ -369,187 +369,187 @@ exports[`renders a plain sqs queue and lambda target 1`] = `
 
 exports[`renders a plain sqs queue with a deadletter and lambda target 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-sqs-lambda_lambda-default-file_52E1CC8A\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-sqs-lambda_lambda-default-file_52E1CC8A": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-sqs-lambda_assume-policy-document_98DE5C4D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-sqs-lambda_assume-policy-document_98DE5C4D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-sqs-lambda_execution-policy-document_2C5F0106\\": {
-        \\"statement\\": [
+      "test-sqs-lambda_execution-policy-document_2C5F0106": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-sqs-lambda_lambda_sqs_policy_3C63A136\\": {
-        \\"statement\\": [
+      "test-sqs-lambda_lambda_sqs_policy_3C63A136": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sqs:SendMessage\\",
-              \\"sqs:ReceiveMessage\\",
-              \\"sqs:DeleteMessage\\",
-              \\"sqs:GetQueueAttributes\\",
-              \\"sqs:ChangeMessageVisibility\\"
+            "actions": [
+              "sqs:SendMessage",
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+              "sqs:ChangeMessageVisibility"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}\\"
+            "effect": "Allow",
+            "resources": [
+              "\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}"
             ]
           }
         ]
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-sqs-lambda_log-group_F69AB78F\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-sqs-lambda_log-group_F69AB78F": {
+        "depends_on": [
+          "aws_lambda_function.test-sqs-lambda_C2DB9DC9"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-sqs-lambda_execution-policy_ED32F1C0\\": {
-        \\"name\\": \\"test-sqs-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}\\"
+    "aws_iam_policy": {
+      "test-sqs-lambda_execution-policy_ED32F1C0": {
+        "name": "test-sqs-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-sqs-lambda_execution-policy-document_2C5F0106.json}"
       },
-      \\"test-sqs-lambda_sqs-policy_E98CC69F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\"
+      "test-sqs-lambda_sqs-policy_E98CC69F": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9"
         ],
-        \\"name\\": \\"test-sqs-lambda-LambdaSQSPolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}\\"
+        "name": "test-sqs-lambda-LambdaSQSPolicy",
+        "policy": "\${data.aws_iam_policy_document.test-sqs-lambda_lambda_sqs_policy_3C63A136.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-sqs-lambda_execution-role_7323CCD9\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}\\",
-        \\"name\\": \\"test-sqs-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-sqs-lambda_execution-role_7323CCD9": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-sqs-lambda_assume-policy-document_98DE5C4D.json}",
+        "name": "test-sqs-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-sqs-lambda_execution-role-policy-attachment_45759A7F\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
-          \\"aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0\\"
+    "aws_iam_role_policy_attachment": {
+      "test-sqs-lambda_execution-role-policy-attachment_45759A7F": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9",
+          "aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-sqs-lambda_execution-policy_ED32F1C0.arn}",
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}"
       },
-      \\"test-sqs-lambda_execution-role-policy-attachment_CA21C309\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-sqs-lambda_execution-role_7323CCD9\\",
-          \\"aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F\\"
+      "test-sqs-lambda_execution-role-policy-attachment_CA21C309": {
+        "depends_on": [
+          "aws_iam_role.test-sqs-lambda_execution-role_7323CCD9",
+          "aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-sqs-lambda_sqs-policy_E98CC69F.arn}",
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-sqs-lambda_alias_2C2A09A2\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-sqs-lambda_C2DB9DC9\\"
+    "aws_lambda_alias": {
+      "test-sqs-lambda_alias_2C2A09A2": {
+        "depends_on": [
+          "aws_lambda_function.test-sqs-lambda_C2DB9DC9"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-sqs-lambda_C2DB9DC9.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-sqs-lambda_C2DB9DC9.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_event_source_mapping\\": {
-      \\"test-sqs-lambda_lambda_event_source_mapping_C60D5FF2\\": {
-        \\"event_source_arn\\": \\"\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}\\",
-        \\"function_name\\": \\"\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}\\"
+    "aws_lambda_event_source_mapping": {
+      "test-sqs-lambda_lambda_event_source_mapping_C60D5FF2": {
+        "event_source_arn": "\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_7C6D24B3.arn}",
+        "function_name": "\${aws_lambda_alias.test-sqs-lambda_alias_2C2A09A2.arn}"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-sqs-lambda_C2DB9DC9\\": {
-        \\"filename\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}\\",
-        \\"function_name\\": \\"test-sqs-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-sqs-lambda_C2DB9DC9": {
+        "filename": "\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_path}",
+        "function_name": "test-sqs-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-sqs-lambda_execution-role_7323CCD9.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-sqs-lambda_lambda-default-file_52E1CC8A.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-sqs-lambda_code-bucket_34D549A2\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-sqs-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-sqs-lambda_code-bucket_34D549A2": {
+        "acl": "private",
+        "bucket": "pocket-test-sqs-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-sqs-lambda_code-bucket-public-access-block_942034EC\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-sqs-lambda_code-bucket-public-access-block_942034EC": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-sqs-lambda_code-bucket_34D549A2.id}"
       }
     },
-    \\"aws_sqs_queue\\": {
-      \\"test-sqs-lambda_lambda_sqs_queue_7C6D24B3\\": {
-        \\"fifo_queue\\": false,
-        \\"name\\": \\"test-sqs-lambda-Queue\\",
-        \\"redrive_policy\\": \\"{\\\\\\"maxReceiveCount\\\\\\":3,\\\\\\"deadLetterTargetArn\\\\\\":\\\\\\"\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_redrive_sqs_queue_EBFF9A33.arn}\\\\\\"}\\"
+    "aws_sqs_queue": {
+      "test-sqs-lambda_lambda_sqs_queue_7C6D24B3": {
+        "fifo_queue": false,
+        "name": "test-sqs-lambda-Queue",
+        "redrive_policy": "{\\"maxReceiveCount\\":3,\\"deadLetterTargetArn\\":\\"\${aws_sqs_queue.test-sqs-lambda_lambda_sqs_queue_redrive_sqs_queue_EBFF9A33.arn}\\"}"
       },
-      \\"test-sqs-lambda_lambda_sqs_queue_redrive_sqs_queue_EBFF9A33\\": {
-        \\"fifo_queue\\": false,
-        \\"name\\": \\"test-sqs-lambda-Queue-Deadletter\\"
+      "test-sqs-lambda_lambda_sqs_queue_redrive_sqs_queue_EBFF9A33": {
+        "fifo_queue": false,
+        "name": "test-sqs-lambda-Queue-Deadletter"
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketSynthetics.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketSynthetics.spec.ts.snap
@@ -2,44 +2,44 @@
 
 exports[`allows passing different values for nrql config 1`] = `
 "{
-  \\"resource\\": {
-    \\"newrelic_nrql_alert_condition\\": {
-      \\"test-synthetic_alert-condition_4C991B53\\": {
-        \\"aggregation_delay\\": \\"180\\",
-        \\"aggregation_method\\": \\"cadence\\",
-        \\"aggregation_window\\": 3000,
-        \\"close_violations_on_expiration\\": true,
-        \\"critical\\": {
-          \\"operator\\": \\"above\\",
-          \\"threshold\\": 2,
-          \\"threshold_duration\\": 900,
-          \\"threshold_occurrences\\": \\"AT_LEAST_ONCE\\"
+  "resource": {
+    "newrelic_nrql_alert_condition": {
+      "test-synthetic_alert-condition_4C991B53": {
+        "aggregation_delay": "180",
+        "aggregation_method": "cadence",
+        "aggregation_window": 3000,
+        "close_violations_on_expiration": true,
+        "critical": {
+          "operator": "above",
+          "threshold": 2,
+          "threshold_duration": 900,
+          "threshold_occurrences": "AT_LEAST_ONCE"
         },
-        \\"expiration_duration\\": 600,
-        \\"fill_option\\": \\"static\\",
-        \\"fill_value\\": 0,
-        \\"name\\": \\"test-synthetic-nrql\\",
-        \\"nrql\\": {
-          \\"query\\": \\"SELECT * FROM MY-COOL-TABLE\\"
+        "expiration_duration": 600,
+        "fill_option": "static",
+        "fill_value": 0,
+        "name": "test-synthetic-nrql",
+        "nrql": {
+          "query": "SELECT * FROM MY-COOL-TABLE"
         },
-        \\"policy_id\\": 1707149,
-        \\"slide_by\\": 60,
-        \\"violation_time_limit_seconds\\": 2592000
+        "policy_id": 1707149,
+        "slide_by": 60,
+        "violation_time_limit_seconds": 2592000
       }
     },
-    \\"newrelic_synthetics_monitor\\": {
-      \\"test-synthetic_test-synthetic-synthetics-monitor_914DC880\\": {
-        \\"locations_public\\": [
-          \\"AWS_US_WEST_2\\",
-          \\"AWS_EU_WEST_2\\",
-          \\"AWS_US_EAST_2\\"
+    "newrelic_synthetics_monitor": {
+      "test-synthetic_test-synthetic-synthetics-monitor_914DC880": {
+        "locations_public": [
+          "AWS_US_WEST_2",
+          "AWS_EU_WEST_2",
+          "AWS_US_EAST_2"
         ],
-        \\"name\\": \\"test-synthetic-synthetics\\",
-        \\"period\\": \\"EVERY_5_MINUTES\\",
-        \\"status\\": \\"ENABLED\\",
-        \\"type\\": \\"SIMPLE\\",
-        \\"uri\\": \\"acme.getpocket.dev\\",
-        \\"verify_ssl\\": true
+        "name": "test-synthetic-synthetics",
+        "period": "EVERY_5_MINUTES",
+        "status": "ENABLED",
+        "type": "SIMPLE",
+        "uri": "acme.getpocket.dev",
+        "verify_ssl": true
       }
     }
   }
@@ -48,44 +48,44 @@ exports[`allows passing different values for nrql config 1`] = `
 
 exports[`renders a Pocket New Relic synthetic check 1`] = `
 "{
-  \\"resource\\": {
-    \\"newrelic_nrql_alert_condition\\": {
-      \\"test-synthetic_alert-condition_4C991B53\\": {
-        \\"aggregation_delay\\": \\"180\\",
-        \\"aggregation_method\\": \\"cadence\\",
-        \\"aggregation_window\\": 3000,
-        \\"close_violations_on_expiration\\": true,
-        \\"critical\\": {
-          \\"operator\\": \\"above\\",
-          \\"threshold\\": 2,
-          \\"threshold_duration\\": 900,
-          \\"threshold_occurrences\\": \\"AT_LEAST_ONCE\\"
+  "resource": {
+    "newrelic_nrql_alert_condition": {
+      "test-synthetic_alert-condition_4C991B53": {
+        "aggregation_delay": "180",
+        "aggregation_method": "cadence",
+        "aggregation_window": 3000,
+        "close_violations_on_expiration": true,
+        "critical": {
+          "operator": "above",
+          "threshold": 2,
+          "threshold_duration": 900,
+          "threshold_occurrences": "AT_LEAST_ONCE"
         },
-        \\"expiration_duration\\": 600,
-        \\"fill_option\\": \\"static\\",
-        \\"fill_value\\": 0,
-        \\"name\\": \\"test-synthetic-nrql\\",
-        \\"nrql\\": {
-          \\"query\\": \\"SELECT count(result) from SyntheticCheck where result = 'FAILED' and monitorName = '\${newrelic_synthetics_monitor.test-synthetic_test-synthetic-synthetics-monitor_914DC880.name}'\\"
+        "expiration_duration": 600,
+        "fill_option": "static",
+        "fill_value": 0,
+        "name": "test-synthetic-nrql",
+        "nrql": {
+          "query": "SELECT count(result) from SyntheticCheck where result = 'FAILED' and monitorName = '\${newrelic_synthetics_monitor.test-synthetic_test-synthetic-synthetics-monitor_914DC880.name}'"
         },
-        \\"policy_id\\": 1707149,
-        \\"slide_by\\": 60,
-        \\"violation_time_limit_seconds\\": 2592000
+        "policy_id": 1707149,
+        "slide_by": 60,
+        "violation_time_limit_seconds": 2592000
       }
     },
-    \\"newrelic_synthetics_monitor\\": {
-      \\"test-synthetic_test-synthetic-synthetics-monitor_914DC880\\": {
-        \\"locations_public\\": [
-          \\"AWS_US_WEST_2\\",
-          \\"AWS_EU_WEST_2\\",
-          \\"AWS_US_EAST_2\\"
+    "newrelic_synthetics_monitor": {
+      "test-synthetic_test-synthetic-synthetics-monitor_914DC880": {
+        "locations_public": [
+          "AWS_US_WEST_2",
+          "AWS_EU_WEST_2",
+          "AWS_US_EAST_2"
         ],
-        \\"name\\": \\"test-synthetic-synthetics\\",
-        \\"period\\": \\"EVERY_5_MINUTES\\",
-        \\"status\\": \\"ENABLED\\",
-        \\"type\\": \\"SIMPLE\\",
-        \\"uri\\": \\"acme.getpocket.dev\\",
-        \\"verify_ssl\\": true
+        "name": "test-synthetic-synthetics",
+        "period": "EVERY_5_MINUTES",
+        "status": "ENABLED",
+        "type": "SIMPLE",
+        "uri": "acme.getpocket.dev",
+        "verify_ssl": true
       }
     }
   }

--- a/src/pocket/__snapshots__/PocketVPC.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVPC.spec.ts.snap
@@ -2,102 +2,102 @@
 
 exports[`renders a VPC with minimal config 1`] = `
 "{
-  \\"data\\": {
-    \\"aws_caller_identity\\": {
-      \\"testPocketVPC_current_identity_433574E3\\": {
+  "data": {
+    "aws_caller_identity": {
+      "testPocketVPC_current_identity_433574E3": {
       }
     },
-    \\"aws_kms_alias\\": {
-      \\"testPocketVPC_secrets_manager_key_3F5AECFC\\": {
-        \\"name\\": \\"alias/aws/secretsmanager\\"
+    "aws_kms_alias": {
+      "testPocketVPC_secrets_manager_key_3F5AECFC": {
+        "name": "alias/aws/secretsmanager"
       }
     },
-    \\"aws_region\\": {
-      \\"testPocketVPC_current_region_1C1E28CD\\": {
+    "aws_region": {
+      "testPocketVPC_current_region_1C1E28CD": {
       }
     },
-    \\"aws_security_groups\\": {
-      \\"testPocketVPC_default_security_groups_48E7EA82\\": {
-        \\"filter\\": [
+    "aws_security_groups": {
+      "testPocketVPC_default_security_groups_48E7EA82": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"default\\"
+            "name": "group-name",
+            "values": [
+              "default"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}"
             ]
           }
         ]
       },
-      \\"testPocketVPC_internal_security_groups_2506B665\\": {
-        \\"filter\\": [
+      "testPocketVPC_internal_security_groups_2506B665": {
+        "filter": [
           {
-            \\"name\\": \\"group-name\\",
-            \\"values\\": [
-              \\"pocket-vpc-internal\\"
+            "name": "group-name",
+            "values": [
+              "pocket-vpc-internal"
             ]
           },
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}\\"
-            ]
-          }
-        ]
-      }
-    },
-    \\"aws_ssm_parameter\\": {
-      \\"testPocketVPC_private_subnets_3CC52CDC\\": {
-        \\"name\\": \\"/Shared/PrivateSubnets\\"
-      },
-      \\"testPocketVPC_public_subnets_21F01977\\": {
-        \\"name\\": \\"/Shared/PublicSubnets\\"
-      },
-      \\"testPocketVPC_vpc_ssm_param_DED34ABC\\": {
-        \\"name\\": \\"/Shared/Vpc\\"
-      }
-    },
-    \\"aws_subnets\\": {
-      \\"testPocketVPC_private_subnet_ids_61A307A3\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketVPC_private_subnets_3CC52CDC.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}\\"
-            ]
-          }
-        ]
-      },
-      \\"testPocketVPC_public_subnet_ids_5AC8BE89\\": {
-        \\"filter\\": [
-          {
-            \\"name\\": \\"subnet-id\\",
-            \\"values\\": \\"\${split(\\\\\\",\\\\\\", data.aws_ssm_parameter.testPocketVPC_public_subnets_21F01977.value)}\\"
-          },
-          {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}\\"
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}"
             ]
           }
         ]
       }
     },
-    \\"aws_vpc\\": {
-      \\"testPocketVPC_vpc_52CB41F5\\": {
-        \\"filter\\": [
+    "aws_ssm_parameter": {
+      "testPocketVPC_private_subnets_3CC52CDC": {
+        "name": "/Shared/PrivateSubnets"
+      },
+      "testPocketVPC_public_subnets_21F01977": {
+        "name": "/Shared/PublicSubnets"
+      },
+      "testPocketVPC_vpc_ssm_param_DED34ABC": {
+        "name": "/Shared/Vpc"
+      }
+    },
+    "aws_subnets": {
+      "testPocketVPC_private_subnet_ids_61A307A3": {
+        "filter": [
           {
-            \\"name\\": \\"vpc-id\\",
-            \\"values\\": [
-              \\"\${data.aws_ssm_parameter.testPocketVPC_vpc_ssm_param_DED34ABC.value}\\"
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketVPC_private_subnets_3CC52CDC.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}"
+            ]
+          }
+        ]
+      },
+      "testPocketVPC_public_subnet_ids_5AC8BE89": {
+        "filter": [
+          {
+            "name": "subnet-id",
+            "values": "\${split(\\",\\", data.aws_ssm_parameter.testPocketVPC_public_subnets_21F01977.value)}"
+          },
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_vpc.testPocketVPC_vpc_52CB41F5.id}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_vpc": {
+      "testPocketVPC_vpc_52CB41F5": {
+        "filter": [
+          {
+            "name": "vpc-id",
+            "values": [
+              "\${data.aws_ssm_parameter.testPocketVPC_vpc_ssm_param_DED34ABC.value}"
             ]
           }
         ]

--- a/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
+++ b/src/pocket/__snapshots__/PocketVersionedLambda.spec.ts.snap
@@ -2,163 +2,163 @@
 
 exports[`it can treat missing data as breaching 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"test-lambda_invocations_D15DE20B\\": {
-        \\"alarm_actions\\": [
+    "aws_cloudwatch_metric_alarm": {
+      "test-lambda_invocations_D15DE20B": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Total invocations breaches threshold\\",
-        \\"alarm_name\\": \\"test-lambda-Lambda-Invocations-Alarm\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"FunctionName\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}\\",
-          \\"Resource\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}\\"
+        "alarm_description": "Total invocations breaches threshold",
+        "alarm_name": "test-lambda-Lambda-Invocations-Alarm",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "FunctionName": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}",
+          "Resource": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"Invocations\\",
-        \\"namespace\\": \\"AWS/Lambda\\",
-        \\"ok_actions\\": [
+        "metric_name": "Invocations",
+        "namespace": "AWS/Lambda",
+        "ok_actions": [
         ],
-        \\"period\\": 60,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 1,
-        \\"treat_missing_data\\": \\"breaching\\"
+        "period": 60,
+        "statistic": "Sum",
+        "threshold": 1,
+        "treat_missing_data": "breaching"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -167,138 +167,138 @@ exports[`it can treat missing data as breaching 1`] = `
 
 exports[`renders a lambda target 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -307,158 +307,158 @@ exports[`renders a lambda target 1`] = `
 
 exports[`renders a lambda target with tags 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14,
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tags\\"
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14,
+        "tags": {
+          "for": "test",
+          "my": "tags"
         }
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tags\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}",
+        "tags": {
+          "for": "test",
+          "my": "tags"
         }
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tags\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole",
+        "tags": {
+          "for": "test",
+          "my": "tags"
         }
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tags\\"
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "tags": {
+          "for": "test",
+          "my": "tags"
         },
-        \\"timeout\\": 5
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true,
-        \\"tags\\": {
-          \\"for\\": \\"test\\",
-          \\"my\\": \\"tags\\"
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true,
+        "tags": {
+          "for": "test",
+          "my": "tags"
         }
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -467,255 +467,255 @@ exports[`renders a lambda target with tags 1`] = `
 
 exports[`renders a lambda with alarms 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_cloudwatch_metric_alarm\\": {
-      \\"test-lambda_concurrentexecutions_B7910145\\": {
-        \\"alarm_actions\\": [
+    "aws_cloudwatch_metric_alarm": {
+      "test-lambda_concurrentexecutions_B7910145": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Total concurrentexecutions breaches threshold\\",
-        \\"alarm_name\\": \\"test-lambda-Lambda-ConcurrentExecutions-Alarm\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"FunctionName\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}\\",
-          \\"Resource\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}\\"
+        "alarm_description": "Total concurrentexecutions breaches threshold",
+        "alarm_name": "test-lambda-Lambda-ConcurrentExecutions-Alarm",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "FunctionName": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}",
+          "Resource": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"ConcurrentExecutions\\",
-        \\"namespace\\": \\"AWS/Lambda\\",
-        \\"ok_actions\\": [
+        "metric_name": "ConcurrentExecutions",
+        "namespace": "AWS/Lambda",
+        "ok_actions": [
         ],
-        \\"period\\": 60,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 1,
-        \\"treat_missing_data\\": \\"missing\\"
+        "period": 60,
+        "statistic": "Sum",
+        "threshold": 1,
+        "treat_missing_data": "missing"
       },
-      \\"test-lambda_duration_E92A1EBB\\": {
-        \\"alarm_actions\\": [
+      "test-lambda_duration_E92A1EBB": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Total duration breaches threshold\\",
-        \\"alarm_name\\": \\"test-lambda-Lambda-Duration-Alarm\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"FunctionName\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}\\",
-          \\"Resource\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}\\"
+        "alarm_description": "Total duration breaches threshold",
+        "alarm_name": "test-lambda-Lambda-Duration-Alarm",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "FunctionName": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}",
+          "Resource": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"Duration\\",
-        \\"namespace\\": \\"AWS/Lambda\\",
-        \\"ok_actions\\": [
+        "metric_name": "Duration",
+        "namespace": "AWS/Lambda",
+        "ok_actions": [
         ],
-        \\"period\\": 60,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 1,
-        \\"treat_missing_data\\": \\"missing\\"
+        "period": 60,
+        "statistic": "Sum",
+        "threshold": 1,
+        "treat_missing_data": "missing"
       },
-      \\"test-lambda_errors_E579F2B3\\": {
-        \\"alarm_actions\\": [
+      "test-lambda_errors_E579F2B3": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Total errors breaches threshold\\",
-        \\"alarm_name\\": \\"test-lambda-Lambda-Errors-Alarm\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"FunctionName\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}\\",
-          \\"Resource\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}\\"
+        "alarm_description": "Total errors breaches threshold",
+        "alarm_name": "test-lambda-Lambda-Errors-Alarm",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "FunctionName": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}",
+          "Resource": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"Errors\\",
-        \\"namespace\\": \\"AWS/Lambda\\",
-        \\"ok_actions\\": [
+        "metric_name": "Errors",
+        "namespace": "AWS/Lambda",
+        "ok_actions": [
         ],
-        \\"period\\": 60,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 1,
-        \\"treat_missing_data\\": \\"missing\\"
+        "period": 60,
+        "statistic": "Sum",
+        "threshold": 1,
+        "treat_missing_data": "missing"
       },
-      \\"test-lambda_invocations_D15DE20B\\": {
-        \\"alarm_actions\\": [
+      "test-lambda_invocations_D15DE20B": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Total invocations breaches threshold\\",
-        \\"alarm_name\\": \\"test-lambda-Lambda-Invocations-Alarm\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"FunctionName\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}\\",
-          \\"Resource\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}\\"
+        "alarm_description": "Total invocations breaches threshold",
+        "alarm_name": "test-lambda-Lambda-Invocations-Alarm",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "FunctionName": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}",
+          "Resource": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"Invocations\\",
-        \\"namespace\\": \\"AWS/Lambda\\",
-        \\"ok_actions\\": [
+        "metric_name": "Invocations",
+        "namespace": "AWS/Lambda",
+        "ok_actions": [
         ],
-        \\"period\\": 60,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 1,
-        \\"treat_missing_data\\": \\"missing\\"
+        "period": 60,
+        "statistic": "Sum",
+        "threshold": 1,
+        "treat_missing_data": "missing"
       },
-      \\"test-lambda_throttles_562A3BCE\\": {
-        \\"alarm_actions\\": [
+      "test-lambda_throttles_562A3BCE": {
+        "alarm_actions": [
         ],
-        \\"alarm_description\\": \\"Total throttles breaches threshold\\",
-        \\"alarm_name\\": \\"test-lambda-Lambda-Throttles-Alarm\\",
-        \\"comparison_operator\\": \\"GreaterThanThreshold\\",
-        \\"datapoints_to_alarm\\": 1,
-        \\"dimensions\\": {
-          \\"FunctionName\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}\\",
-          \\"Resource\\": \\"\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}\\"
+        "alarm_description": "Total throttles breaches threshold",
+        "alarm_name": "test-lambda-Lambda-Throttles-Alarm",
+        "comparison_operator": "GreaterThanThreshold",
+        "datapoints_to_alarm": 1,
+        "dimensions": {
+          "FunctionName": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}",
+          "Resource": "\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.function_name}:\${aws_lambda_alias.test-lambda_alias_CCFDFCE9.name}"
         },
-        \\"evaluation_periods\\": 1,
-        \\"insufficient_data_actions\\": [
+        "evaluation_periods": 1,
+        "insufficient_data_actions": [
         ],
-        \\"metric_name\\": \\"Throttles\\",
-        \\"namespace\\": \\"AWS/Lambda\\",
-        \\"ok_actions\\": [
+        "metric_name": "Throttles",
+        "namespace": "AWS/Lambda",
+        "ok_actions": [
         ],
-        \\"period\\": 60,
-        \\"statistic\\": \\"Sum\\",
-        \\"threshold\\": 1,
-        \\"treat_missing_data\\": \\"missing\\"
+        "period": 60,
+        "statistic": "Sum",
+        "threshold": 1,
+        "treat_missing_data": "missing"
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -724,70 +724,70 @@ exports[`renders a lambda with alarms 1`] = `
 
 exports[`renders a lambda with code deploy 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39\\": {
-        \\"statement\\": [
+      "test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -795,139 +795,139 @@ exports[`renders a lambda with code deploy 1`] = `
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda_lambda-code-deploy_code-deploy-app_7C98647C\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"test-lambda-Lambda\\"
+    "aws_codedeploy_app": {
+      "test-lambda_lambda-code-deploy_code-deploy-app_7C98647C": {
+        "compute_platform": "Lambda",
+        "name": "test-lambda-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda_lambda-code-deploy_code-deployment-group_07908CD9\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda_lambda-code-deploy_code-deployment-group_07908CD9": {
+        "app_name": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda_lambda-code-deploy_notifications_E3D09B45\\": {
-        \\"detail_type\\": \\"FULL\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda_lambda-code-deploy_notifications_E3D09B45": {
+        "detail_type": "FULL",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:test-account:application:\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:test-account:application:\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "target": [
           {
-            \\"address\\": \\"arn:test\\"
+            "address": "arn:test"
           }
         ]
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       },
-      \\"test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39.json}\\",
-        \\"name\\": \\"test-lambda-CodeDeployRole\\"
+      "test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39.json}",
+        "name": "test-lambda-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       },
-      \\"test-lambda_lambda-code-deploy_code-deploy-policy-attachment_0805E344\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC\\"
+      "test-lambda_lambda-code-deploy_code-deploy-policy-attachment_0805E344": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\",
-            \\"publish\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash",
+            "publish"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -936,70 +936,70 @@ exports[`renders a lambda with code deploy 1`] = `
 
 exports[`renders a lambda with code deploy with all deploy notifications turned on 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39\\": {
-        \\"statement\\": [
+      "test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"codedeploy.amazonaws.com\\"
+                "identifiers": [
+                  "codedeploy.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
@@ -1007,141 +1007,141 @@ exports[`renders a lambda with code deploy with all deploy notifications turned 
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_codedeploy_app\\": {
-      \\"test-lambda_lambda-code-deploy_code-deploy-app_7C98647C\\": {
-        \\"compute_platform\\": \\"Lambda\\",
-        \\"name\\": \\"test-lambda-Lambda\\"
+    "aws_codedeploy_app": {
+      "test-lambda_lambda-code-deploy_code-deploy-app_7C98647C": {
+        "compute_platform": "Lambda",
+        "name": "test-lambda-Lambda"
       }
     },
-    \\"aws_codedeploy_deployment_group\\": {
-      \\"test-lambda_lambda-code-deploy_code-deployment-group_07908CD9\\": {
-        \\"app_name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"auto_rollback_configuration\\": {
-          \\"enabled\\": true,
-          \\"events\\": [
-            \\"DEPLOYMENT_FAILURE\\"
+    "aws_codedeploy_deployment_group": {
+      "test-lambda_lambda-code-deploy_code-deployment-group_07908CD9": {
+        "app_name": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "auto_rollback_configuration": {
+          "enabled": true,
+          "events": [
+            "DEPLOYMENT_FAILURE"
           ]
         },
-        \\"depends_on\\": [
-          \\"aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C\\"
+        "depends_on": [
+          "aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C"
         ],
-        \\"deployment_config_name\\": \\"CodeDeployDefault.LambdaAllAtOnce\\",
-        \\"deployment_group_name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"deployment_style\\": {
-          \\"deployment_option\\": \\"WITH_TRAFFIC_CONTROL\\",
-          \\"deployment_type\\": \\"BLUE_GREEN\\"
+        "deployment_config_name": "CodeDeployDefault.LambdaAllAtOnce",
+        "deployment_group_name": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "deployment_style": {
+          "deployment_option": "WITH_TRAFFIC_CONTROL",
+          "deployment_type": "BLUE_GREEN"
         },
-        \\"service_role_arn\\": \\"\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.arn}\\"
+        "service_role_arn": "\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.arn}"
       }
     },
-    \\"aws_codestarnotifications_notification_rule\\": {
-      \\"test-lambda_lambda-code-deploy_notifications_E3D09B45\\": {
-        \\"detail_type\\": \\"FULL\\",
-        \\"event_type_ids\\": [
-          \\"codedeploy-application-deployment-failed\\",
-          \\"codedeploy-application-deployment-succeeded\\",
-          \\"codedeploy-application-deployment-started\\"
+    "aws_codestarnotifications_notification_rule": {
+      "test-lambda_lambda-code-deploy_notifications_E3D09B45": {
+        "detail_type": "FULL",
+        "event_type_ids": [
+          "codedeploy-application-deployment-failed",
+          "codedeploy-application-deployment-succeeded",
+          "codedeploy-application-deployment-started"
         ],
-        \\"name\\": \\"\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"resource\\": \\"arn:aws:codedeploy:us-east-1:test-account:application:\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}\\",
-        \\"target\\": [
+        "name": "\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "resource": "arn:aws:codedeploy:us-east-1:test-account:application:\${aws_codedeploy_app.test-lambda_lambda-code-deploy_code-deploy-app_7C98647C.name}",
+        "target": [
           {
-            \\"address\\": \\"arn:test\\"
+            "address": "arn:test"
           }
         ]
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       },
-      \\"test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39.json}\\",
-        \\"name\\": \\"test-lambda-CodeDeployRole\\"
+      "test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_lambda-code-deploy_code-deploy-assume-role-policy-document_C6C06F39.json}",
+        "name": "test-lambda-CodeDeployRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       },
-      \\"test-lambda_lambda-code-deploy_code-deploy-policy-attachment_0805E344\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC\\"
+      "test-lambda_lambda-code-deploy_code-deploy-policy-attachment_0805E344": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC"
         ],
-        \\"policy_arn\\": \\"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.name}\\"
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+        "role": "\${aws_iam_role.test-lambda_lambda-code-deploy_code-deploy-role_6EA86ECC.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\",
-            \\"publish\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash",
+            "publish"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -1150,138 +1150,138 @@ exports[`renders a lambda with code deploy with all deploy notifications turned 
 
 exports[`renders a lambda with concurrencyLimit 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": 10,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": 10,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -1290,144 +1290,144 @@ exports[`renders a lambda with concurrencyLimit 1`] = `
 
 exports[`renders a lambda with environment variables 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"environment\\": {
-          \\"variables\\": {
-            \\"IS\\": \\"good\\",
-            \\"my\\": \\"var\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "environment": {
+          "variables": {
+            "IS": "good",
+            "my": "var"
           }
         },
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -1436,147 +1436,147 @@ exports[`renders a lambda with environment variables 1`] = `
 
 exports[`renders a lambda with execution policy 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"*\\"
+            "actions": [
+              "*"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -1585,138 +1585,138 @@ exports[`renders a lambda with execution policy 1`] = `
 
 exports[`renders a lambda with lambda description 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -1725,138 +1725,138 @@ exports[`renders a lambda with lambda description 1`] = `
 
 exports[`renders a lambda with log retention 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 10
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 10
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -1865,138 +1865,138 @@ exports[`renders a lambda with log retention 1`] = `
 
 exports[`renders a lambda with memorySizeInMb 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 512,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 512,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -2005,138 +2005,138 @@ exports[`renders a lambda with memorySizeInMb 1`] = `
 
 exports[`renders a lambda with s3 bucket 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"test-bucket\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "test-bucket",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -2145,138 +2145,138 @@ exports[`renders a lambda with s3 bucket 1`] = `
 
 exports[`renders a lambda with timeout 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 300
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 300
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }
@@ -2285,161 +2285,161 @@ exports[`renders a lambda with timeout 1`] = `
 
 exports[`renders a lambda with vpc config 1`] = `
 "{
-  \\"data\\": {
-    \\"archive_file\\": {
-      \\"test-lambda_lambda-default-file_7A7DBB68\\": {
-        \\"output_path\\": \\"index.py.zip\\",
-        \\"source\\": [
+  "data": {
+    "archive_file": {
+      "test-lambda_lambda-default-file_7A7DBB68": {
+        "output_path": "index.py.zip",
+        "source": [
           {
-            \\"content\\": \\"import json\\\\ndef handler(event, context):\\\\n\\\\t print(event)\\\\n\\\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}\\",
-            \\"filename\\": \\"index.py\\"
+            "content": "import json\\ndef handler(event, context):\\n\\t print(event)\\n\\t return {'statusCode': 200, 'headers': {'dance': 'party'}, 'body': json.dumps({'electric': 'boogaloo'}), 'isBase64Encoded': False}",
+            "filename": "index.py"
           }
         ],
-        \\"type\\": \\"zip\\"
+        "type": "zip"
       }
     },
-    \\"aws_iam_policy_document\\": {
-      \\"test-lambda_assume-policy-document_D538087D\\": {
-        \\"statement\\": [
+    "aws_iam_policy_document": {
+      "test-lambda_assume-policy-document_D538087D": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"sts:AssumeRole\\"
+            "actions": [
+              "sts:AssumeRole"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"principals\\": [
+            "effect": "Allow",
+            "principals": [
               {
-                \\"identifiers\\": [
-                  \\"lambda.amazonaws.com\\",
-                  \\"edgelambda.amazonaws.com\\"
+                "identifiers": [
+                  "lambda.amazonaws.com",
+                  "edgelambda.amazonaws.com"
                 ],
-                \\"type\\": \\"Service\\"
+                "type": "Service"
               }
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       },
-      \\"test-lambda_execution-policy-document_D94D17B4\\": {
-        \\"statement\\": [
+      "test-lambda_execution-policy-document_D94D17B4": {
+        "statement": [
           {
-            \\"actions\\": [
-              \\"logs:CreateLogGroup\\",
-              \\"logs:CreateLogStream\\",
-              \\"logs:PutLogEvents\\",
-              \\"logs:DescribeLogStreams\\"
+            "actions": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"arn:aws:logs:*:*:*\\"
+            "effect": "Allow",
+            "resources": [
+              "arn:aws:logs:*:*:*"
             ]
           },
           {
-            \\"actions\\": [
-              \\"ec2:DescribeNetworkInterfaces\\",
-              \\"ec2:CreateNetworkInterface\\",
-              \\"ec2:DeleteNetworkInterface\\",
-              \\"ec2:DescribeInstances\\",
-              \\"ec2:AttachNetworkInterface\\"
+            "actions": [
+              "ec2:DescribeNetworkInterfaces",
+              "ec2:CreateNetworkInterface",
+              "ec2:DeleteNetworkInterface",
+              "ec2:DescribeInstances",
+              "ec2:AttachNetworkInterface"
             ],
-            \\"effect\\": \\"Allow\\",
-            \\"resources\\": [
-              \\"*\\"
+            "effect": "Allow",
+            "resources": [
+              "*"
             ]
           }
         ],
-        \\"version\\": \\"2012-10-17\\"
+        "version": "2012-10-17"
       }
     }
   },
-  \\"resource\\": {
-    \\"aws_cloudwatch_log_group\\": {
-      \\"test-lambda_log-group_ACC182B5\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "test-lambda_log-group_ACC182B5": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"name\\": \\"/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"retention_in_days\\": 14
+        "name": "/aws/lambda/\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "retention_in_days": 14
       }
     },
-    \\"aws_iam_policy\\": {
-      \\"test-lambda_execution-policy_19C785A8\\": {
-        \\"name\\": \\"test-lambda-ExecutionRolePolicy\\",
-        \\"policy\\": \\"\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}\\"
+    "aws_iam_policy": {
+      "test-lambda_execution-policy_19C785A8": {
+        "name": "test-lambda-ExecutionRolePolicy",
+        "policy": "\${data.aws_iam_policy_document.test-lambda_execution-policy-document_D94D17B4.json}"
       }
     },
-    \\"aws_iam_role\\": {
-      \\"test-lambda_execution-role_9D4EE856\\": {
-        \\"assume_role_policy\\": \\"\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}\\",
-        \\"name\\": \\"test-lambda-ExecutionRole\\"
+    "aws_iam_role": {
+      "test-lambda_execution-role_9D4EE856": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.test-lambda_assume-policy-document_D538087D.json}",
+        "name": "test-lambda-ExecutionRole"
       }
     },
-    \\"aws_iam_role_policy_attachment\\": {
-      \\"test-lambda_execution-role-policy-attachment_8796505D\\": {
-        \\"depends_on\\": [
-          \\"aws_iam_role.test-lambda_execution-role_9D4EE856\\",
-          \\"aws_iam_policy.test-lambda_execution-policy_19C785A8\\"
+    "aws_iam_role_policy_attachment": {
+      "test-lambda_execution-role-policy-attachment_8796505D": {
+        "depends_on": [
+          "aws_iam_role.test-lambda_execution-role_9D4EE856",
+          "aws_iam_policy.test-lambda_execution-policy_19C785A8"
         ],
-        \\"policy_arn\\": \\"\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}\\",
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}\\"
+        "policy_arn": "\${aws_iam_policy.test-lambda_execution-policy_19C785A8.arn}",
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.name}"
       }
     },
-    \\"aws_lambda_alias\\": {
-      \\"test-lambda_alias_CCFDFCE9\\": {
-        \\"depends_on\\": [
-          \\"aws_lambda_function.test-lambda_8915D118\\"
+    "aws_lambda_alias": {
+      "test-lambda_alias_CCFDFCE9": {
+        "depends_on": [
+          "aws_lambda_function.test-lambda_8915D118"
         ],
-        \\"function_name\\": \\"\${aws_lambda_function.test-lambda_8915D118.function_name}\\",
-        \\"function_version\\": \\"\${element(split(\\\\\\":\\\\\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"function_version\\"
+        "function_name": "\${aws_lambda_function.test-lambda_8915D118.function_name}",
+        "function_version": "\${element(split(\\":\\", aws_lambda_function.test-lambda_8915D118.qualified_arn), 7)}",
+        "lifecycle": {
+          "ignore_changes": [
+            "function_version"
           ]
         },
-        \\"name\\": \\"DEPLOYED\\"
+        "name": "DEPLOYED"
       }
     },
-    \\"aws_lambda_function\\": {
-      \\"test-lambda_8915D118\\": {
-        \\"filename\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}\\",
-        \\"function_name\\": \\"test-lambda-Function\\",
-        \\"handler\\": \\"index.handler\\",
-        \\"lifecycle\\": {
-          \\"ignore_changes\\": [
-            \\"filename\\",
-            \\"source_code_hash\\"
+    "aws_lambda_function": {
+      "test-lambda_8915D118": {
+        "filename": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_path}",
+        "function_name": "test-lambda-Function",
+        "handler": "index.handler",
+        "lifecycle": {
+          "ignore_changes": [
+            "filename",
+            "source_code_hash"
           ]
         },
-        \\"memory_size\\": 128,
-        \\"publish\\": true,
-        \\"reserved_concurrent_executions\\": -1,
-        \\"role\\": \\"\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}\\",
-        \\"runtime\\": \\"python3.8\\",
-        \\"source_code_hash\\": \\"\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}\\",
-        \\"timeout\\": 5,
-        \\"vpc_config\\": {
-          \\"security_group_ids\\": [
-            \\"sec1\\",
-            \\"sec2\\"
+        "memory_size": 128,
+        "publish": true,
+        "reserved_concurrent_executions": -1,
+        "role": "\${aws_iam_role.test-lambda_execution-role_9D4EE856.arn}",
+        "runtime": "python3.8",
+        "source_code_hash": "\${data.archive_file.test-lambda_lambda-default-file_7A7DBB68.output_base64sha256}",
+        "timeout": 5,
+        "vpc_config": {
+          "security_group_ids": [
+            "sec1",
+            "sec2"
           ],
-          \\"subnet_ids\\": [
-            \\"1\\",
-            \\"2\\"
+          "subnet_ids": [
+            "1",
+            "2"
           ]
         }
       }
     },
-    \\"aws_s3_bucket\\": {
-      \\"test-lambda_code-bucket_177F316E\\": {
-        \\"acl\\": \\"private\\",
-        \\"bucket\\": \\"pocket-test-lambda\\",
-        \\"force_destroy\\": true
+    "aws_s3_bucket": {
+      "test-lambda_code-bucket_177F316E": {
+        "acl": "private",
+        "bucket": "pocket-test-lambda",
+        "force_destroy": true
       }
     },
-    \\"aws_s3_bucket_public_access_block\\": {
-      \\"test-lambda_code-bucket-public-access-block_1E7CE5AE\\": {
-        \\"block_public_acls\\": true,
-        \\"block_public_policy\\": true,
-        \\"bucket\\": \\"\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}\\"
+    "aws_s3_bucket_public_access_block": {
+      "test-lambda_code-bucket-public-access-block_1E7CE5AE": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "bucket": "\${aws_s3_bucket.test-lambda_code-bucket_177F316E.id}"
       }
     }
   }


### PR DESCRIPTION
# Goal

Do a major package update (Jest & associated libraries) + update all the snapshots since the newer version of Jest is saving snapshots without the many backward slashes.


## Reference

https://getpocket.atlassian.net/browse/INFRA-1356
